### PR TITLE
remove tag protection for data-platform-apps

### DIFF
--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -40,7 +40,8 @@ resource "github_repository" "default" {
 }
 
 resource "github_branch_protection" "default" {
-  count          = var.type == "app" ? 0 : 1 # Temp fix for app-migration setup
+  count = var.type == "app" ? 0 : 1 # Temp fix for app-migration setup
+
   repository_id  = github_repository.default.id
   pattern        = "main"
   enforce_admins = true
@@ -64,6 +65,7 @@ resource "github_branch_protection" "default" {
 
 resource "github_repository_tag_protection" "default" {
   count = var.type == "app" ? 0 : 1 # apps will not have tag protection
+
   repository = github_repository.default.id
   pattern    = "*"
 }

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -63,6 +63,7 @@ resource "github_branch_protection" "default" {
 }
 
 resource "github_repository_tag_protection" "default" {
+  count = var.type == "app" ? 0 : 1 # apps will not have tag protection
   repository = github_repository.default.id
   pattern    = "*"
 }

--- a/terraform/github/modules/repository/main.tf
+++ b/terraform/github/modules/repository/main.tf
@@ -40,11 +40,11 @@ resource "github_repository" "default" {
 }
 
 resource "github_branch_protection" "default" {
-  count = var.type == "app" ? 0 : 1 # Temp fix for app-migration setup
-  #checkov:skip=CKV_GIT_6:"Following discussions with other teams we will not be enforcing signed commits currently"
+  count          = var.type == "app" ? 0 : 1 # Temp fix for app-migration setup
   repository_id  = github_repository.default.id
   pattern        = "main"
   enforce_admins = true
+  #checkov:skip=CKV_GIT_6:"Following discussions with other teams we will not be enforcing signed commits currently"
   #tfsec:ignore:github-branch_protections-require_signed_commits
   require_signed_commits = var.require_signed_commits
 


### PR DESCRIPTION
## What has changed?
removing tag protection for data-platform-apps allows the app workflows to bump the version and create a release. 

## Why though?
With the current state of tag protection, github workflows cannot receive the required permission to create tags if tags are protected. We want to retain the current GitHub Actions functionality, so we need to remove tag protection for apps.