### PR TITLE
👷 Add tech docs paths for gh action

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - "main"
+    paths:
+      - "source/**"
+      - "config/**"
     paths-ignore:
       - "docs/**"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,8 +8,7 @@ on:
     paths:
       - "source/**"
       - "config/**"
-    paths-ignore:
-      - "docs/**"
+      - ".github/workflows/publish.yml"
 
 # GITHUB_TOKEN permissions to allow deployment to GitHub Pages
 permissions:


### PR DESCRIPTION
This PR adds a must include only `source` and `config` folders to workflow, this will stop GitHub pages from publishing all merges to main.