### PR TITLE
DMT-1238/airflow-vpc-attachments

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/network.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/network.tf
@@ -113,3 +113,30 @@ resource "aws_route_table_association" "airflow_dev_private_route_table_assoc" {
   subnet_id      = aws_subnet.private_subnet[count.index].id
   route_table_id = aws_route_table.airflow_dev_private[count.index].id
 }
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "airflow_dev_cloud_platform" {
+  subnet_ids = [
+    aws_subnet.private_subnet[0].id,
+    aws_subnet.private_subnet[1].id,
+    aws_subnet.private_subnet[2].id,
+  ]
+  transit_gateway_id = "tgw-009e14703041026a5"
+  vpc_id             = aws_vpc.airflow_dev.id
+  tags = {
+    Name = "airflow-dev-cloud-platform"
+  }
+}
+
+resource "aws_ec2_transit_gateway_vpc_attachment" "airflow_dev_moj" {
+  subnet_ids = [
+    aws_subnet.private_subnet[0].id,
+    aws_subnet.private_subnet[1].id,
+    aws_subnet.private_subnet[2].id,
+  ]
+  transit_gateway_id = "tgw-0e7b982ea47c28fba"
+  vpc_id             = aws_vpc.airflow_dev.id
+
+  tags = {
+    Name = "airflow-dev-moj"
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/airflow/network.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/network.tf
@@ -71,7 +71,7 @@ resource "aws_route_table" "airflow_dev_public" {
     gateway_id = aws_internet_gateway.airflow_dev.id
   }
   route { # known dead end to noms-live
-    cidr_block = var.noms_live_dead_end
+    cidr_block = var.noms_live_dead_end_cidr_block
     gateway_id = aws_internet_gateway.airflow_dev.id
   }
 
@@ -95,11 +95,11 @@ resource "aws_route_table" "airflow_dev_private" {
     nat_gateway_id = aws_nat_gateway.airflow_dev[count.index].id
   }
   route {
-    cidr_block         = "10.26.0.0/15"
+    cidr_block         = var.modernisation_platform_cidr_block
     transit_gateway_id = var.transit_gateway_ids["airflow-dev-moj"]
   }
   route { # known dead end to noms-live
-    cidr_block         = var.noms_live_dead_end
+    cidr_block         = var.noms_live_dead_end_cidr_block
     transit_gateway_id = var.transit_gateway_ids["airflow-dev-moj"]
   }
 

--- a/terraform/aws/analytical-platform-data-production/airflow/network.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/network.tf
@@ -71,7 +71,7 @@ resource "aws_route_table" "airflow_dev_public" {
     gateway_id = aws_internet_gateway.airflow_dev.id
   }
   route { # known dead end to noms-live
-    cidr_block = "10.40.0.0/18"
+    cidr_block = var.noms_live_dead_end
     gateway_id = aws_internet_gateway.airflow_dev.id
   }
 
@@ -96,11 +96,11 @@ resource "aws_route_table" "airflow_dev_private" {
   }
   route {
     cidr_block         = "10.26.0.0/15"
-    transit_gateway_id = "tgw-0e7b982ea47c28fba"
+    transit_gateway_id = var.transit_gateway_ids["airflow-dev-moj"]
   }
   route { # known dead end to noms-live
-    cidr_block         = "10.40.0.0/18"
-    transit_gateway_id = "tgw-0e7b982ea47c28fba"
+    cidr_block         = var.noms_live_dead_end
+    transit_gateway_id = var.transit_gateway_ids["airflow-dev-moj"]
   }
 
   tags = {
@@ -115,12 +115,8 @@ resource "aws_route_table_association" "airflow_dev_private_route_table_assoc" {
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "airflow_dev_cloud_platform" {
-  subnet_ids = [
-    aws_subnet.private_subnet[0].id,
-    aws_subnet.private_subnet[1].id,
-    aws_subnet.private_subnet[2].id,
-  ]
-  transit_gateway_id = "tgw-009e14703041026a5"
+  subnet_ids         = aws_subnet.private_subnet[*].id
+  transit_gateway_id = var.transit_gateway_ids["airflow-dev-cloud-platform"]
   vpc_id             = aws_vpc.airflow_dev.id
   tags = {
     Name = "airflow-dev-cloud-platform"
@@ -128,12 +124,8 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "airflow_dev_cloud_platform" {
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "airflow_dev_moj" {
-  subnet_ids = [
-    aws_subnet.private_subnet[0].id,
-    aws_subnet.private_subnet[1].id,
-    aws_subnet.private_subnet[2].id,
-  ]
-  transit_gateway_id = "tgw-0e7b982ea47c28fba"
+  subnet_ids         = aws_subnet.private_subnet[*].id
+  transit_gateway_id = var.transit_gateway_ids["airflow-dev-moj"]
   vpc_id             = aws_vpc.airflow_dev.id
 
   tags = {

--- a/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars
@@ -22,11 +22,12 @@ tags = {
 ##################################################
 # Network
 ##################################################
-vpc_cidr_block       = "10.200.0.0/16"
-noms_live_dead_end   = "10.40.0.0/18"
-azs                  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
-private_subnet_cidrs = ["10.200.20.0/24", "10.200.21.0/24", "10.200.22.0/24"]
-public_subnet_cidrs  = ["10.200.10.0/24", "10.200.11.0/24", "10.200.12.0/24"]
+vpc_cidr_block                    = "10.200.0.0/16"
+noms_live_dead_end_cidr_block     = "10.40.0.0/18"
+modernisation_platform_cidr_block = "10.26.0.0/15"
+azs                               = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
+private_subnet_cidrs              = ["10.200.20.0/24", "10.200.21.0/24", "10.200.22.0/24"]
+public_subnet_cidrs               = ["10.200.10.0/24", "10.200.11.0/24", "10.200.12.0/24"]
 
 
 transit_gateway_ids = {

--- a/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars
@@ -23,6 +23,13 @@ tags = {
 # Network
 ##################################################
 vpc_cidr_block       = "10.200.0.0/16"
+noms_live_dead_end   = "10.40.0.0/18"
 azs                  = ["eu-west-1a", "eu-west-1b", "eu-west-1c"]
 private_subnet_cidrs = ["10.200.20.0/24", "10.200.21.0/24", "10.200.22.0/24"]
 public_subnet_cidrs  = ["10.200.10.0/24", "10.200.11.0/24", "10.200.12.0/24"]
+
+
+transit_gateway_ids = {
+  "airflow-dev-cloud-platform" = "tgw-009e14703041026a5"
+  "airflow-dev-moj"            = "tgw-0e7b982ea47c28fba"
+}

--- a/terraform/aws/analytical-platform-data-production/airflow/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/variables.tf
@@ -21,9 +21,14 @@ variable "vpc_cidr_block" {
   description = "CIDR range for the VPC"
 }
 
-variable "noms_live_dead_end" {
+variable "noms_live_dead_end_cidr_block" {
   type        = string
   description = "CIDR range for NOMS live"
+}
+
+variable "modernisation_platform_cidr_block" {
+  type        = string
+  description = "CIDR range for Modernisation Platform"
 }
 
 variable "azs" {

--- a/terraform/aws/analytical-platform-data-production/airflow/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/variables.tf
@@ -20,6 +20,12 @@ variable "vpc_cidr_block" {
   type        = string
   description = "CIDR range for the VPC"
 }
+
+variable "noms_live_dead_end" {
+  type        = string
+  description = "CIDR range for NOMS live"
+}
+
 variable "azs" {
   type        = list(string)
   description = "List of availability zones in Ireland region"
@@ -34,3 +40,9 @@ variable "public_subnet_cidrs" {
   type        = list(string)
   description = "List of public subnet CIDR ranges"
 }
+
+variable "transit_gateway_ids" {
+  type        = map(string)
+  description = "Map of transit gateway names to ids"
+}
+


### PR DESCRIPTION
Add transit gateway vpc attachments x2
```
    │  ├─ aws:ec2transitgateway/vpcAttachment:VpcAttachment          airflow-dev-cloud-platform
    │  │     ID: tgw-attach-0cfad215cd14d724e
    │  └─ aws:ec2transitgateway/vpcAttachment:VpcAttachment          airflow-dev-moj
    │        ID: tgw-attach-0e5e2e0c05dbd638d
```
https://github.com/ministryofjustice/data-platform/issues/1238
