### PR TITLE
Adding data-engineering-aws team to manage access.

### DIFF
--- a/terraform/github/locals.tf
+++ b/terraform/github/locals.tf
@@ -24,7 +24,7 @@ locals {
   tech_archs = concat(local.tech_archs_members, local.tech_archs_maintainers)
   # All data engineers
 
-  all_members_data_engineers = concat(local.data_engineering_maintainers, local.data_engineering_members)
+  all_members_data_engineers = concat(local.data_engineering_maintainers, local.data_engineering_members, local.data_engineering_aws_members)
 
   # All members
   all_members = concat(local.general_members, local.engineers)

--- a/terraform/github/main.tf
+++ b/terraform/github/main.tf
@@ -80,11 +80,23 @@ module "aws-team" {
 module "data-engineering-team" {
   source      = "./modules/team"
   name        = "data-engineering"
-  description = "Data Engineering team"
+  description = "Data Engineering team with Sandbox Access"
 
   maintainers = local.data_engineering_maintainers
   members     = local.all_members_data_engineers
   ci          = local.ci_users
+}
+
+# Data Engineering AWS Team
+module "data-engineering-aws-team" {
+  source      = "./modules/team"
+  name        = "data-engineering-aws"
+  description = "Data Engineering team with Environment Access"
+
+  maintainers    = local.data_engineering_maintainers
+  members        = concat(local.data_engineering_aws_members, local.data_engineering_maintainers)
+  ci             = local.ci_users
+  parent_team_id = module.data-engineering-team.team_id
 }
 
 # Allow data engineering to raise PRs in Data Platform repos

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -51,12 +51,24 @@ locals {
   data_engineering_maintainers = [
     "calumabarnett",
     "SoumayaMauthoorMOJ",
-    "PriyaBasker23"
+    "PriyaBasker23",
+    "julialawrence"
   ]
 
-  # DATA-ENGINEERING GITHUB GROUP
+  # DATA-ENGINEERING GITHUB GROUP WITH SANDBOX-ONLY ACCESS
 
   data_engineering_members = [
+    "lalithanagarur",
+    "Bharat-Dhiman",
+    "mdowniecog",
+    "pjxcog",
+    "sivabathina2",
+    "hemeshpatel-moj"
+  ]
+
+  # DATA-ENGINEERING-AWS GITHUB GROUP WITH FULL AWS ACCESS
+
+  data_engineering_aws_members = [
     "Mamonu",        # Theodoros Manassis
     "mratford",      # Mike Ratford
     "Danjiv",        # Danjiv Ramkhalawon
@@ -73,7 +85,6 @@ locals {
     "jhpyke", # Jake H Pyke
     "makl3",
     "oliver-critchfield",
-    "AlexVilela",
-    "lalithanagarur"
+    "AlexVilela"
   ]
 }


### PR DESCRIPTION
Adding a new team to manage environment access for Data Engineering. Will work in a similar way to how `analytics-hq` and `analytical-platform` currently work: `data-engineering` is a parent team with limited access and `data-engineering-aws` is a child team with full access.