### PR TITLE
Rewriting the line that checks if terraform is being run locally.

### DIFF
--- a/terraform/application-migration/app-role-trusts.tf
+++ b/terraform/application-migration/app-role-trusts.tf
@@ -71,6 +71,7 @@ resource "null_resource" "update_iam_role_trust_policy" {
     export AWS_SECRET_ACCESS_KEY=$(echo $TEMP_CREDS | jq -r '.Credentials.SecretAccessKey')
     export AWS_SESSION_TOKEN=$(echo $TEMP_CREDS | jq -r '.Credentials.SessionToken')
     aws sts get-caller-identity
+    aws iam update-assume-role-policy --role-name ${each.value.name} --policy-document '${data.aws_iam_policy_document.updated_trust[each.key].json}'
 EOF
   }
 }

--- a/terraform/application-migration/app-role-trusts.tf
+++ b/terraform/application-migration/app-role-trusts.tf
@@ -61,19 +61,17 @@ resource "null_resource" "update_iam_role_trust_policy" {
   }
 
   provisioner "local-exec" {
-    interpreter = ["bash"]
-    command     = <<EOF
+    command = <<EOF
 
     # Do an inverted grep on the output of caller identity (return 0 if NOT found) and if the return code isn't 0 (meaning string was found or an error); assume running locally and unset the envvar.
-    if grep -zqv "SSO" <<< $(aws sts get-caller-identity) || unset AWS_SECURITY_TOKEN # Needed when running locally using aws-vault https://github.com/hashicorp/terraform-provider-aws/issues/8242#issuecomment-696828321
+    aws sts get-caller-identity | grep -zqv "SSO" || unset AWS_SECURITY_TOKEN # Needed when running locally using aws-vault https://github.com/hashicorp/terraform-provider-aws/issues/8242#issuecomment-696828321
 
     TEMP_CREDS=$(aws sts assume-role --role-arn ${data.aws_iam_session_context.data.issuer_arn} --role-session-name localexecupdatetrust)
     export AWS_ACCESS_KEY_ID=$(echo $TEMP_CREDS | jq -r '.Credentials.AccessKeyId')
     export AWS_SECRET_ACCESS_KEY=$(echo $TEMP_CREDS | jq -r '.Credentials.SecretAccessKey')
     export AWS_SESSION_TOKEN=$(echo $TEMP_CREDS | jq -r '.Credentials.SessionToken')
     aws sts get-caller-identity
-    aws iam update-assume-role-policy --role-name ${each.value.name} --policy-document '${data.aws_iam_policy_document.updated_trust[each.key].json}'
-  EOF
+EOF
   }
 }
 


### PR DESCRIPTION
`local-exec` was failing with (eventually) unexpected EOF. Turns out it doesn't like how the "check if running locally" line was written so changed it to play nicer with terraform.

As the only way to test is to apply, this was run in locally after it was fixed. But the error was replicated and fixed. 