### PR TITLE
:art: Remove exception from URL checking

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -62,7 +62,7 @@ jobs:
         id: checkout
         uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
-      - name: Compile Markdown to HTML
+      - name: Compile Markdown to HTML and run htmlproofer
         id: compile
         run: /scripts/check-url-links.sh
 
@@ -84,8 +84,7 @@ jobs:
           cd github-pages
           tar -xvf artifact.tar
           npm install JustinBeckwith/linkinator#e3d929bbda79d28fb46d20c04a2a6f9a9bce6f5c # v4.1.2
-          npx linkinator . --recurse --markdown \
-            --skip "https://technical-documentation.data-platform.service.justice.gov.uk/images/govuk-large.png"
+          npx linkinator . --recurse --markdown
 
   deploy:
     if: github.ref == 'refs/heads/main'


### PR DESCRIPTION
The last deployment of tech-docs published https://technical-documentation.data-platform.service.justice.gov.uk/images/govuk-large.png so this test shouldn't fail anymore