### PR TITLE
💚 Moved certificate authority configuration to its own command

### DIFF
--- a/.github/workflows/platform-simulated-data-producer.yml
+++ b/.github/workflows/platform-simulated-data-producer.yml
@@ -34,7 +34,8 @@ jobs:
       - name: Configure Kubernetes CLI
         id: configure_kubectl
         run: |
-          kubectl config set-cluster cloud-platform --server=${KUBE_CLUSTER} --certificate-authority=<(echo "${KUBE_CERT}")
+          kubectl config set-cluster cloud-platform --server=${KUBE_CLUSTER}
+          kubectl config set clusters.cloud-platform.certificate-authority-data "$( echo ${KUBE_CERT} | base64 )"
           kubectl config set-context cloud-platform --cluster=cloud-platform --namespace=${KUBE_NAMESPACE}
           kubectl config set-credentials cloud-platform --token="${KUBE_TOKEN}"
 


### PR DESCRIPTION
Resolves #197

1. `--certificate-authority` expects a path a file containing the certificte

1. `CLOUD_PLATFORM_DATA_PLATFORM_DEVELOPMENT_KUBE_CERT` isn't base64 encoded