### PR TITLE
Add `GitHub.vscode-github-actions` to the list of default dev container extensions

### DIFF
--- a/.devcontainer/platform-engineering/devcontainer.json
+++ b/.devcontainer/platform-engineering/devcontainer.json
@@ -23,7 +23,7 @@
   "workspaceFolder": "/home/vscode/workspace",
   "customizations": {
     "vscode": {
-      "extensions": ["EditorConfig.EditorConfig", "GitHub.copilot", "GitHub.vscode-pull-request-github"]
+      "extensions": ["EditorConfig.EditorConfig", "GitHub.copilot", "GitHub.vscode-pull-request-github", "GitHub.vscode-github-actions"]
     }
   }
 }


### PR DESCRIPTION
Adds https://marketplace.visualstudio.com/items?itemName=github.vscode-github-actions

When using the dev container for multiple projects, this project doesn't work as expected, it cannot load the actions on per folder basis 😿, but it does ass the GitHub Actions Workflow language syntax 🎉 