### PR TITLE
ap-terraform-bootstrap into code + simplifying adding additional repos.

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -4,6 +4,14 @@ locals {
   # NB: Terraform shows a perputal difference in roles if someone is an organisation owner
   # and will attempt to change them from `maintainer` to `member`, so owners should go in here.
 
+  core_repos = [{ # Legacy Analytical Platform Internal Infrastructure Repos in the MOJ org
+    name        = "ap-terraform-bootstrap",
+    description = "Bootstrap for setting up analytical platform and data engineering accounts"
+    },
+    {
+      name        = "analytics-platform-infrastructure",
+      description = "Core Infrastructure Repo for Data Platform"
+  }]
   maintainers = [ # maintainers of analytics-hq and analytical-platform gh teams
     "julialawrence",
     "rossjones",

--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -11,6 +11,10 @@ locals {
     {
       name        = "analytics-platform-infrastructure",
       description = "Core Infrastructure Repo for Data Platform"
+    },
+    {
+      name        = "ap-test-github-workflow",
+      description = "Test repository for github docker workflow"
   }]
   maintainers = [ # maintainers of analytics-hq and analytical-platform gh teams
     "julialawrence",

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -1,9 +1,10 @@
 # Repositories
 module "core" {
+  for_each     = { for repo in local.core_repos : repo.name => repo }
   source       = "./modules/repository"
-  name         = "analytics-platform-infrastructure"
+  name         = each.key
   type         = "core"
-  description  = "Core Infrastructure Repo for Data Platform"
+  description  = each.value.description
   visibility   = "internal"
   homepage_url = "https://ministryofjustice.github.io/ap-tech-docs"
   topics = [
@@ -45,12 +46,10 @@ module "data-platform" {
 
 # Everyone, with access to the above repositories
 module "core-team" {
-  source      = "./modules/team"
-  name        = "analytics-hq"
-  description = "Analytical Platform team"
-  repositories = [
-    module.core.repository.name
-  ]
+  source       = "./modules/team"
+  name         = "analytics-hq"
+  description  = "Analytical Platform team"
+  repositories = [for repo in module.core : repo.repository.name]
 
   maintainers = local.maintainers
   members     = local.all_members


### PR DESCRIPTION
* Adding `ap-terraform-bootstrap` repository in the MOJ org into code. 
* Adding `ap-test-github-workflow` repository in the MOJ org into code.

Additionally, simplifying the addition of new repos managed by the analytics-hq team.
