### PR TITLE
🛠️ Adding directory prefix to artifact upload

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/upload-artifact@v3
         with:
           name: github-pages
-          path: artifact.tar
+          path: docs/artifact.tar
           retention-days: 1
 
   deploy:


### PR DESCRIPTION
`defaults.run.working-directory` is not taken into account for `uses` steps