### PR TITLE
🩹 Fix PagerDuty Slack on-call script

### DIFF
--- a/scripts/pagerduty/slack-on-call/README.md
+++ b/scripts/pagerduty/slack-on-call/README.md
@@ -27,7 +27,7 @@ cd scripts/pagerduty/slack-on-call
 
 # Run Python container
 docker run -it --rm \
-  --entrypoint /bin/sh \
+  --entrypoint /bin/bash \
   --volume $( pwd ):/app \
   --workdir /app \
   --env PAGERDUTY_SCHEDULE_ID="REPLACE_ME" \

--- a/scripts/pagerduty/slack-on-call/main.py
+++ b/scripts/pagerduty/slack-on-call/main.py
@@ -46,11 +46,13 @@ def get_on_call_user():
 
 
 def get_slack_user_id():
-    response = slack_client.users_lookupByEmail(email=get_on_call_user()[1])
     user_id = None
 
-    if response["ok"]:
+    try:
+        response = slack_client.users_lookupByEmail(email=get_on_call_user()[1])
         user_id = response["user"]["id"]
+    except Exception:
+        pass
 
     return user_id
 

--- a/scripts/pagerduty/slack-on-call/requirements.txt
+++ b/scripts/pagerduty/slack-on-call/requirements.txt
@@ -1,2 +1,2 @@
-pdpyras==4.5.2
+pdpyras==5.0.3
 slack-sdk==3.21.3


### PR DESCRIPTION
Resolves #450

- Uses a try when looking up the user, and passes on exception
- Bumped `pdpyras` to [`5.0.3`](https://github.com/PagerDuty/pdpyras/releases/tag/v5.0.3)
- Switched to `/bin/bash` when running locally, so the shell works properly 😺

If I update line 45 to an email it can't find in Slack

```python
return "Jacob Woffenden", "jacob.woffenden@justice.gov.uk"
```

It will now return

```bash
$ python main.py
Today's on-call engineer for Data Platform is Jacob Woffenden (I can't match their email to a Slack user, sorry!)
```