### PR TITLE
Add Andy Cook to data-engineering-aws

### DIFF
--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -92,7 +92,8 @@ locals {
     "oliver-critchfield",
     "AlexVilela",
     "davidbridgwood",
-    "mshodge" # Michael Hodge
+    "mshodge", # Michael Hodge
+    "Andy-Cook"
   ]
 
   data_platform_core_infrastructure_maintainers = [


### PR DESCRIPTION
Adds Andy Cook to the `data-engineering-aws` team. He's a new member of the Data Modelling and Engineering team.