### PR TITLE
Adding tempertature-check app

### DIFF
--- a/configuration/ap_migration_apps.json
+++ b/configuration/ap_migration_apps.json
@@ -403,5 +403,11 @@
       "source_repo_name": "workforce-planning-app",
       "team": [],
       "description": ""
+  },
+  {
+    "name": "temperature-check",
+    "source_repo_name": "temperature-check",
+    "team": [],
+    "description": ""
   }
 ]

--- a/terraform/github/data-platform/teams.tf
+++ b/terraform/github/data-platform/teams.tf
@@ -69,7 +69,7 @@ locals {
     "pjxcog",
     "sivabathina2",
     "hemeshpatel-moj",
-    "ChikC",     # Chike Chinukwue
+    "ChikC",      # Chike Chinukwue
     "hrahim-moj", # Haymon
     "lalithanagarur"
   ]


### PR DESCRIPTION
Adding temp-check app.

Additionally, every time this workflow runs, it reconciles group memberships from the other organisations with the memberships in the main org, so if it hasn't been applied in a while, it's normal to see team ownership of a repo, repo environments being destroyed/created and users being added to teams.

Unless otherwise specified, repo destructions are not an expected output of this workflow, unless explicitly stated in the PR. The plan is not destroying repositories. Plan looks normal. 