### PR TITLE
🧹 remove unused labels

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,12 +1,10 @@
 documentation:
-  - "architecture/**"
-  - "diagrams/**"
   - "docs/**"
   - "README.md"
   - "source/**"
 
 github-workflow:
-  - "github/workflows/**"
+  - ".github/workflows/**"
 
 identity-access-management:
   - "data-platform/terraform/github/teams.tf"


### PR DESCRIPTION
This PR cleans unused labels and addresses `github-workflow`