### PR TITLE
Add Haymon to data engineering group for write access

### DIFF
--- a/terraform/github/data-platform/teams.tf
+++ b/terraform/github/data-platform/teams.tf
@@ -72,7 +72,8 @@ locals {
     "pjxcog",
     "sivabathina2",
     "hemeshpatel-moj",
-    "ChikC" # Chike Chinukwue
+    "ChikC",     # Chike Chinukwue
+    "hrahim-moj" # Haymon
   ]
 
   # DATA-ENGINEERING-AWS GITHUB GROUP WITH FULL AWS ACCESS


### PR DESCRIPTION
Adds Haymon to data-engineering githhub group to give `writer` permission, we will add an additional group as part of #632