### PR TITLE
Adding tamsin, murad and jake to data-platform group.

### DIFF
--- a/terraform/github/data-platform/teams.tf
+++ b/terraform/github/data-platform/teams.tf
@@ -53,7 +53,10 @@ locals {
   ]
 
   tech_archs_members = [ # members of the data-tech-archs gh group
-    "AlexVilela"
+    "AlexVilela",
+    "jhpyke",
+    "tamsinforbes",
+    "murad-ali-MoJ"
   ]
 
   data_engineering_maintainers = [


### PR DESCRIPTION
Required for access to the `data-platform` namespace.