### PR TITLE
🔥 Replace hclq with hcl2json

### DIFF
--- a/.devcontainer/features/src/terraform-tools/devcontainer-feature.json
+++ b/.devcontainer/features/src/terraform-tools/devcontainer-feature.json
@@ -2,7 +2,7 @@
   "id": "terraform-tools",
   "version": "1.0.0",
   "name": "terraform-tools",
-  "description": "Terraform Tools - Terraform Switcher, Terraform Docs, hclq",
+  "description": "Terraform Tools - Terraform Switcher, Terraform Docs, hcl2json",
   "options": {
     "installTerraformSwitcher": {
       "type": "boolean",
@@ -32,14 +32,14 @@
       "proposals": ["latest"],
       "default": "latest"
     },
-    "installHclq": {
+    "installHcl2json": {
       "type": "boolean",
-      "description": "Install hclq (https://github.com/mattolenik/hclq)",
+      "description": "Install hcl2json (https://github.com/tmccombs/hcl2json)",
       "default": true
     },
-    "hclqVersion": {
+    "hcl2jsonVersion": {
       "type": "string",
-      "description": "hclq version",
+      "description": "hcl2json version",
       "proposals": ["latest"],
       "default": "latest"
     }

--- a/.devcontainer/features/src/terraform-tools/install-hcl2json.sh
+++ b/.devcontainer/features/src/terraform-tools/install-hcl2json.sh
@@ -4,8 +4,8 @@ set -e
 
 source /usr/local/bin/devcontainer-utils
 
-VERSION=${HCLQVERSION:-"latest"}
-GITHUB_REPOSITORY="mattolenik/hclq"
+VERSION=${HCL2JSONVERSION:-"latest"}
+GITHUB_REPOSITORY="tmccombs/hcl2json"
 
 if [ "${VERSION}" == "latest" ]; then
   get_github_latest_tag ${GITHUB_REPOSITORY}
@@ -17,7 +17,7 @@ fi
 
 ### Install
 
-curl --location https://github.com/${GITHUB_REPOSITORY}/releases/download/${VERSION}/hclq-linux-amd64 \
-    --output /usr/local/bin/hclq
+curl --location https://github.com/${GITHUB_REPOSITORY}/releases/download/${VERSION}/hcl2json_linux_${ARCHITECTURE} \
+    --output /usr/local/bin/hcl2json
 
-chmod +x /usr/local/bin/hclq
+chmod +x /usr/local/bin/hcl2json

--- a/.devcontainer/features/src/terraform-tools/install.sh
+++ b/.devcontainer/features/src/terraform-tools/install.sh
@@ -8,6 +8,6 @@ if [[ "${INSTALLTERRAFORMDOCS}" == "true" ]]; then
   bash $( dirname $0 )/install-terraform-docs.sh
 fi
 
-if [[ "${INSTALLHCLQ}" == "true" ]]; then
-  bash $( dirname $0 )/install-hclq.sh
+if [[ "${INSTALLHCL2JSON}" == "true" ]]; then
+  bash $( dirname $0 )/install-hcl2json.sh
 fi

--- a/.devcontainer/features/test/terraform-tools/test.sh
+++ b/.devcontainer/features/test/terraform-tools/test.sh
@@ -8,6 +8,6 @@ source dev-container-features-test-lib
 check "tfswitch version" tfswitch --version
 check "terraform version" /home/vscode/terraform-bin/terraform -version
 check "terraform-docs version" terraform-docs --version
-check "hclq version" hclq --version
+check "hcl2json" hcl2json -h
 
 reportResults


### PR DESCRIPTION
`hclq` couldn't handle HCL2 😢

`hcl2json` can 🚀

```bash
$ cat data-platform-teams.tf | hcl2json | jq -r '.locals[].data_platform_core_teams[].members[]'
AlexVilela
bagg3rs
jemnery
bagg3rs
jacobwoffenden
julialawrence
Emterry
andyrogers1973
jhpyke
tamsinforbes
PriyaBasker23
hemeshpatel-moj
murdo-moj
simonsMOJ
```

Caveat is that `hcl2json` doesn't have a version flag to test against 🙃 but `-h` is good enough for validating it executes without issue