### PR TITLE
:construction_worker: Add github action to add issues to project

### DIFF
--- a/.github/workflows/add-issues-to-project.yml
+++ b/.github/workflows/add-issues-to-project.yml
@@ -1,0 +1,15 @@
+name: Add issues to project
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@960fbad431afda394cfcf8743445e741acd19e85 # v0.4.0
+        with:
+          project-url: https://github.com/orgs/ministryofjustice/projects/27
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds a workflow to add any GitHub issues on this repository to the [Data Platform GitHub Project](https://github.com/orgs/ministryofjustice/projects/27/views/1).