### PR TITLE
✔️ add final DMT member to modernisation role

### DIFF
--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -94,6 +94,7 @@ locals {
     "lalithanagarur", # Lalitha Nagarur (Cog)
     "murad-ali-j",    # Murad Ali
     "Bharat-Dhiman",  # Bharat Dhiman (Cog)
+    "mdowniecog"      # Michael Downie (Cog)
     "oliver-critchfield",
     "AlexVilela",
     "davidbridgwood",

--- a/terraform/github/teams.tf
+++ b/terraform/github/teams.tf
@@ -94,7 +94,7 @@ locals {
     "lalithanagarur", # Lalitha Nagarur (Cog)
     "murad-ali-j",    # Murad Ali
     "Bharat-Dhiman",  # Bharat Dhiman (Cog)
-    "mdowniecog"      # Michael Downie (Cog)
+    "mdowniecog",     # Michael Downie (Cog)
     "oliver-critchfield",
     "AlexVilela",
     "davidbridgwood",


### PR DESCRIPTION
This PR extends the work of [PR 421](https://github.com/ministryofjustice/data-platform/pull/421), adding the final member now they have returned from leave and signed the required document. Let me know if you have any questions!