### PR TITLE
Creating an inline role with amended trust policy to get around character limitations. This will need a permnanet fix with a change in the oidc module.

### DIFF
--- a/terraform/aws/analytical-platform/oidc/data.tf
+++ b/terraform/aws/analytical-platform/oidc/data.tf
@@ -6,6 +6,10 @@ data "aws_caller_identity" "session" {
   provider = aws.session
 }
 
+data "aws_caller_identity" "data_producion" {
+  providers = aws.analytical-platform-data-production
+}
+
 data "aws_iam_session_context" "session" {
   provider = aws.session
 

--- a/terraform/aws/analytical-platform/oidc/data.tf
+++ b/terraform/aws/analytical-platform/oidc/data.tf
@@ -6,7 +6,7 @@ data "aws_caller_identity" "session" {
   provider = aws.session
 }
 
-data "aws_caller_identity" "data_producion" {
+data "aws_caller_identity" "data_production" {
   providers = aws.analytical-platform-data-production
 }
 

--- a/terraform/aws/analytical-platform/oidc/data.tf
+++ b/terraform/aws/analytical-platform/oidc/data.tf
@@ -7,7 +7,7 @@ data "aws_caller_identity" "session" {
 }
 
 data "aws_caller_identity" "data_production" {
-  providers = aws.analytical-platform-data-production
+  provider = aws.analytical-platform-data-production
 }
 
 data "aws_iam_session_context" "session" {

--- a/terraform/aws/analytical-platform/oidc/oidc-providers.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-providers.tf
@@ -150,9 +150,9 @@ module "analytical_platform_data_production_github_oidc_provider" {
     aws = aws.analytical-platform-data-production
   }
 
-  role_name              = "github-actions-ecr-oidc"
+  role_name              = "github-actions-ecr-oidc-dummy"
   additional_permissions = data.aws_iam_policy_document.analytical_platform_data_production_github_oidc_provider.json
-  github_repositories    = formatlist("ministryofjustice/%s:*", concat([for app in local.migration_apps_map : app.name], local.additional_repos_for_ecr))
+  github_repositories    = [format("ministryofjustice/%s:*", "data-platform-dummy-repo")]
 
   tags_prefix = "data-platform"
   tags_common = var.tags

--- a/terraform/aws/analytical-platform/oidc/oidc-roles.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-roles.tf
@@ -194,7 +194,7 @@ resource "aws_iam_role_policy_attachment" "read_only" {
 
 # Add actions missing from arn:aws:iam::aws:policy/ReadOnlyAccess
 resource "aws_iam_policy" "extra_permissions" {
-  name        = var.role_name
+  name        = "github-actions-ecr-oidc"
   path        = "/"
   description = "A policy for extra permissions for GitHub Actions"
 

--- a/terraform/aws/analytical-platform/oidc/oidc-roles.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-roles.tf
@@ -149,6 +149,7 @@ module "analytical_platform_management_production_github_oidc_role" {
 
 
 resource "aws_iam_role" "github_actions" {
+  provider           = aws.analytical-platform-data-production
   name               = "github-actions-ecr-oidc"
   assume_role_policy = data.aws_iam_policy_document.github_oidc_assume_role.json
 }
@@ -163,7 +164,7 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
     principals {
       type = "Federated"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+        "arn:aws:iam::${data.aws_caller_identity.data_production.account_id}:oidc-provider/token.actions.githubusercontent.com"
       ]
     }
 
@@ -188,13 +189,15 @@ data "aws_iam_policy_document" "github_oidc_assume_role" {
 }
 
 resource "aws_iam_role_policy_attachment" "read_only" {
+  provider   = aws.analytical-platform-data-production
   role       = aws_iam_role.github_actions.name
   policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
 }
 
 # Add actions missing from arn:aws:iam::aws:policy/ReadOnlyAccess
 resource "aws_iam_policy" "extra_permissions" {
-  name        = "github-actions-ecr-oidc"
+  provider    = aws.analytical-platform-data-production
+  name        = aws_iam_role.github_actions.name
   path        = "/"
   description = "A policy for extra permissions for GitHub Actions"
 
@@ -202,6 +205,7 @@ resource "aws_iam_policy" "extra_permissions" {
 }
 
 resource "aws_iam_role_policy_attachment" "extra_permissions" {
+  provider   = aws.analytical-platform-data-production
   role       = aws_iam_role.github_actions.name
   policy_arn = aws_iam_policy.extra_permissions.arn
 }

--- a/terraform/aws/analytical-platform/oidc/oidc-roles.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-roles.tf
@@ -146,3 +146,62 @@ module "analytical_platform_management_production_github_oidc_role" {
 
   tags = var.tags
 }
+
+
+resource "aws_iam_role" "github_actions" {
+  name               = "github-actions-ecr-oidc"
+  assume_role_policy = data.aws_iam_policy_document.github_oidc_assume_role.json
+}
+
+data "aws_iam_policy_document" "github_oidc_assume_role" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type = "Federated"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:oidc-provider/token.actions.githubusercontent.com"
+      ]
+    }
+
+    condition {
+      test     = "StringEquals"
+      variable = "token.actions.githubusercontent.com:aud"
+      values   = ["sts.amazonaws.com"]
+    }
+
+    condition {
+      test     = "StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = formatlist("*:*/%s:*", concat([for app in local.migration_apps_map : app.name], local.additional_repos_for_ecr))
+    }
+
+    condition {
+      test     = "ForAllValues:StringLike"
+      variable = "token.actions.githubusercontent.com:sub"
+      values   = ["repo:ministryofjustice/*"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "read_only" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+}
+
+# Add actions missing from arn:aws:iam::aws:policy/ReadOnlyAccess
+resource "aws_iam_policy" "extra_permissions" {
+  name        = var.role_name
+  path        = "/"
+  description = "A policy for extra permissions for GitHub Actions"
+
+  policy = data.aws_iam_policy_document.analytical_platform_data_production_github_oidc_provider.json
+}
+
+resource "aws_iam_role_policy_attachment" "extra_permissions" {
+  role       = aws_iam_role.github_actions.name
+  policy_arn = aws_iam_policy.extra_permissions.arn
+}


### PR DESCRIPTION
This is mostly a bandaid to get around policy character limits with too many repos using the the same role.

This PR
* Renames the role created via the module to `ecr-oidc-dummy` and adds a dummy repo for assumption
* Uses flat terraform to author a new version of the `ecr-oidc` role with a refactored trust policy with two sets of conditions.

This requires a fix in the near future both to figure out how to limit the number of repos using the role and a PR to the OIDC module to allow more custom options for defining trust policy conditions.