### PR TITLE
⬆️ Bump Terraform to 1.4.5

### DIFF
--- a/.github/workflows/reusable-terraform.yml
+++ b/.github/workflows/reusable-terraform.yml
@@ -25,7 +25,6 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   terraform:
-    name: Terraform
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-terraform.yml
+++ b/.github/workflows/reusable-terraform.yml
@@ -25,6 +25,7 @@ on: # yamllint disable-line rule:truthy
 
 jobs:
   terraform:
+    name: Terraform
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/reusable-terraform.yml
+++ b/.github/workflows/reusable-terraform.yml
@@ -1,6 +1,4 @@
 ---
-name: Terraform
-
 on: # yamllint disable-line rule:truthy
   workflow_call:
     inputs:

--- a/.github/workflows/terraform-github.yml
+++ b/.github/workflows/terraform-github.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       working-directory: terraform/github
       aws-role-to-assume: arn:aws:iam::042130406152:role/GlobalGitHubActionAccess
-      terraform-version: 1.4.4
+      terraform-version: 1.4.5
       terraform-backend-config-role: arn:aws:iam::042130406152:role/GlobalGitHubActionAdmin
     secrets: inherit

--- a/.github/workflows/terraform-pagerduty.yml
+++ b/.github/workflows/terraform-pagerduty.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       working-directory: terraform/pagerduty
       aws-role-to-assume: arn:aws:iam::042130406152:role/GlobalGitHubActionAccess
-      terraform-version: 1.4.4
+      terraform-version: 1.4.5
       terraform-backend-config-role: arn:aws:iam::042130406152:role/GlobalGitHubActionAdmin
     secrets: inherit


### PR DESCRIPTION
- Bumped Terraform to 1.4.5
- Removed `.name` from `.github/workflows/reusable-terraform.yml` as it wasn't necessary 