### PR TITLE
Dpl 1193 create metadata lambda

### DIFF
--- a/.github/path-filter/containers.yml
+++ b/.github/path-filter/containers.yml
@@ -5,6 +5,7 @@
 alpine-base: containers/alpine-base/**
 daap-athena-load: containers/daap-athena-load/**
 daap-authorizer: containers/daap-authorizer/**
+daap-create-metadata: containers/daap-create-metadata/**
 daap-docs: containers/daap-docs/**
 daap-get-glue-metadata: containers/daap-get-glue-metadata/**
 daap-presigned-url: containers/daap-presigned-url/**

--- a/.github/path-filter/containers.yml
+++ b/.github/path-filter/containers.yml
@@ -5,7 +5,6 @@
 alpine-base: containers/alpine-base/**
 daap-athena-load: containers/daap-athena-load/**
 daap-authorizer: containers/daap-authorizer/**
-daap-create-metadata: containers/daap-create-metadata/**
 daap-docs: containers/daap-docs/**
 daap-get-glue-metadata: containers/daap-get-glue-metadata/**
 daap-presigned-url: containers/daap-presigned-url/**

--- a/containers/daap-create-metadata/CHANGELOG.md
+++ b/containers/daap-create-metadata/CHANGELOG.md
@@ -1,0 +1,16 @@
+<!-- markdownlint-disable MD003 -->
+
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [1.0.0]
+
+### Added
+
+- Initial container definition

--- a/containers/daap-create-metadata/Dockerfile
+++ b/containers/daap-create-metadata/Dockerfile
@@ -1,0 +1,9 @@
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:0.3.0
+
+ARG VERSION
+
+ENV VERSION="${VERSION}"
+
+COPY src/var/task ${LAMDA_TASK_ROOT}
+
+CMD ["create_metadata.handler"]

--- a/containers/daap-create-metadata/Dockerfile
+++ b/containers/daap-create-metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:0.3.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:0.4.0
 
 ARG VERSION
 

--- a/containers/daap-create-metadata/config.json
+++ b/containers/daap-create-metadata/config.json
@@ -1,0 +1,11 @@
+{
+  "name": "daap-create-metadata",
+  "version": "1.0.0",
+  "registry": "ecr",
+  "ecr": {
+    "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",
+    "account": "374269020027",
+    "region": "eu-west-2",
+    "repository": "data-platform-create-metadata-lambda-ecr-repo"
+  }
+}

--- a/containers/daap-create-metadata/src/var/task/create_metadata.py
+++ b/containers/daap-create-metadata/src/var/task/create_metadata.py
@@ -40,7 +40,7 @@ def handler(event, context):
     data_product_metadata = DataProductMetadata(data_product_name, logger)
 
     if not data_product_metadata.metadata_exists:
-        data_product_metadata.validate_metadata(event["metadata"])
+        data_product_metadata.validate(event["metadata"])
     else:
         data_product_metadata.logger.write_log_dict_to_s3_json(
             os.environ["BUCKET_NAME"], **s3_security_opts
@@ -57,7 +57,7 @@ def handler(event, context):
         }
 
     if data_product_metadata.valid_metadata:
-        data_product_metadata.write_metadata_json_to_s3()
+        data_product_metadata.write_json_to_s3()
         data_product_metadata.logger.write_log_dict_to_s3_json(
             os.environ["BUCKET_NAME"], **s3_security_opts
         )

--- a/containers/daap-create-metadata/src/var/task/create_metadata.py
+++ b/containers/daap-create-metadata/src/var/task/create_metadata.py
@@ -29,7 +29,8 @@ def handler(event, context):
             "headers": {"Content-Type": "application/json"},
             "body": json.dumps(
                 {
-                    "message": "The name of the data product is missing, it must be specified in the metadata against the 'name' key"
+                    "message": "Data product name is missing, it must be specified \
+                        in the metadata against the 'name' key"
                 }
             ),
         }
@@ -80,7 +81,8 @@ def handler(event, context):
             "body": json.dumps(
                 {
                     "data_product_name": data_product_name,
-                    "message": f"Your metadata failed validation with this error: {data_product_metadata.error_traceback}",
+                    "message": f"Your metadata failed validation with \
+                        this error: {data_product_metadata.error_traceback}",
                 }
             ),
         }

--- a/containers/daap-create-metadata/src/var/task/create_metadata.py
+++ b/containers/daap-create-metadata/src/var/task/create_metadata.py
@@ -6,7 +6,6 @@ from data_product_metadata import DataProductMetadata
 
 
 def handler(event, context):
-
     logger = DataPlatformLogger(
         extra={
             "image_version": os.getenv("VERSION", "unknown"),
@@ -15,16 +14,24 @@ def handler(event, context):
         }
     )
 
+    s3_security_opts = {
+        "ACL": "bucket-owner-full-control",
+        "ServerSideEncryption": "AES256",
+    }
+
     try:
         data_product_name = event["metadata"]["name"]
     except KeyError:
         logger.error("The name of the data product is missing")
+        logger.write_log_dict_to_s3_json(os.environ["BUCKET_NAME"], **s3_security_opts)
         return {
             "statusCode": 400,
             "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({
-                "message": "The name of the data product is missing, it must be specified in the metadata against the 'name' key"
-            })
+            "body": json.dumps(
+                {
+                    "message": "The name of the data product is missing, it must be specified in the metadata against the 'name' key"
+                }
+            ),
         }
 
     logger.add_extras({"data_product_name": data_product_name})
@@ -34,31 +41,46 @@ def handler(event, context):
     if not data_product_metadata.metadata_exists:
         data_product_metadata.validate_metadata(event["metadata"])
     else:
+        data_product_metadata.logger.write_log_dict_to_s3_json(
+            os.environ["BUCKET_NAME"], **s3_security_opts
+        )
         return {
             "statusCode": 400,
             "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({
-                "data_product_name": data_product_name,
-                "message": "Your data product already has a version 1 registered metadata"
-            }),
+            "body": json.dumps(
+                {
+                    "data_product_name": data_product_name,
+                    "message": "Your data product already has a version 1 registered metadata.",
+                }
+            ),
         }
 
     if data_product_metadata.valid_metadata:
         data_product_metadata.write_metadata_json_to_s3()
+        data_product_metadata.logger.write_log_dict_to_s3_json(
+            os.environ["BUCKET_NAME"], **s3_security_opts
+        )
         return {
             "statusCode": 200,
             "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({
-                "data_product_name": data_product_name,
-                "message": "Data product metadata has been created."
-            }),
+            "body": json.dumps(
+                {
+                    "data_product_name": data_product_name,
+                    "message": "Data product metadata has been created.",
+                }
+            ),
         }
     else:
+        data_product_metadata.logger.write_log_dict_to_s3_json(
+            os.environ["BUCKET_NAME"], **s3_security_opts
+        )
         return {
             "statusCode": 400,
             "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({
-                "data_product_name": data_product_name,
-                "message": f"Your metadata failed validation with this error: {data_product_metadata.error_traceback}"
-            }),
+            "body": json.dumps(
+                {
+                    "data_product_name": data_product_name,
+                    "message": f"Your metadata failed validation with this error: {data_product_metadata.error_traceback}",
+                }
+            ),
         }

--- a/containers/daap-create-metadata/src/var/task/create_metadata.py
+++ b/containers/daap-create-metadata/src/var/task/create_metadata.py
@@ -1,0 +1,64 @@
+import json
+import os
+
+from data_platform_logging import DataPlatformLogger
+from data_product_metadata import DataProductMetadata
+
+
+def handler(event, context):
+
+    logger = DataPlatformLogger(
+        extra={
+            "image_version": os.getenv("VERSION", "unknown"),
+            "base_image_version": os.getenv("BASE_VERSION", "unknown"),
+            "lambda_name": context.function_name,
+        }
+    )
+
+    try:
+        data_product_name = event["metadata"]["name"]
+    except KeyError:
+        logger.error("The name of the data product is missing")
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({
+                "message": "The name of the data product is missing, it must be specified in the metadata against the 'name' key"
+            })
+        }
+
+    logger.add_extras({"data_product_name": data_product_name})
+
+    data_product_metadata = DataProductMetadata(data_product_name, logger)
+
+    if not data_product_metadata.metadata_exists:
+        data_product_metadata.validate_metadata(event["metadata"])
+    else:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({
+                "data_product_name": data_product_name,
+                "message": "Your data product already has a version 1 registered metadata"
+            }),
+        }
+
+    if data_product_metadata.valid_metadata:
+        data_product_metadata.write_metadata_json_to_s3()
+        return {
+            "statusCode": 200,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({
+                "data_product_name": data_product_name,
+                "message": "Data product metadata has been created."
+            }),
+        }
+    else:
+        return {
+            "statusCode": 400,
+            "headers": {"Content-Type": "application/json"},
+            "body": json.dumps({
+                "data_product_name": data_product_name,
+                "message": f"Your metadata failed validation with this error: {data_product_metadata.error_traceback}"
+            }),
+        }

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2023-09-01
+
+## Added
+
+- data_product_metadata python module. This contains code that will be used, intially
+by an api endpoint to create data product metadata, but in future, expanded to be used
+in other endpoints too, such as an update_metadata endpoint.
+
 ## [0.3.0] - 2023-08-11
 
 ### Changed

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -12,9 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Added
 
-- data_product_metadata python module. This contains code that will be used, intially
-by an api endpoint to create data product metadata, but in future, expanded to be used
-in other endpoints too, such as an update_metadata endpoint.
+- data_product_metadata python module. This contains code that will be used,
+intially by an API endpoint to create data product metadata, but in future,
+expanded to be usedin other endpoints too, such as an update_metadata endpoint.
 
 ## [0.3.0] - 2023-08-11
 

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
     "name": "daap-python-base",
-    "version": "0.3.0",
+    "version": "0.4.0",
     "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -132,9 +132,13 @@ class DataProductMetadata:
                 **{
                     "ACL": "bucket-owner-full-control",
                     "ServerSideEncryption": "AES256",
-                }
+                },
             )
             self.logger.info("Data Product metadata written to s3")
         else:
-            self.logger.error("Metadata need to be validated before writing to s3, run the validate() class method")
-            raise ValidationError("Metadata must be validated before being written to s3.")
+            self.logger.error(
+                "Metadata need to be validated before writing to s3, run the validate() class method"
+            )
+            raise ValidationError(
+                "Metadata must be validated before being written to s3."
+            )

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -123,14 +123,18 @@ class DataProductMetadata:
         return self
 
     def write_json_to_s3(self) -> None:
-        json_metadata = json.dumps(self.data_product_metadata)
-        s3_client.put_object(
-            Body=json_metadata,
-            Bucket=self.metadata_bucket,
-            Key=self.metadata_key,
-            **{
-                "ACL": "bucket-owner-full-control",
-                "ServerSideEncryption": "AES256",
-            },
-        )
-        self.logger.info("Data Product metadata written to s3")
+        if hasattr(self, "data_product_metadata") and self.valid_metadata:
+            json_metadata = json.dumps(self.data_product_metadata)
+            s3_client.put_object(
+                Body=json_metadata,
+                Bucket=self.metadata_bucket,
+                Key=self.metadata_key,
+                **{
+                    "ACL": "bucket-owner-full-control",
+                    "ServerSideEncryption": "AES256",
+                }
+            )
+            self.logger.info("Data Product metadata written to s3")
+        else:
+            self.logger.error("Metadata need to be validated before writing to s3, run the validate() class method")
+            raise ValidationError("Metadata must be validated before being written to s3.")

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -13,11 +13,11 @@ s3_client = boto3.client("s3")
 
 
 # These can be moved to separate module for all paths when work starts on that
-def get_bucket_name():
+def get_bucket_name() -> str:
     return os.environ["BUCKET_NAME"]
 
 
-def get_data_product_metadata_path(data_product_name):
+def get_data_product_metadata_path(data_product_name: str) -> str:
     metadata_s3_path = os.path.join(
         "s3://",
         get_bucket_name(),
@@ -29,9 +29,9 @@ def get_data_product_metadata_path(data_product_name):
     return metadata_s3_path
 
 
-def get_data_product_metadata_spec_path(version: str = None) -> str:
-    # if version is None we'll get the latest version
-    if version is None:
+def get_data_product_metadata_spec_path(version: str = "") -> str:
+    # if version is empty we'll get the latest version
+    if version == "":
         file_paths = get_filepaths_from_s3_folder(
             os.path.join("s3://", get_bucket_name(), "data_product_metadata_spec")
         )
@@ -80,7 +80,7 @@ class DataProductMetadata:
         self.metadata_key = key
         self._check_if_metadata_exists()
 
-    def _check_if_metadata_exists(self) -> bool:
+    def _check_if_metadata_exists(self) -> object:
         # establish whether metadata for data product already exists
         try:
             # get head of object (if it exists)
@@ -103,8 +103,8 @@ class DataProductMetadata:
     def validate_metadata(
         self,
         data_product_metadata: dict,
-        metadata_schema_version: str = None,
-    ) -> bool:
+        metadata_schema_version: str = "",
+    ) -> object:
         metadata_schema = read_json_from_s3(
             get_data_product_metadata_spec_path(metadata_schema_version)
         )

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -1,0 +1,117 @@
+import json
+import os
+import traceback
+
+import boto3
+import botocore
+from jsonschema import validate
+from jsonschema.exceptions import ValidationError
+
+from data_platform_logging import DataPlatformLogger
+from dataengineeringutils3.s3 import get_filepaths_from_s3_folder, read_json_from_s3
+
+s3_client = boto3.client("s3")
+
+
+# These can be moved to separate module for all paths when work starts on that
+def get_bucket_name():
+    return os.environ["BUCKET_NAME"]
+
+
+def get_data_product_metadata_path(data_product_name):
+    metadata_s3_path = os.path.join(
+        "s3://",
+        get_bucket_name(),
+        "metadata",
+        data_product_name,
+        "v1.0",
+        "metadata.json"
+    )
+    return metadata_s3_path
+
+
+def get_data_product_metadata_spec_path(version: str = None) -> str:
+    # if version is None we'll get the latest version
+    if version is None:
+        file_paths = get_filepaths_from_s3_folder(
+            os.path.join("s3://", get_bucket_name(), "data_product_metadata_spec")
+        )
+        versions = list(
+            {i for p in file_paths for i in p.split("/") if i.startswith("v")}
+        )
+        versions.sort()
+        latest_version = versions[-1]
+        spec_path = os.path.join("s3://", get_bucket_name(), "data_product_metadata_spec", latest_version, "moj_data_product_metadata_spec.json")
+    else:
+        spec_path = os.path.join("s3://", get_bucket_name(), "data_product_metadata_spec", version, "moj_data_product_metadata_spec.json")
+
+    return spec_path
+
+
+def split_bucket_and_key(path):
+    bucket, key = path.replace("s3://", "").split("/", 1)
+    return bucket, key
+
+
+class DataProductMetadata():
+    """
+    class to handle creation and updating of
+    metadata relating to a dataproduct
+    """
+    def __init__(self, data_product_name: str, logger: DataPlatformLogger):
+        self.data_product_name = data_product_name
+        self.logger = logger
+        bucket, key = split_bucket_and_key(get_data_product_metadata_path(data_product_name))
+        self.metadata_bucket = bucket
+        self.metadata_key = key
+        self._check_if_metadata_exists()
+
+
+    def _check_if_metadata_exists(self) -> bool:
+        # establish whether metadata for data product already exists
+        try:
+            # get head of object (if it exists)
+            s3_client.head_object(Bucket=self.metadata_bucket, Key=self.metadata_key)
+        except botocore.exceptions.ClientError as e:
+            if e.response['Error']['Code'] == "404":
+                self.metadata_exists = False
+            else:
+                self.logger.error(f"Uknown error - {e}")
+                raise Exception(f"Uknown error - {e}")
+        else:
+            self.logger.info("version 1 of metadata already exists for this data product")
+            self.metadata_exists = True
+
+        return self
+
+    def validate_metadata(
+        self,
+        data_product_metadata: dict,
+        metadata_schema_version: str = None,
+    ) -> bool:
+
+        metadata_schema = read_json_from_s3(get_data_product_metadata_spec_path(metadata_schema_version))
+        try:
+            validate(instance=data_product_metadata, schema=metadata_schema)
+        except ValidationError:
+            self.error_traceback = traceback.format_exc()
+            self.logger.error(f"metadata has failed validation with error: {self.error_traceback}")
+            self.valid_metadata = False
+        else:
+            self.logger.info("metadata has passed validation")
+            self.valid_metadata = True
+            self.data_product_metadata = data_product_metadata
+        return self
+
+    def write_metadata_json_to_s3(self) -> None:
+        json_metadata = json.dumps(self.data_product_metadata)
+        s3_client.put_object(
+            Body=json_metadata,
+            Bucket=self.metadata_bucket,
+            Key=self.metadata_key,
+            **{
+                "ACL": "bucket-owner-full-control",
+                "ServerSideEncryption": "AES256",
+            }
+        )
+        self.logger.info("Data Product metadata written to s3")

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -100,7 +100,7 @@ class DataProductMetadata:
 
         return self
 
-    def validate_metadata(
+    def validate(
         self,
         data_product_metadata: dict,
         metadata_schema_version: str = "",
@@ -122,7 +122,7 @@ class DataProductMetadata:
             self.data_product_metadata = data_product_metadata
         return self
 
-    def write_metadata_json_to_s3(self) -> None:
+    def write_json_to_s3(self) -> None:
         json_metadata = json.dumps(self.data_product_metadata)
         s3_client.put_object(
             Body=json_metadata,

--- a/containers/daap-python-base/src/var/task/requirements.txt
+++ b/containers/daap-python-base/src/var/task/requirements.txt
@@ -1,1 +1,13 @@
+attrs==23.1.0
 boto3==1.28.9
+botocore==1.31.39
+dataengineeringutils3==1.4.3
+jmespath==1.0.1
+jsonschema==4.19.0
+jsonschema-specifications==2023.7.1
+python-dateutil==2.8.2
+referencing==0.30.2
+rpds-py==0.10.0
+s3transfer==0.6.2
+six==1.16.0
+urllib3==1.26.16


### PR DESCRIPTION
added new lambda container image for a create data product metadata endpoint and also added a new module to the python base image. This is because the new `DataProductMetadata` class can be expanded and used by other api endpoints (that are yet to be created)