### PR TITLE
👷 Remove Andy from PagerDuty and hardcode vendor IDs

### DIFF
--- a/.github/linters/.tflint.hcl
+++ b/.github/linters/.tflint.hcl
@@ -1,3 +1,8 @@
+rule "terraform_naming_convention" {
+  enabled = true
+  format  = "snake_case"
+}
+
 rule "terraform_required_providers" {
   enabled = false
 }

--- a/.github/linters/.tflint.hcl
+++ b/.github/linters/.tflint.hcl
@@ -1,3 +1,3 @@
 rule "terraform_required_providers" {
-  enabled = true
+  enabled = false
 }

--- a/.github/linters/.tflint.hcl
+++ b/.github/linters/.tflint.hcl
@@ -1,0 +1,3 @@
+rule "terraform_required_providers" {
+  enabled = true
+}

--- a/.github/linters/.tflint.hcl
+++ b/.github/linters/.tflint.hcl
@@ -3,6 +3,10 @@ rule "terraform_naming_convention" {
   format  = "snake_case"
 }
 
+/*
+  terraform_required_providers has been disabled so that child modules can inherit the providers from their parent.
+  Also, when parent and child both specified versions, Dependabot would raise PR to update both parent and child modules, and they would conflict
+*/
 rule "terraform_required_providers" {
   enabled = false
 }

--- a/.github/workflows/terraform-pagerduty.yml
+++ b/.github/workflows/terraform-pagerduty.yml
@@ -27,6 +27,6 @@ jobs:
     with:
       working-directory: terraform/pagerduty
       aws-role-to-assume: arn:aws:iam::042130406152:role/GlobalGitHubActionAccess
-      terraform-version: 1.4.5
+      terraform-version: 1.5.0
       terraform-backend-config-role: arn:aws:iam::042130406152:role/GlobalGitHubActionAdmin
     secrets: inherit

--- a/terraform/pagerduty/modules/service/technical/main.tf
+++ b/terraform/pagerduty/modules/service/technical/main.tf
@@ -73,7 +73,8 @@ resource "pagerduty_service_integration" "cloudwatch" {
 
   name    = data.pagerduty_vendor.cloudwatch.name
   service = pagerduty_service.this.id
-  vendor  = data.pagerduty_vendor.cloudwatch.id
+  # vendor  = data.pagerduty_vendor.cloudwatch.id
+  vendor = "PZQ6AUS"
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_cloudwatch_integration_key" {
@@ -103,7 +104,8 @@ resource "pagerduty_service_integration" "cloudtrail" {
 
   name    = data.pagerduty_vendor.cloudtrail.name
   service = pagerduty_service.this.id
-  vendor  = data.pagerduty_vendor.cloudtrail.id
+  # vendor  = data.pagerduty_vendor.cloudtrail.id
+  vendor = "PDSJRA7"
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_cloudtrail_integration_key" {
@@ -133,7 +135,8 @@ resource "pagerduty_service_integration" "guardduty" {
 
   name    = data.pagerduty_vendor.guardduty.name
   service = pagerduty_service.this.id
-  vendor  = data.pagerduty_vendor.guardduty.id
+  # vendor  = data.pagerduty_vendor.guardduty.id
+  vendor = "PH27SPX"
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_guardduty_integration_key" {
@@ -193,7 +196,8 @@ resource "pagerduty_service_integration" "security_hub" {
 
   name    = data.pagerduty_vendor.security_hub.name
   service = pagerduty_service.this.id
-  vendor  = data.pagerduty_vendor.security_hub.id
+  # vendor  = data.pagerduty_vendor.security_hub.id
+  vendor = "PF0BK6R"
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_security_hub_integration_key" {
@@ -221,9 +225,10 @@ data "pagerduty_vendor" "email" {
 resource "pagerduty_service_integration" "email" {
   count = var.enable_email_integration ? 1 : 0
 
-  name              = data.pagerduty_vendor.email.name
-  service           = pagerduty_service.this.id
-  vendor            = data.pagerduty_vendor.email.id
+  name    = data.pagerduty_vendor.email.name
+  service = pagerduty_service.this.id
+  # vendor            = data.pagerduty_vendor.email.id
+  vendor            = "PBPQJ1M"
   integration_email = local.pagerduty_integration_email
 }
 

--- a/terraform/pagerduty/modules/service/technical/providers.tf
+++ b/terraform/pagerduty/modules/service/technical/providers.tf
@@ -1,5 +1,8 @@
 terraform {
   required_providers {
+    aws = {
+      source = "hashicorp/aws"
+    }
     pagerduty = {
       source = "pagerduty/pagerduty"
     }

--- a/terraform/pagerduty/schedules.tf
+++ b/terraform/pagerduty/schedules.tf
@@ -69,7 +69,6 @@ locals {
             module.users["emma.terry@digital.justice.gov.uk"].id,
             module.users["julia.lawrence@digital.justice.gov.uk"].id,
             module.users["richard.baguley@digital.justice.gov.uk"].id,
-            module.users["andy.rogers@digital.justice.gov.uk"].id
           ]
           restrictions = [
             {

--- a/terraform/pagerduty/teams.tf
+++ b/terraform/pagerduty/teams.tf
@@ -27,7 +27,6 @@ locals {
         module.users["richard.baguley@digital.justice.gov.uk"].id
       ]
       responders = [
-        module.users["andy.rogers@digital.justice.gov.uk"].id,
         module.users["emma.terry@digital.justice.gov.uk"].id
       ]
     }

--- a/terraform/pagerduty/technical-services.tf
+++ b/terraform/pagerduty/technical-services.tf
@@ -233,7 +233,8 @@ locals {
           ]
         }
       ]
-      enable_email_integration = true
+      enable_email_integration      = true
+      enable_cloudwatch_integration = true
     },
     {
       name              = "Data Platform Security"

--- a/terraform/pagerduty/users.tf
+++ b/terraform/pagerduty/users.tf
@@ -1,10 +1,6 @@
 locals {
   users = [
     {
-      name  = "Andy Rogers"
-      email = "andy.rogers@digital.justice.gov.uk"
-    },
-    {
       name  = "Emma Terry"
       email = "emma.terry@digital.justice.gov.uk"
     },


### PR DESCRIPTION
- Andy is moving teams 👋 
- Hardcoding PagerDuty vendor to stop them updating as a workaround for https://github.com/ministryofjustice/data-platform/issues/556 🔀
- Adding CloudWatch integration for Data Platform ☁️ 🔍 
- Bump Terraform to 1.5.0 💪 
- Added some TFLint rules 📏 
  - enable `terraform_naming_convention` 🐍
  - disable `terraform_required_providers` 🔒