### PR TITLE
Athena load update event keys

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -8,6 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2]
+
+### Added
+
+- `image_version` to lambda code, applied as env var inside container in v1.0.1
+
+### Changed
+
+- the keys to get the bucket and key from the event passed to the lambda from eventbridge
+as the event rule have changed slightly.
+
 ## [1.0.1]
 
 ### Added

--- a/containers/daap-athena-load/config.json
+++ b/containers/daap-athena-load/config.json
@@ -1,6 +1,6 @@
 {
     "name": "daap-athena-load",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "registry": "ecr",
     "ecr": {
         "role": "arn:aws:iam::013433889002:role/data-platform-gha",

--- a/containers/daap-athena-load/src/var/task/athena_load_handler.py
+++ b/containers/daap-athena-load/src/var/task/athena_load_handler.py
@@ -441,7 +441,7 @@ def handler(event, context):
     bucket_name = event["detail"]["bucket"]["name"]
     file_key = event["detail"]["object"]["key"]
     image_version = os.getenv("VERSION", "unknown")
-    logging.info(f"lambda is using image version: {image_version}"
+    logging.info(f"lambda is using image version: {image_version}")
     full_s3_path = os.path.join("s3://", bucket_name, file_key)
     logging.info(f"file is: {full_s3_path}")
     metadata_raw = infer_glue_schema(full_s3_path, "data_products_raw")

--- a/containers/daap-athena-load/src/var/task/athena_load_handler.py
+++ b/containers/daap-athena-load/src/var/task/athena_load_handler.py
@@ -438,8 +438,8 @@ def clean_up_temp_tables(table_name: str) -> None:
 
 
 def handler(event, context):
-    bucket_name = event["detail"]["requestParameters"]["bucketName"]
-    file_key = event["detail"]["requestParameters"]["key"]
+    bucket_name = event["detail"]["bucket"]["name"]
+    file_key = event["detail"]["object"]["key"]
 
     full_s3_path = os.path.join("s3://", bucket_name, file_key)
     logging.info(f"file is: {full_s3_path}")

--- a/containers/daap-athena-load/src/var/task/athena_load_handler.py
+++ b/containers/daap-athena-load/src/var/task/athena_load_handler.py
@@ -440,7 +440,8 @@ def clean_up_temp_tables(table_name: str) -> None:
 def handler(event, context):
     bucket_name = event["detail"]["bucket"]["name"]
     file_key = event["detail"]["object"]["key"]
-
+    image_version = os.getenv("VERSION", "unknown")
+    logging.info(f"lambda is using image version: {image_version}"
     full_s3_path = os.path.join("s3://", bucket_name, file_key)
     logging.info(f"file is: {full_s3_path}")
     metadata_raw = infer_glue_schema(full_s3_path, "data_products_raw")


### PR DESCRIPTION
We've made a change to the eventbridge rule and the format of the event passed to the lambda has changed to updated to account for this and also testing out the version available in the container now.