### PR TITLE
🩹 Specify static analysis override label for Terraform

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,17 +17,6 @@ updates:
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
   - package-ecosystem: "docker"
-    directory: ".devcontainer/features/test"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "docker"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "docker"
     directory: "containers/alpine-base"
     schedule:
       interval: "daily"
@@ -170,8 +159,19 @@ updates:
       include: "scope"
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
+  - package-ecosystem: "docker"
+    directory: ".devcontainer/features/test"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "docker"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
   - package-ecosystem: "pip"
-    directory: "=containers/daap-athena-load/src/var/task"
+    directory: "containers/daap-athena-load/src/var/task"
     schedule:
       interval: "daily"
       time: "09:00"
@@ -225,116 +225,10 @@ updates:
       include: "scope"
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-engineering-production/10ds"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/airflow"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/artifact-repos"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/kops"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/rds-s3-exports"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/s3-glue-crawler"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-development/cluster"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-development/open-metadata"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-management-production/cluster"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-production/cluster"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
   - package-ecosystem: "terraform"
     directory: "terraform/aws/analytical-platform/baseline"
     schedule:
@@ -346,6 +240,145 @@ updates:
       include: "scope"
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-data-engineering-production/10ds"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-data-production/airflow"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-data-production/artifact-repos"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-data-production/kops"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-data-production/rds-s3-exports"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-data-production/s3-glue-crawler"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-development/cluster"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-development/open-metadata"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-management-production/cluster"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
   - package-ecosystem: "terraform"
     directory: "terraform/aws/analytical-platform/oidc"
     schedule:
@@ -357,6 +390,25 @@ updates:
       include: "scope"
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-production/cluster"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
   - package-ecosystem: "terraform"
     directory: "terraform/github/application-migration"
     schedule:
@@ -368,6 +420,10 @@ updates:
       include: "scope"
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
   - package-ecosystem: "terraform"
     directory: "terraform/github/data-platform"
     schedule:
@@ -379,6 +435,10 @@ updates:
       include: "scope"
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"
   - package-ecosystem: "terraform"
     directory: "terraform/pagerduty"
     schedule:
@@ -390,3 +450,7 @@ updates:
       include: "scope"
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
+    labels:
+      - "dependencies"
+      - "terraform"
+      - "override-static-analysis"

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -3,7 +3,7 @@
 declare -xr DEPENDABOT_CONFIGURATION_FILE=".github/dependabot.yml"
 
 dockerFolders=$(find . -type f -name "*Dockerfile*" -exec dirname {} \; | sort -h | uniq | cut -c 3-)
-pythonFolders==$(find . -type f -name "*requirements*.txt" -exec dirname {} \; | sort -h | uniq | cut -c 3-)
+pythonFolders=$(find . -type f -name "*requirements*.txt" -exec dirname {} \; | sort -h | uniq | cut -c 3-)
 terraformFolders=$(find . -type f -name ".terraform.lock.hcl" -exec dirname {} \; | sort -h | uniq | cut -c 3-)
 
 echo "=== Docker Folders ==="
@@ -77,6 +77,10 @@ for folder in ${terraformFolders}; do
   printf "      include: \"scope\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "    reviewers:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      - \"ministryofjustice/data-platform-core-infra\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    labels:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "      - \"dependencies\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "      - \"terraform\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "      - \"override-static-analysis\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
 done
 
 if [[ "${GITHUB_ACTIONS}" == "true" ]]; then


### PR DESCRIPTION
Automated approval won't work if static analysis fails, but that is out of scope for a dependabot PR

Related https://github.com/ministryofjustice/data-platform/issues/886