### PR TITLE
DMT-1238/add-airflow-subnets

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/network.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/network.tf
@@ -21,3 +21,23 @@ resource "aws_internet_gateway" "airflow_dev" {
     Name = "airflow-dev"
   }
 }
+
+resource "aws_subnet" "public_subnet" {
+  vpc_id            = aws_vpc.airflow_dev.id
+  count             = length(var.public_subnet_cidrs)
+  cidr_block        = element(var.public_subnet_cidrs, count.index)
+  availability_zone = element(var.azs, count.index)
+  tags = {
+    Name = "airflow-dev-public-${element(var.azs, count.index)}"
+  }
+}
+
+resource "aws_subnet" "private_subnet" {
+  vpc_id            = aws_vpc.airflow_dev.id
+  count             = length(var.private_subnet_cidrs)
+  cidr_block        = element(var.private_subnet_cidrs, count.index)
+  availability_zone = element(var.azs, count.index)
+  tags = {
+    Name = "airflow-dev-private-${element(var.azs, count.index)}"
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars
@@ -18,3 +18,11 @@ tags = {
   infrastructure-support = "data-platform:data-platform-tech@digital.justice.gov.uk"
   source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/airflow"
 }
+
+##################################################
+# Network
+##################################################
+
+azs                  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+private_subnet_cidrs = ["10.200.20.0/24", "10.200.21.0/24", "10.200.22.0/24"]
+public_subnet_cidrs  = ["10.200.10.0/24", "10.200.11.0/24", "10.200.12.0/24"]

--- a/terraform/aws/analytical-platform-data-production/airflow/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/variables.tf
@@ -11,3 +11,22 @@ variable "tags" {
   type        = map(string)
   description = "Map of tags to apply to resources"
 }
+
+##################################################
+# Network
+##################################################
+
+variable "azs" {
+  type        = list(string)
+  description = "List of availability zones in Ireland region"
+}
+
+variable "private_subnet_cidrs" {
+  type        = list(string)
+  description = "List of private subnet CIDR ranges"
+}
+
+variable "public_subnet_cidrs" {
+  type        = list(string)
+  description = "List of public subnet CIDR ranges"
+}


### PR DESCRIPTION
Adding 6 subnets, 3 each of private/public, one for each AZ

airflow-dev-private-eu-west-1a subnet-02c12ac78aa071d71
airflow-dev-private-eu-west-1b subnet-0984267608686a5ce
airflow-dev-private-eu-west-1c subnet-0f0f0e17d45e9791f

airflow-dev-public-eu-west-1a subnet-0269adc880d237914
airflow-dev-public-eu-west-1b subnet-0d63aad6294936483
airflow-dev-public-eu-west-1c subnet-02a13fd4fd56ee6c5

https://github.com/ministryofjustice/data-platform/issues/1238