### PR TITLE
Update daap athena load

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.0]
+
+### Changed
+
+- Changed the SerializationLibrary in serdeinfo of glue table metadata from
+`LazySimpleSerDe` to `OpenCSVSerde`
+- `infer_glue_schema()` changed so null columns are typed as `string` not `null`
+- The csv bytes value in `infer_glue_schema()` now decodes using uft-8-sig encoding
+as byte order marks were persisting in some data
+
 ## [0.1.1] - 2023-09-30
 
 ###

--- a/containers/daap-athena-load/config.json
+++ b/containers/daap-athena-load/config.json
@@ -1,6 +1,6 @@
 {
     "name": "daap-athena-load",
-    "version": "0.1.1",
+    "version": "1.0.0",
     "registry": "ecr",
     "ecr": {
         "role": "arn:aws:iam::013433889002:role/data-platform-gha",


### PR DESCRIPTION
Some additions made to `infer_glue_schema()` to ensure processed data are properly queryable via Athena once registered in the glue catalog