### PR TITLE
Adding contributor module, adding push for DE team.

### DIFF
--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -89,7 +89,7 @@ module "data-engineering-team" {
 
 # Allow data engineering to raise PRs in Data Platform repos
 module "contributor-access" {
-  for_each          = [for repo in module.data-platform : repo.repository.name]
+  for_each          = toset([for repo in module.data-platform : repo.repository.name])
   source            = "./modules/contributor"
   application_teams = ["data-engineering"]
   repository_id     = each.key

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -86,3 +86,11 @@ module "data-engineering-team" {
   members     = local.all_members_data_engineers
   ci          = local.ci_users
 }
+
+# Allow data engineering to raise PRs in Data Platform repos
+module "contributor-access" {
+  for_each          = [for repo in module.data-platform : repo.repository.name]
+  source            = "./modules/contributor"
+  application_teams = ["data-engineering"]
+  repository_id     = each.key
+}

--- a/terraform/github/modules/contributor/main.tf
+++ b/terraform/github/modules/contributor/main.tf
@@ -1,0 +1,6 @@
+resource "github_team_repository" "main" {
+  for_each   = { for team in var.application_teams : team => team }
+  team_id    = each.value
+  repository = var.repository_id
+  permission = "push"
+}

--- a/terraform/github/modules/contributor/variables.tf
+++ b/terraform/github/modules/contributor/variables.tf
@@ -1,0 +1,8 @@
+variable "application_teams" {
+  description = "A list of github slugs that corresponds to modernisation platform customers"
+  type        = list(string)
+}
+variable "repository_id" {
+  description = "The name of the repository in scope for additional permissions"
+  type        = string
+}

--- a/terraform/github/modules/contributor/versions.tf
+++ b/terraform/github/modules/contributor/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = "~> 1.0"
+  required_providers {
+    github = {
+      version = "~> 5.2"
+      source  = "integrations/github"
+    }
+  }
+}


### PR DESCRIPTION
Adding a module to give "push" permissions to teams outside the core AP teams, in order to allow them to raise PRs in the core repos.

Doing this allows:

* DE to raise PRs for onboarding new users
* Foster collaboration

