### PR TITLE
:green_heart: Update documentation workflow

### DIFF
--- a/.github/linters/.jscpd.json
+++ b/.github/linters/.jscpd.json
@@ -1,6 +1,6 @@
 {
   "absolute": true,
-  "ignore": ["**/.github/workflows/devcontainer.yml", "**/.devcontainer/**/devcontainer.json"],
+  "ignore": ["**/.github/workflows/devcontainer.yml", "**/.devcontainer/**/devcontainer.json", "**/.github/workflows/documentation.yml"],
   "reporters": ["consoleFull"],
   "threshold": 0
 }

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -68,7 +68,7 @@ jobs:
 
   linkinator:
     needs: [build]
-    name: URL Check
+    name: linkinator
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
@@ -84,7 +84,8 @@ jobs:
           cd github-pages
           tar -xvf artifact.tar
           npm install JustinBeckwith/linkinator#e3d929bbda79d28fb46d20c04a2a6f9a9bce6f5c # v4.1.2
-          npx linkinator . --recurse --markdown
+          npx linkinator . --recurse --markdown \
+            --skip "https://technical-documentation.data-platform.service.justice.gov.uk/images/govuk-large.png"
 
   deploy:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -2,6 +2,12 @@
 name: Documentation
 
 on: # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/documentation.yml
+      - docs/**
   push:
     branches:
       - main

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -48,29 +48,26 @@ jobs:
           path: docs/artifact.tar
           retention-days: 1
 
-  deploy:
-    if: github.ref == 'refs/heads/main'
+  htmlproofer:
     needs: [build]
-    name: Deploy
+    name: htmlproofer
     runs-on: ubuntu-latest
-    environment:
-      name: github-pages
-      url: ${{ steps.deploy_github_pages.outputs.page_url }}
-    permissions:
-      pages: write
-      id-token: write
+    container:
+      image: ministryofjustice/tech-docs-github-pages-publisher:data-platform
+    defaults:
+      run:
+        working-directory: docs
     steps:
-      - name: Configure GitHub Pages
-        id: configure_github_pages
-        uses: actions/configure-pages@fc89b04e7d263ef510d9e77d3a1d088fb2688522 # v3.0.4
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
-      - name: Deploy to GitHub Pages
-        id: deploy_github_pages
-        uses: actions/deploy-pages@0243b6c10d06cb8e95ed8ee471231877621202c0 # v1.2.4
+      - name: Compile Markdown to HTML
+        id: compile
+        run: /scripts/check-url-links.sh
 
-  url-check:
-    if: github.ref == 'refs/heads/main'
-    needs: [deploy]
+  linkinator:
+    needs: [build]
     name: URL Check
     runs-on: ubuntu-latest
     steps:
@@ -87,5 +84,24 @@ jobs:
           cd github-pages
           tar -xvf artifact.tar
           npm install JustinBeckwith/linkinator#e3d929bbda79d28fb46d20c04a2a6f9a9bce6f5c # v4.1.2
-          npx linkinator . --recurse --markdown \
-            --skip https://technical-documentation.data-platform.service.justice.gov.uk/images/govuk-large.png \
+          npx linkinator . --recurse --markdown
+
+  deploy:
+    if: github.ref == 'refs/heads/main'
+    needs: [build, htmlproofer, linkinator]
+    name: Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy_github_pages.outputs.page_url }}
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Configure GitHub Pages
+        id: configure_github_pages
+        uses: actions/configure-pages@fc89b04e7d263ef510d9e77d3a1d088fb2688522 # v3.0.4
+
+      - name: Deploy to GitHub Pages
+        id: deploy_github_pages
+        uses: actions/deploy-pages@0243b6c10d06cb8e95ed8ee471231877621202c0 # v1.2.4

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -1,12 +1,12 @@
 ---
-name: Publish documentation
+name: Documentation
 
 on: # yamllint disable-line rule:truthy
   push:
     branches:
       - main
     paths:
-      - .github/workflows/documentation-publish.yml
+      - .github/workflows/documentation.yml
       - docs/**
   workflow_dispatch:
 
@@ -42,27 +42,6 @@ jobs:
           path: docs/artifact.tar
           retention-days: 1
 
-  url-check:
-    needs: [build]
-    name: URL Check
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifact
-        id: download_artifact
-        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-        with:
-          name: github-pages
-          path: github-pages
-
-      - name: Check URLs
-        id: check_urls
-        run: |
-          cd github-pages
-          tar -xvf artifact.tar
-          npm install JustinBeckwith/linkinator#e3d929bbda79d28fb46d20c04a2a6f9a9bce6f5c # v4.1.2
-          npx linkinator . --recurse --markdown \
-            --skip https://ministryofjustice.github.io/data-platform/images/govuk-large.png \
-
   deploy:
     if: github.ref == 'refs/heads/main'
     needs: [build]
@@ -82,3 +61,25 @@ jobs:
       - name: Deploy to GitHub Pages
         id: deploy_github_pages
         uses: actions/deploy-pages@0243b6c10d06cb8e95ed8ee471231877621202c0 # v1.2.4
+
+  url-check:
+    if: github.ref == 'refs/heads/main'
+    needs: [deploy]
+    name: URL Check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download artifact
+        id: download_artifact
+        uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
+        with:
+          name: github-pages
+          path: github-pages
+
+      - name: Check URLs
+        id: check_urls
+        run: |
+          cd github-pages
+          tar -xvf artifact.tar
+          npm install JustinBeckwith/linkinator#e3d929bbda79d28fb46d20c04a2a6f9a9bce6f5c # v4.1.2
+          npx linkinator . --recurse --markdown \
+            --skip https://technical-documentation.data-platform.service.justice.gov.uk/images/govuk-large.png \

--- a/.github/workflows/repository-code-formatters.yml
+++ b/.github/workflows/repository-code-formatters.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: MoJ Code Formatter
         id: code_formatter
-        uses: ministryofjustice/github-actions/code-formatter@15729e214b8e626847cf4b4596c7635ddb6b1b0a # v10
+        uses: ministryofjustice/github-actions/code-formatter@d9a5f75c10cd50abd5f312ab9f4bab5826e4fedf # v11
         with:
           ignore-files: README.md
         env:

--- a/.github/workflows/repository-code-formatters.yml
+++ b/.github/workflows/repository-code-formatters.yml
@@ -54,7 +54,7 @@ jobs:
           # yamllint disable rule:line-length
           VALIDATE_GITHUB_ACTIONS: false # yaml This is disabled until Super-Linter ships with a newer version of actionlint supports the new `var` context
           # yamllint enable rule:line-length
-          # Commenting out as we have a lot of shell scripts that are not formatted correctly and we don't want to fix them all at once
+          # TODO: Fix all the shell scripts and re-enable these
           VALIDATE_BASH: false
           VALIDATE_BASH_EXEC: false
           VALIDATE_SHELL_SHFMT: false

--- a/docs/config/tech-docs.yml
+++ b/docs/config/tech-docs.yml
@@ -7,7 +7,7 @@
 host: https://technical-documentation.data-platform.service.justice.gov.uk
 
 # Header-related options
-show_govuk_logo: true
+show_govuk_logo: false
 service_name: Data Platform
 service_link: /
 phase: Alpha

--- a/docs/makefile
+++ b/docs/makefile
@@ -25,4 +25,4 @@ check:
 		--publish 4567:4567 \
 		--volume $$( pwd )/config:/app/config \
 		--volume $$( pwd )/source:/app/source \
-		$(IMAGE) /scripts/check.sh
+		$(IMAGE) /scripts/check-url-links.sh


### PR DESCRIPTION
This pull request updates the skipped image URL and also moves URL Check to after `deploy` as it checks links against the artifact but references the live site, which might have not been deployed yet as it was in parallel