### PR TITLE
:memo: Add team folder and joining team information page

### DIFF
--- a/docs/source/documentation/index.html.md.erb
+++ b/docs/source/documentation/index.html.md.erb
@@ -11,3 +11,7 @@ weight: 0
 ## Architecture
 
 - [Architecture Decision Records (ADR)](/documentation/adrs/adr-index.html)
+
+## Data Platform Team Information
+
+- [Joining our teams](/documentation/team/joining-our-teams.html)

--- a/docs/source/documentation/team/joining-our-teams.html.md.erb
+++ b/docs/source/documentation/team/joining-our-teams.html.md.erb
@@ -19,11 +19,11 @@ We have three main Slack channels listed below.
 
 #### #data-platform
 
-The [#data-platform](https://mojdt.slack.com/archives/C04BBJR3RPB) channel is the main channel with all members of the Data Plarform.
+The [#data-platform](https://mojdt.slack.com/archives/C04BBJR3RPB) channel is the main channel with all members of the Data Platform.
 
 #### #data-platform-core-infrastructure
 
-The [#data-platform-core-infrastructure](https://mojdt.slack.com/archives/C04BRGD7KFH) channel is our team channel where the Core Infrastructure team discussions about anything ranging from:
+The [#data-platform-core-infrastructure](https://mojdt.slack.com/archives/C04BRGD7KFH) channel is where the Core Infrastructure team have discussions about anything ranging from:
 
 - in-depth technical issues
 - our plans for the day

--- a/docs/source/documentation/team/joining-our-teams.html.md.erb
+++ b/docs/source/documentation/team/joining-our-teams.html.md.erb
@@ -1,0 +1,47 @@
+---
+owner_slack: "#data-platform-notifications"
+title: Joining our teams
+last_reviewed_on: 2023-02-27
+review_in: 6 months
+---
+
+# <%= current_page.data.title %>
+
+## Tools
+
+### Communication
+
+We use Google Meet for team calls, and Slack huddles or Google Meet for pairing or direct calls.
+
+Our main chat platform is Slack, and this is our preferred method of communication.
+
+We have three main Slack channels listed below.
+
+#### #data-platform
+
+The [#data-platform](https://mojdt.slack.com/archives/C04BBJR3RPB) channel is the main channel with all members of the Data Plarform.
+
+#### #data-platform-core-infrastructure
+
+The [#data-platform-core-infrastructure](https://mojdt.slack.com/archives/C04BRGD7KFH) channel is our team channel where the Core Infrastructure team discussions about anything ranging from:
+
+- in-depth technical issues
+- our plans for the day
+- to request someone else from the team's help
+- when we're away for lunch
+- general musings
+
+If you can't make standup, post your standup update here.
+
+#### #ask-data-platform
+
+The [#ask-data-platform](https://mojdt.slack.com/archives/C04LY2RVCS2) channel is for anyone who isn't in the team to:
+
+- ask questions about the services we run
+- get advice from the team
+
+#### #data-platform-notifications
+
+The [#data-platform-notifications](https://mojdt.slack.com/archives/C04MUAV0QC8) channel is where we direct notifications from GitHub, such as pull requests or issues. This includes updates to Team Documentation and  [Architecture Decision Records (ADR)](/documentation/adrs/adr-index.html)
+
+It's a noisy channel, so it's up to you whether to join it.


### PR DESCRIPTION
This PR will add a team folder to `docs\source\documentation` which we can add e.g. ways of working, a page "joining the team" to list our slack channels and tools we use. 