### PR TITLE
Create the beginnings of a contribution guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing to the MoJ Data Platform
+
+## Table of contents
+
+* [Code of Conduct](#code-of-conduct)
+* [Standards](#standards)
+* [Reporting Bugs](#reporting-bugs)
+* [Reporting security issues](#reporting-security-issues)
+* [Signing Contributions](#signing-contributions)
+* [External Contributions](#external-contributions)
+* [Licence](#licence)
+
+
+## Code of Conduct
+
+The Ministry of Justice [Code of Conduct](https://github.com/ministryofjustice/.github/blob/main/CODE_OF_CONDUCT.md) is used to govern the project and those participating].
+Please report unacceptable behavior to the maintainers or administrators.
+
+
+## Standards
+
+We follow the [MoJ Technical Guidance](https://technical-guidance.service.justice.gov.uk/#moj-technical-guidance),
+which complements the Service Standard,
+and also the MoJ [Cyber and Technical Security Guidance](https://security-guidance.service.justice.gov.uk/#cyber-and-technical-security-guidance).
+
+## Reporting bugs
+
+Bugs are tracked on the [project issues](https://github.com/ministryofjustice/data-platform/issues) page. Please check if your issue has already been filed by someone else by searching the existing issues before filing a new one. Once your issue is filed, it will be triaged by another contributor or maintainer.
+
+## Reporting security issues
+
+Please report any security issues inline with the Ministry of Justice [Vulnerability Disclosure Policy](https://mojdigital.blog.gov.uk/vulnerability-disclosure-policy/)
+
+
+## Signing contributions
+
+In addition to following the above guidance,
+the data platform also requires that all git commits are signed.
+This will enable the project to improve project integrity,
+begin to secure the supply chain,
+and [provide assurances about security practices](https://slsa.dev/).
+
+## External contributions
+
+The Data Platform is developed [in the open](https://gds.blog.gov.uk/2014/07/22/making-things-open-making-things-better/),
+but this is done primarily by Ministry of Justice staff.
+Although it's possible that external contributions may be accepted,
+please discuss your change [in an issue](/ministryofjustice/data-platform/issues) before submitting a pull request.
+
+## Licence
+
+The software and assets within this repository are licensed under the [MIT Licence](https://github.com/ministryofjustice/data-platform/blob/main/LICENSE).


### PR DESCRIPTION
Adds the beginning of a contribution guide that will be used to describe the governance of the project and how others can contribute.  This is currently incomplete but can be updated once it is clearer how teams will work together on the project.