### PR TITLE
⚡ Enhance permissions of Data Modelling Tooling engineers

### DIFF
--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -91,6 +91,8 @@ locals {
     "williamorrie", # William Orr
     "gustavmoller",
     "jhpyke", # Jake H Pyke
+    "lalithanagarur",
+    "murad-ali-j",
     "oliver-critchfield",
     "AlexVilela",
     "davidbridgwood",

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -90,9 +90,10 @@ locals {
     "LavMatt",
     "williamorrie", # William Orr
     "gustavmoller",
-    "jhpyke", # Jake H Pyke
-    "lalithanagarur",
-    "murad-ali-j",
+    "jhpyke",         # Jake Hamblin-Pyke
+    "lalithanagarur", # Lalitha Nagarur
+    "murad-ali-j",    # Murad Ali
+    "Bharat-Dhiman",  # Bharat Dhiman
     "oliver-critchfield",
     "AlexVilela",
     "davidbridgwood",

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -91,9 +91,9 @@ locals {
     "williamorrie", # William Orr
     "gustavmoller",
     "jhpyke",         # Jake Hamblin-Pyke
-    "lalithanagarur", # Lalitha Nagarur
+    "lalithanagarur", # Lalitha Nagarur (Cog)
     "murad-ali-j",    # Murad Ali
-    "Bharat-Dhiman",  # Bharat Dhiman
+    "Bharat-Dhiman",  # Bharat Dhiman (Cog)
     "oliver-critchfield",
     "AlexVilela",
     "davidbridgwood",


### PR DESCRIPTION
This PR adds three new members to the `data-engineering-aws` team. These represent the newest data engineers who will be working on `Create-A-Derived-Table`, and so having access to the proper data engineer roles will be required for their development work on the product. All will have already signed the PNC agreement by the time this is converted from draft, so will be covered there. A further PR will follow for the final cognizant staff member, but due to sick leave they are unable to sign until their return, so will be handled separately. 

Let me know if you have any questions about this PR!