### PR TITLE
Added cluster_autoscaler_role to Data Platform

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/iam-policies.tf
@@ -111,3 +111,37 @@ data "aws_iam_policy_document" "airflow_dev_execution_assume_role_policy" {
     actions = ["sts:AssumeRole"]
   }
 }
+
+data "aws_iam_policy_document" "airflow_dev_cluster_autoscaler_policy" {
+  statement {
+    sid    = ""
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeInstanceTypes",
+      "autoscaling:TerminateInstanceInAutoScalingGroup",
+      "autoscaling:SetDesiredCapacity",
+      "autoscaling:DescribeTags",
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeAutoScalingInstances",
+      "autoscaling:DescribeAutoScalingGroups"
+    ]
+    resources = ["*"]
+  }
+
+}
+
+data "aws_iam_policy_document" "airflow_dev_cluster_autoscaler_assume_role_policy" {
+  statement {
+    sid    = ""
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::593291632749:role/airflow-dev-node-instance-role"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
@@ -28,3 +28,14 @@ resource "aws_iam_role" "airflow_dev_execution_role" {
     policy = data.aws_iam_policy_document.airflow_dev_execution_role_policy.json
   }
 }
+
+resource "aws_iam_role" "airflow_dev_cluster_autoscaler_role" {
+  name               = "airflow-dev-cluster-autoscaler-role"
+  description        = "Cluster Autoscaler role for Airflow dev"
+  assume_role_policy = data.aws_iam_policy_document.airflow_dev_cluster_autoscaler_assume_role_policy.json
+
+  inline_policy {
+    name   = "cluster-autoscaler"
+    policy = data.aws_iam_policy_document.airflow_dev_cluster_autoscaler_policy.json
+  }
+}


### PR DESCRIPTION
This PR adds an additional role to the Airflow resources being managed via terrraform. Please check for any unintended changes in the plan!