### PR TITLE
📌 Bump GitHub component providers

### DIFF
--- a/terraform/github/modules/contributor/versions.tf
+++ b/terraform/github/modules/contributor/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
   required_providers {
     github = {
-      version = "5.23.0"
+      version = "5.25.1"
       source  = "integrations/github"
     }
   }

--- a/terraform/github/modules/repository/versions.tf
+++ b/terraform/github/modules/repository/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
   required_providers {
     github = {
-      version = "5.23.0"
+      version = "5.25.1"
       source  = "integrations/github"
     }
   }

--- a/terraform/github/modules/team/versions.tf
+++ b/terraform/github/modules/team/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
   required_providers {
     github = {
-      version = "5.23.0"
+      version = "5.25.1"
       source  = "integrations/github"
     }
   }

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -2,7 +2,7 @@ terraform {
   required_version = "~> 1.0"
   required_providers {
     aws = {
-      version = "4.65.0"
+      version = "4.67.0"
       source  = "hashicorp/aws"
     }
     github = {

--- a/terraform/github/versions.tf
+++ b/terraform/github/versions.tf
@@ -6,7 +6,7 @@ terraform {
       source  = "hashicorp/aws"
     }
     github = {
-      version = "5.23.0"
+      version = "5.25.1"
       source  = "integrations/github"
     }
     time = {


### PR DESCRIPTION
- `integrations/github` to 5.25.1 (supersedes https://github.com/ministryofjustice/data-platform/pull/467, https://github.com/ministryofjustice/data-platform/pull/466 and https://github.com/ministryofjustice/data-platform/pull/464)
- `hashicorp/aws` to 4.67.0 (supersedes https://github.com/ministryofjustice/data-platform/pull/472)