### PR TITLE
🔧 Add Cloud Platform Kubernetes configuration to dev container

### DIFF
--- a/.devcontainer/docs/DEVCONTAINER.md
+++ b/.devcontainer/docs/DEVCONTAINER.md
@@ -1,3 +1,4 @@
+ <!-- markdownlint-disable -->
 # Data Platform Development Container
 
 This implementation of the development container is meant to have all repositories cloned into it under the persistent workspace `/home/vscode/workspace`. Once we begin our journey to the monorepo, this should become redundant. That means that right now, it is not intended to use this with GitHub Codespaces.
@@ -20,7 +21,7 @@ This implementation of the development container is meant to have all repositori
   brew install --cask rancher
   ```
 
-- Node / NPM
+- Node / `npm`
 
   ```bash
   brew install node
@@ -98,18 +99,21 @@ The supplied `~/.kube/config`:
 
 1. Replace your Auth0 email with the generic string
 
-   kubectl config set-credentials "auth0" \
-    --auth-provider=oidc \
-    --auth-provider-arg=client-id="..." \
-    --auth-provider-arg=client-secret="..." \
-    --auth-provider-arg=id-token="..." \
-    --auth-provider-arg=refresh-token="..." \
-    --auth-provider-arg=idp-issuer-url="https://justice-cloud-platform.eu.auth0.com/"
+    ```bash
+    kubectl config set-credentials "auth0" \
+      --auth-provider=oidc \
+      --auth-provider-arg=client-id="..." \
+      --auth-provider-arg=client-secret="..." \
+      --auth-provider-arg=id-token="..." \
+      --auth-provider-arg=refresh-token="..." \
+      --auth-provider-arg=idp-issuer-url="https://justice-cloud-platform.eu.auth0.com/"
+    ```
 
 1. Set Cloud Platform to the current context
 
-   kubectl config use-context live.cloud-platform.service.justice.gov.uk
-
+    ```bash
+    kubectl config use-context live.cloud-platform.service.justice.gov.uk
+    ```
 ---
 
 # Developing

--- a/.devcontainer/docs/DEVCONTAINER.md
+++ b/.devcontainer/docs/DEVCONTAINER.md
@@ -84,9 +84,31 @@ Your GPG and SSH agents are mounted from macOS, so GPG and SSH commands inside t
 
 The supplied `~/.kube/config`:
 
-1. Invokes a wrapper for authenticating to EKS using AWS Vault. If you're in an AWS Vault sub-shell, it will not call AWS Vault
+1. Invokes a wrapper for authenticating with Analytical Platform's EKS clusters using AWS Vault, if you're in an AWS Vault sub-shell, it will not call AWS Vault
 
-1. Has the default context to the development EKS cluster
+1. Has no default context set, you can view with `kubectl config get-contexts` and set with `kubectl config use-context ${CONTEXT_NAME}`
+
+### Cloud Platform Authentication
+
+> Rebuilding will remove your Cloud Platform credentials
+
+1. Login to Cloud Platform Kuberos (https://login.cloud-platform.service.justice.gov.uk/)
+
+1. Obtain the command from "Authenticate Manually"
+
+1. Replace your Auth0 email with the generic string
+
+    kubectl config set-credentials "auth0" \
+      --auth-provider=oidc \
+      --auth-provider-arg=client-id="..." \
+      --auth-provider-arg=client-secret="..." \
+      --auth-provider-arg=id-token="..." \
+      --auth-provider-arg=refresh-token="..." \
+      --auth-provider-arg=idp-issuer-url="https://justice-cloud-platform.eu.auth0.com/"
+
+1. Set Cloud Platform to the current context
+
+    kubectl config use-context live.cloud-platform.service.justice.gov.uk
 
 ---
 

--- a/.devcontainer/docs/DEVCONTAINER.md
+++ b/.devcontainer/docs/DEVCONTAINER.md
@@ -98,17 +98,17 @@ The supplied `~/.kube/config`:
 
 1. Replace your Auth0 email with the generic string
 
-    kubectl config set-credentials "auth0" \
-      --auth-provider=oidc \
-      --auth-provider-arg=client-id="..." \
-      --auth-provider-arg=client-secret="..." \
-      --auth-provider-arg=id-token="..." \
-      --auth-provider-arg=refresh-token="..." \
-      --auth-provider-arg=idp-issuer-url="https://justice-cloud-platform.eu.auth0.com/"
+   kubectl config set-credentials "auth0" \
+    --auth-provider=oidc \
+    --auth-provider-arg=client-id="..." \
+    --auth-provider-arg=client-secret="..." \
+    --auth-provider-arg=id-token="..." \
+    --auth-provider-arg=refresh-token="..." \
+    --auth-provider-arg=idp-issuer-url="https://justice-cloud-platform.eu.auth0.com/"
 
 1. Set Cloud Platform to the current context
 
-    kubectl config use-context live.cloud-platform.service.justice.gov.uk
+   kubectl config use-context live.cloud-platform.service.justice.gov.uk
 
 ---
 

--- a/.devcontainer/docs/DEVCONTAINER.md
+++ b/.devcontainer/docs/DEVCONTAINER.md
@@ -1,4 +1,5 @@
  <!-- markdownlint-disable -->
+
 # Data Platform Development Container
 
 This implementation of the development container is meant to have all repositories cloned into it under the persistent workspace `/home/vscode/workspace`. Once we begin our journey to the monorepo, this should become redundant. That means that right now, it is not intended to use this with GitHub Codespaces.
@@ -99,21 +100,22 @@ The supplied `~/.kube/config`:
 
 1. Replace your Auth0 email with the generic string
 
-    ```bash
-    kubectl config set-credentials "auth0" \
-      --auth-provider=oidc \
-      --auth-provider-arg=client-id="..." \
-      --auth-provider-arg=client-secret="..." \
-      --auth-provider-arg=id-token="..." \
-      --auth-provider-arg=refresh-token="..." \
-      --auth-provider-arg=idp-issuer-url="https://justice-cloud-platform.eu.auth0.com/"
-    ```
+   ```bash
+   kubectl config set-credentials "auth0" \
+     --auth-provider=oidc \
+     --auth-provider-arg=client-id="..." \
+     --auth-provider-arg=client-secret="..." \
+     --auth-provider-arg=id-token="..." \
+     --auth-provider-arg=refresh-token="..." \
+     --auth-provider-arg=idp-issuer-url="https://justice-cloud-platform.eu.auth0.com/"
+   ```
 
 1. Set Cloud Platform to the current context
 
-    ```bash
-    kubectl config use-context live.cloud-platform.service.justice.gov.uk
-    ```
+   ```bash
+   kubectl config use-context live.cloud-platform.service.justice.gov.uk
+   ```
+
 ---
 
 # Developing

--- a/.devcontainer/features/src/base/moj-codespaces.zsh-theme
+++ b/.devcontainer/features/src/base/moj-codespaces.zsh-theme
@@ -3,7 +3,7 @@
 
 __zsh_prompt() {
     local prompt_username
-    if [ ! -z "${GITHUB_USER}" ]; then 
+    if [ ! -z "${GITHUB_USER}" ]; then
         prompt_username="@${GITHUB_USER}"
     else
         prompt_username="%n"
@@ -46,6 +46,8 @@ __zsh_prompt() {
             echo -n "[ k8s: %{$fg[blue]%}github-actions-moj%{$reset_color%} ] "; \
           elif [[ "$( kubectl config get-contexts | grep "*" | awk "{ print $2 }" | cut -d"/" -f2 )" == *"production"* ]]; then \
             echo -n "[ k8s: %{$fg[red]%}production%{$reset_color%} ] "; \
+          elif [[ "$( kubectl config get-contexts | grep "*" | awk "{ print $2 }" | cut -d"/" -f2 )" == *"live.cloud-platform.service.justice.gov.uk"* ]]; then \
+            echo -n "[ k8s: %{$fg[red]%}cloud-platform%{$reset_color%} ] "; \
           fi`'
     fi
 

--- a/.devcontainer/features/src/kubernetes-tools/src/home/vscode/.kube/config
+++ b/.devcontainer/features/src/kubernetes-tools/src/home/vscode/.kube/config
@@ -1,79 +1,108 @@
+---
 apiVersion: v1
 kind: Config
 preferences: {}
 
-current-context: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
+####################################################################################################
+#
+# Changes to this file will be overwritten when rebuilding the devcontainer.
+#
+####################################################################################################
+
+# current-context: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
 # current-context: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
 # current-context: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
+# current-context: live.cloud-platform.service.justice.gov.uk
 
 clusters:
-- name: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
-  cluster:
-    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1USXdOVEE1TkRReU5sb1hEVE14TVRJd016QTVORFF5Tmxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBSnlICmZ2MStZR0ZGZUpKbGJGUVVuK2N1N0hSRWRiTldHUzVSZWNCNlE3YWprNnYrT2xoZ3lZR0FzeXBiR291LzRUNXUKM2JSUjJYS1lkZk9tSmNSMzBVMUNzNExFZWJrSXVndERBenBvdW8yZHBPd3liMjJSVndwRWgvd1dUL1ZFV2ZjUQpwVEhkVEQ2RWQ4NkNGWEd0akxrTFN2UWtPQ0IzUnR4anZPOFlvSVZIaXdMWW4yenJmdytoTW9RSHhQRnh3UDRZCmJyTFkzZzJxVFArMjV4dE5TcDBua1IwQnZUMEwzazVRUTNNQUZ3RzBSWmhvRlBpNlJ2VzRPYWc2OFhFeHJVTUcKRE1YUXlEL3NsWGhtbVR2cjd3MHVtQlBSeHdZbFUxdzlkZFp0NjRDVytTeEdGUlRyNm41U1ZPWStDUjlhR2NuSgo4SDFMQ3J5RENuNnlHSDVBSHhrQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZNZFowR083STNDdFNKbDFHczRuaGt6US81WXNNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFCSFNXK25OK01xeCtBT3R1aUhjQ3hEeXhvMU5VWXRtK29TaUthMm9kVEIrVTI4UFdOagpYUFMzamF4Nyt5K05MQ0psVENWcllxVHZhQit2V3pVV3lqVzBHZGN5K29TR3FWdTNvcXBuNDBVazkzWXRnRkZQCmIrRVdwbjZ4R1BodDVROGZ6ZE9adCtKbVQ5SElsYTVPSDJJejY5T2dtYjUvQU1YNW94ajlRZVFQVEh0Ym5DNDAKWlRRZHlXMTRQTXZwQmV1QnFQM3ZhZHRabHkvU1RLQnZzMk9qV3Y3WStNMXBtQWdFWHV4TTQ2Nzl6ZFpnbEdYegpFRm1mNTZlUmJLQXZyN3o3ZkpmV0dSNTRvdkpNZGJ0NFAxOWVxRm8vd05IRHNTK1ZuTVJ5azkxQUdBNmVwQWFDCjFyZVp5R3VUSnZuU0hxTzJ2VHBOdWhkWlo4RWtjSU03Vlk5KwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
-    server: https://6F58D1C4FD8FAE6D3D9282A400EDCE79.gr7.eu-west-1.eks.amazonaws.com
+  - name: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
+    cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1USXdOVEE1TkRReU5sb1hEVE14TVRJd016QTVORFF5Tmxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBSnlICmZ2MStZR0ZGZUpKbGJGUVVuK2N1N0hSRWRiTldHUzVSZWNCNlE3YWprNnYrT2xoZ3lZR0FzeXBiR291LzRUNXUKM2JSUjJYS1lkZk9tSmNSMzBVMUNzNExFZWJrSXVndERBenBvdW8yZHBPd3liMjJSVndwRWgvd1dUL1ZFV2ZjUQpwVEhkVEQ2RWQ4NkNGWEd0akxrTFN2UWtPQ0IzUnR4anZPOFlvSVZIaXdMWW4yenJmdytoTW9RSHhQRnh3UDRZCmJyTFkzZzJxVFArMjV4dE5TcDBua1IwQnZUMEwzazVRUTNNQUZ3RzBSWmhvRlBpNlJ2VzRPYWc2OFhFeHJVTUcKRE1YUXlEL3NsWGhtbVR2cjd3MHVtQlBSeHdZbFUxdzlkZFp0NjRDVytTeEdGUlRyNm41U1ZPWStDUjlhR2NuSgo4SDFMQ3J5RENuNnlHSDVBSHhrQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZNZFowR083STNDdFNKbDFHczRuaGt6US81WXNNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFCSFNXK25OK01xeCtBT3R1aUhjQ3hEeXhvMU5VWXRtK29TaUthMm9kVEIrVTI4UFdOagpYUFMzamF4Nyt5K05MQ0psVENWcllxVHZhQit2V3pVV3lqVzBHZGN5K29TR3FWdTNvcXBuNDBVazkzWXRnRkZQCmIrRVdwbjZ4R1BodDVROGZ6ZE9adCtKbVQ5SElsYTVPSDJJejY5T2dtYjUvQU1YNW94ajlRZVFQVEh0Ym5DNDAKWlRRZHlXMTRQTXZwQmV1QnFQM3ZhZHRabHkvU1RLQnZzMk9qV3Y3WStNMXBtQWdFWHV4TTQ2Nzl6ZFpnbEdYegpFRm1mNTZlUmJLQXZyN3o3ZkpmV0dSNTRvdkpNZGJ0NFAxOWVxRm8vd05IRHNTK1ZuTVJ5azkxQUdBNmVwQWFDCjFyZVp5R3VUSnZuU0hxTzJ2VHBOdWhkWlo4RWtjSU03Vlk5KwotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      server: https://6F58D1C4FD8FAE6D3D9282A400EDCE79.gr7.eu-west-1.eks.amazonaws.com
 
-- name: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
-  cluster:
-    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ERXlOekV4TXpJeU9Gb1hEVE14TURFeU5URXhNekl5T0Zvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTW1FCnRMVG5oUmNEZDA3Uk9pcllvellaK2F4dW82TmFDWHhVTDk5TFhkdE9TR0l6OVR1N0NRNHB4Mmc1dGl5bEsxR3EKV1hqZEZZR3BaMjV0N3VsQytHWTRSR3dwbHVwcWdIdmlXYVUrVlBXNHdzSWo3citwa2tSYzNpYU52MzIxdlVGaQpmbjVRVUlmVTZQN2xaU3VWbS9VS0Y4QXNxUDl2Q2xBZnlTak8xelJ3TkJFVVBSdGU1VExnNkNjejVqSU5tL1Y2Ck4vK2Q5TGZ6UGl2RnhKQU5DR2I3WGFkcWhGaUZuR2Z1SWo2RmhJb3F6WnN5QUxtOG81cGExaGdJRFE1elBVZlkKODkwdEJuWVI3LzUxODJjRWdXOHlZT2creHU3cWJndkJ1VzBVNTk1cmtuQTVoVTZGK05HSnRuTzlGUFVYQlo2UgpSakc3WjlQQXVkb3hmeVMwTE5FQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFHOUlrZ2MzYWc4YnNZczZlcGJlc29mRVRrRHUKV0svNE5QbThDWjFaaVh6eFl0eVpIb0pJUEFJVGowaWFyUGJRd05sMW1BeEhtRnFFaU9CREZKS09SWFh4YlJQdApNWHgzV1o0a0JSZXR1WVprMW85cVdvNWJaMWJITnRxa2JZS0QxSTVIMWFJODdsNy9mSVFxVVAyMkRDTkUwc3dGClliamhsbEpBUk13SDFSNkQwd3hZUHhoS1V4MnFKM1lLMkdvZkV2TUw4MXNHVlpTUkZCSk02NCtvZE5UK1VscG8KV2w3N1JBNlZKdTEzVGdIUS8rM2RjMENKVDNtQUVHd1lzeXUrMVJ2aTg5Q2JEWDE2NldZZEVmSFpBdDZKTk45egprQyswSm81aC9paDE0cXVaNE83dGFDbGdBeDJaakYzQ2FlVGxZeHlVUkpEZXdvWFIrMUJZTmYxQ0wxOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
-    server: https://2CE598AB4F4281116DE892C9FE8E9737.gr7.eu-west-1.eks.amazonaws.com
+  - name: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
+    cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1ERXlOekV4TXpJeU9Gb1hEVE14TURFeU5URXhNekl5T0Zvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTW1FCnRMVG5oUmNEZDA3Uk9pcllvellaK2F4dW82TmFDWHhVTDk5TFhkdE9TR0l6OVR1N0NRNHB4Mmc1dGl5bEsxR3EKV1hqZEZZR3BaMjV0N3VsQytHWTRSR3dwbHVwcWdIdmlXYVUrVlBXNHdzSWo3citwa2tSYzNpYU52MzIxdlVGaQpmbjVRVUlmVTZQN2xaU3VWbS9VS0Y4QXNxUDl2Q2xBZnlTak8xelJ3TkJFVVBSdGU1VExnNkNjejVqSU5tL1Y2Ck4vK2Q5TGZ6UGl2RnhKQU5DR2I3WGFkcWhGaUZuR2Z1SWo2RmhJb3F6WnN5QUxtOG81cGExaGdJRFE1elBVZlkKODkwdEJuWVI3LzUxODJjRWdXOHlZT2creHU3cWJndkJ1VzBVNTk1cmtuQTVoVTZGK05HSnRuTzlGUFVYQlo2UgpSakc3WjlQQXVkb3hmeVMwTE5FQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFHOUlrZ2MzYWc4YnNZczZlcGJlc29mRVRrRHUKV0svNE5QbThDWjFaaVh6eFl0eVpIb0pJUEFJVGowaWFyUGJRd05sMW1BeEhtRnFFaU9CREZKS09SWFh4YlJQdApNWHgzV1o0a0JSZXR1WVprMW85cVdvNWJaMWJITnRxa2JZS0QxSTVIMWFJODdsNy9mSVFxVVAyMkRDTkUwc3dGClliamhsbEpBUk13SDFSNkQwd3hZUHhoS1V4MnFKM1lLMkdvZkV2TUw4MXNHVlpTUkZCSk02NCtvZE5UK1VscG8KV2w3N1JBNlZKdTEzVGdIUS8rM2RjMENKVDNtQUVHd1lzeXUrMVJ2aTg5Q2JEWDE2NldZZEVmSFpBdDZKTk45egprQyswSm81aC9paDE0cXVaNE83dGFDbGdBeDJaakYzQ2FlVGxZeHlVUkpEZXdvWFIrMUJZTmYxQ0wxOD0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      server: https://2CE598AB4F4281116DE892C9FE8E9737.gr7.eu-west-1.eks.amazonaws.com
 
-- name: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
-  cluster:
-    certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1EZ3lOREV5TVRBd05Gb1hEVE14TURneU1qRXlNVEF3TkZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTGtyCllrNVhVT3VyU3M0T2o3aE5XRE0zSC9vUnhUMmY0c014eGJoMEEwM010OXQ5SUtBaWM2TFpiMlZJd3VobG14bUIKaVhuSEtXSHREbi85NUwwdEgvWURnN3VFSXVMa2xMS3F0NjRVWlFFWHNocElaakxpNFU1bW03WWttT1N4VjFYSQo4bXJ4VEhaRGZ1NHZwdURUSWdmR2szTE8rTXBBZVgrTFNFM1JVSWR4UFo1eDVzYloyU29NWkFYekRnaHEzOU9RCjY3WVNFdmRYS1Bkd1JDUnR0d2k4OGVuOGpxanRZMFB5dUVaMVQzRjVPeWhBMjNQWVBMam10aWt2akNwMmNKOTkKZnhUNG1NNWsyUUlxQmxZWTRzR0s3dzhTL1I2VGxtL1g4KzBjeWhyU2FmMjh2dUNVL0dXZVJ6MWhYa05rV2FKTQpkampuWElzeFRkc0tGc1RUMzVVQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZQVkpZMGlHcW9RODlmMy9sbkNsdUQ4NnZvUDNNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBb2tScklHRzRWbVBGMnBhV3dSdEdhU01NVnBaWDdRRGhEL0tSajY5NXZLOU1YaDJnSgpPeWR3enRJd2tMalNjZUhaZTJocE9DNkt3VUxMbFJYRzJRbXhzUnJtaEM5NU8xWEM1cURZV2JFRUoxUnpsUkJGCkdQT1FMQ0tWTnc4b21KTlRXcDdTTDgxeFBiZCtnNm1KSlB3UHQ2cVJHNTBaMnRVSzZVRnZSbVRUcXl3Z1U4UXkKemp5cFJMVkJtQWc3Tkw3MW9zS0x4T25qUHRHNDl4eVNTVExQaGpDSzlIUnM5bXJDaVJ0RWo1b2EwUHY3d2hIOQpWQS8yYVVmRTA5cjg4dXFYWHIvZlNoY1FXSlhmU1gvYVVIbFZwK0NJU2tHUkJscmFKc3ZHSlZ3UWJRR3ZvTGZmCnMyTFo3M1EzbHpDM2VOajJ6WTcrbTdlazVLOUJEc29oK2lWeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
-    server: https://EB06461747C1D40013EE978C4D8D1755.gr7.eu-west-1.eks.amazonaws.com
-  
+  - name: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
+    cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUM1ekNDQWMrZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1EZ3lOREV5TVRBd05Gb1hEVE14TURneU1qRXlNVEF3TkZvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTGtyCllrNVhVT3VyU3M0T2o3aE5XRE0zSC9vUnhUMmY0c014eGJoMEEwM010OXQ5SUtBaWM2TFpiMlZJd3VobG14bUIKaVhuSEtXSHREbi85NUwwdEgvWURnN3VFSXVMa2xMS3F0NjRVWlFFWHNocElaakxpNFU1bW03WWttT1N4VjFYSQo4bXJ4VEhaRGZ1NHZwdURUSWdmR2szTE8rTXBBZVgrTFNFM1JVSWR4UFo1eDVzYloyU29NWkFYekRnaHEzOU9RCjY3WVNFdmRYS1Bkd1JDUnR0d2k4OGVuOGpxanRZMFB5dUVaMVQzRjVPeWhBMjNQWVBMam10aWt2akNwMmNKOTkKZnhUNG1NNWsyUUlxQmxZWTRzR0s3dzhTL1I2VGxtL1g4KzBjeWhyU2FmMjh2dUNVL0dXZVJ6MWhYa05rV2FKTQpkampuWElzeFRkc0tGc1RUMzVVQ0F3RUFBYU5DTUVBd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0hRWURWUjBPQkJZRUZQVkpZMGlHcW9RODlmMy9sbkNsdUQ4NnZvUDNNQTBHQ1NxR1NJYjMKRFFFQkN3VUFBNElCQVFBb2tScklHRzRWbVBGMnBhV3dSdEdhU01NVnBaWDdRRGhEL0tSajY5NXZLOU1YaDJnSgpPeWR3enRJd2tMalNjZUhaZTJocE9DNkt3VUxMbFJYRzJRbXhzUnJtaEM5NU8xWEM1cURZV2JFRUoxUnpsUkJGCkdQT1FMQ0tWTnc4b21KTlRXcDdTTDgxeFBiZCtnNm1KSlB3UHQ2cVJHNTBaMnRVSzZVRnZSbVRUcXl3Z1U4UXkKemp5cFJMVkJtQWc3Tkw3MW9zS0x4T25qUHRHNDl4eVNTVExQaGpDSzlIUnM5bXJDaVJ0RWo1b2EwUHY3d2hIOQpWQS8yYVVmRTA5cjg4dXFYWHIvZlNoY1FXSlhmU1gvYVVIbFZwK0NJU2tHUkJscmFKc3ZHSlZ3UWJRR3ZvTGZmCnMyTFo3M1EzbHpDM2VOajJ6WTcrbTdlazVLOUJEc29oK2lWeAotLS0tLUVORCBDRVJUSUZJQ0FURS0tLS0tCg==
+      server: https://EB06461747C1D40013EE978C4D8D1755.gr7.eu-west-1.eks.amazonaws.com
+
+  - name: live.cloud-platform.service.justice.gov.uk
+    cluster:
+      certificate-authority-data: LS0tLS1CRUdJTiBDRVJUSUZJQ0FURS0tLS0tCk1JSUN5RENDQWJDZ0F3SUJBZ0lCQURBTkJna3Foa2lHOXcwQkFRc0ZBREFWTVJNd0VRWURWUVFERXdwcmRXSmwKY201bGRHVnpNQjRYRFRJeE1EWXlPREUyTXprMU5sb1hEVE14TURZeU5qRTJNemsxTmxvd0ZURVRNQkVHQTFVRQpBeE1LYTNWaVpYSnVaWFJsY3pDQ0FTSXdEUVlKS29aSWh2Y05BUUVCQlFBRGdnRVBBRENDQVFvQ2dnRUJBTDNZCk9jcWxuVUdZTGR6TFlZTFcyOHVVWk1QdGE3TWJTK09EbTh4RWNXNlRVMXoyeFovcUNwSUhRS0VGelk2SWJwVSsKaHB0Z2VrRnNKQllEc2pjRjhRSTNPSkFaMFVjMXpNaXo1TFE2ZU1pOENsbmRMYnk4NWRNLzliRGZ0T1dlMDVqcQpYSENmYW9RNWR0Y3NCbWplWFAzbm1ZZGRJcTBiRUZZMTJiQjkvOTRLRVJSdnp4U3oxNkg5VkJwdzA3UVArTFRTCnRKT2JjWWlzcEFSTXJUVTlZa1pVS1lJT2FUYnBqRHhHVGdMNm1EaWNSdHlQeU9admx0MUFSTFR3NUpBVG42WUYKaXNCMkt5cHA2Q05DNDVoaFVpU05vZE9vaUcxNVRpNU5WeWM5azQ4eTFqZWExZ0kzTnM0VGFpQXRxNEhPTHR3NQpML2RqMEFRTTJIalZlVG90TVJVQ0F3RUFBYU1qTUNFd0RnWURWUjBQQVFIL0JBUURBZ0trTUE4R0ExVWRFd0VCCi93UUZNQU1CQWY4d0RRWUpLb1pJaHZjTkFRRUxCUUFEZ2dFQkFHUCs2RTZCMDVNSmxFZ04zcEJkRUxEa29yakEKMGJ0SmR2S1lEakkyWTE0cGtSMFlacXZjT2Zkd0tOM1VuL2FYblllT21xNFExdHRpMUZQRDR6MTE0TFU4VjBTcwo3Q080azE5NzNMVGxValRGTVZNNHZoZXlXc0JLRzJxZW10TGhkVjJGSDh1Y2lDZnVWd0hNb3lQTmJJdktCSVFOCnFIS08wclU0bElpSzVrcEdydXBZYWRIV3pLL0VMTlk5alZtelJxcXpGQ3lmVjJuWGZJK2xrbXFUOGN5Y0FWbS8KOExSQjhnK1dhTGxLQThydWMzYmZIWUJNZ2J1ZkpzYTVaU3lGd2dkNlNua0dta1c2KzBERklRUVAweEl5ajRaWgpFL1JxL0QyNE5zK2ZNc3lxWVRUQ21rRktUdTJENzJvQllUdmt5bnQ3Rjh3a0gwSWRiK1MxMXNxUVdCcz0KLS0tLS1FTkQgQ0VSVElGSUNBVEUtLS0tLQo=
+      server: https://DF366E49809688A3B16EEC29707D8C09.gr7.eu-west-2.eks.amazonaws.com
+
 users:
-- name: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
-  user:
-    exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
-      command: /usr/local/bin/aws-eks-auth      
-      env:
-        - name: AWS_VAULT_PROFILE
-          value: "analytical-platform-dev"
-        - name: AWS_EKS_CLUSTER_NAME
-          value: "development-aWrhyc0m"
-      interactiveMode: IfAvailable
-      provideClusterInfo: false
+  - name: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: /usr/local/bin/aws-eks-auth
+        env:
+          - name: AWS_VAULT_PROFILE
+            value: "analytical-platform-dev"
+          - name: AWS_EKS_CLUSTER_NAME
+            value: "development-aWrhyc0m"
+        interactiveMode: IfAvailable
+        provideClusterInfo: false
 
-- name: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
-  user:
-    exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
-      command: /usr/local/bin/aws-eks-auth      
-      env:
-        - name: AWS_VAULT_PROFILE
-          value: "analytical-platform-management"
-        - name: AWS_EKS_CLUSTER_NAME
-          value: "github-actions-moj-CoFBZ3xV"
-      interactiveMode: IfAvailable
-      provideClusterInfo: false
+  - name: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: /usr/local/bin/aws-eks-auth
+        env:
+          - name: AWS_VAULT_PROFILE
+            value: "analytical-platform-management"
+          - name: AWS_EKS_CLUSTER_NAME
+            value: "github-actions-moj-CoFBZ3xV"
+        interactiveMode: IfAvailable
+        provideClusterInfo: false
 
-- name: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
-  user:
-    exec:
-      apiVersion: client.authentication.k8s.io/v1beta1
-      command: /usr/local/bin/aws-eks-auth      
-      env:
-        - name: AWS_VAULT_PROFILE
-          value: "analytical-platform-prod"
-        - name: AWS_EKS_CLUSTER_NAME
-          value: "production-dBSvju9Y"
-      interactiveMode: IfAvailable
-      provideClusterInfo: false
+  - name: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
+    user:
+      exec:
+        apiVersion: client.authentication.k8s.io/v1beta1
+        command: /usr/local/bin/aws-eks-auth
+        env:
+          - name: AWS_VAULT_PROFILE
+            value: "analytical-platform-prod"
+          - name: AWS_EKS_CLUSTER_NAME
+            value: "production-dBSvju9Y"
+        interactiveMode: IfAvailable
+        provideClusterInfo: false
+
+  - name: auth0
+    user:
+      auth-provider:
+        name: oidc
+        config:
+          client-id: "REPLACE_WITH_CLIENT_ID"
+          client-secret: "REPLACE_WITH_CLIENT_SECRET"
+          id-token: "REPLACE_WITH_ID_TOKEN"
+          idp-issuer-url: https://justice-cloud-platform.eu.auth0.com/
+          refresh-token: "REPLACE_WITH_REFRESH_TOKEN"
 
 contexts:
-- name: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
-  context:
-    cluster: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
-    user: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
+  - name: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
+    context:
+      cluster: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
+      user: arn:aws:eks:eu-west-1:525294151996:cluster/development-aWrhyc0m
 
-- name: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
-  context:
-    cluster: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
-    user: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
+  - name: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
+    context:
+      cluster: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
+      user: arn:aws:eks:eu-west-1:042130406152:cluster/github-actions-moj-CoFBZ3xV
 
-- name: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
-  context:
-    cluster: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
-    user: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
+  - name: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
+    context:
+      cluster: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
+      user: arn:aws:eks:eu-west-1:312423030077:cluster/production-dBSvju9Y
+
+  - name: live.cloud-platform.service.justice.gov.uk
+    context:
+      cluster: live.cloud-platform.service.justice.gov.uk
+      user: auth0


### PR DESCRIPTION
Resolves #175

This PR adds a vanilla Cloud Platform configuration to kubeconfig, as it is based on OIDC via Kuberos, I can't add any logic to make it seamless, it requires the user interacting with the file which will be overwritten on **rebuild**

