### PR TITLE
🎡 Add Data Platform Apps and Tools Development account to AWS config

### DIFF
--- a/.devcontainer/features/src/aws-tools/src/home/vscode/.aws/config
+++ b/.devcontainer/features/src/aws-tools/src/home/vscode/.aws/config
@@ -58,3 +58,7 @@ sso_account_id=967617145656
 [profile data-platform-development]
 include_profile=sso-modernisation-platform-sandbox
 sso_account_id=013433889002
+
+[profile data-platform-apps-and-tools-development]
+include_profile=sso-modernisation-platform-sandbox
+sso_account_id=335889174965


### PR DESCRIPTION
As the title says, this PR adds our new Apps and Tools Development account to the AWS config 🚀 