### PR TITLE
DPL-1316 Refactor shared metadata library to use shared path module

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -8,6 +8,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2023-09-08
+
+### Added
+
+- `data_platform_paths.DataProductConfig.metadata_spec_path`
+(method moved from `data_product_metadata` module)
+
+### Removed
+
+- `data_product_metadata.get_bucket_name`
+(use `data_platform_paths.get_bucket_name` instead)
+- `data_product_metadata.get_data_product_metadata_path`
+(use `data_platform_paths.get_data_product_metadata_path` instead)
+
 ## [0.5.0] - 2023-09-07
 
 ### Added

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
     "name": "daap-python-base",
-    "version": "0.5.0",
+    "version": "0.6.0",
     "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -133,9 +133,24 @@ class DataProductConfig:
         return BucketPath(bucket=bucket_name, key=key)
 
     @staticmethod
+    def metadata_spec_prefix(bucket_name: str | None = None) -> BucketPath:
+        """
+        Path to the metadata spec files
+        """
+        if bucket_name is None:
+            bucket_name = get_bucket_name()
+
+        return BucketPath(
+            bucket_name,
+            os.path.join(
+                "data_product_metadata_spec",
+            ),
+        )
+
+    @staticmethod
     def metadata_spec_path(version: str, bucket_name: str | None = None) -> BucketPath:
         """
-        Path to the metadata spec file
+        Path to a metadata spec file
         """
         if bucket_name is None:
             bucket_name = get_bucket_name()

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -132,6 +132,23 @@ class DataProductConfig:
         )
         return BucketPath(bucket=bucket_name, key=key)
 
+    @staticmethod
+    def metadata_spec_path(version: str, bucket_name: str | None = None) -> BucketPath:
+        """
+        Path to the metadata spec file
+        """
+        if bucket_name is None:
+            bucket_name = get_bucket_name()
+
+        return BucketPath(
+            bucket_name,
+            os.path.join(
+                "data_product_metadata_spec",
+                version,
+                "moj_data_product_metadata_spec.json",
+            ),
+        )
+
     def metadata_path(self):
         """
         Path to the V1 metadata file

--- a/containers/daap-python-base/tests/requirements.txt
+++ b/containers/daap-python-base/tests/requirements.txt
@@ -1,3 +1,2 @@
-boto3==1.28.40
-botocore==1.31.40
+-r ../src/var/task/requirements.txt
 pytest==7.4.1

--- a/containers/daap-python-base/tests/unit/data_platform_paths_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_paths_test.py
@@ -181,3 +181,13 @@ def test_extraction_config_parse_from_raw_uri():
     assert config.data_product_config.curated_data_prefix == BucketPath(
         "a-bucket", "curated_data/database_name=database-name/table_name=table-name/"
     )
+
+
+def test_data_product_metadata_spec_path():
+    version = "1"
+    path = DataProductConfig.metadata_spec_path(version, bucket_name="foo")
+
+    assert path == BucketPath(
+        bucket="foo",
+        key="data_product_metadata_spec/1/moj_data_product_metadata_spec.json",
+    )

--- a/containers/daap-python-base/tests/unit/data_product_metadata_test.py
+++ b/containers/daap-python-base/tests/unit/data_product_metadata_test.py
@@ -1,0 +1,33 @@
+import data_product_metadata
+
+
+def test_get_latest_metadata_spec_path(monkeypatch):
+    bucket_name = "bucket"
+    monkeypatch.setenv("BUCKET_NAME", bucket_name)
+    monkeypatch.setattr(
+        data_product_metadata,
+        "get_filepaths_from_s3_folder",
+        lambda _name: ["v1/foo/bar", "v2/foo/bar"],
+    )
+
+    path = data_product_metadata.get_data_product_metadata_spec_path()
+    assert (
+        path
+        == "s3://bucket/data_product_metadata_spec/v2/moj_data_product_metadata_spec.json"
+    )
+
+
+def test_get_specific_metadata_spec_path(monkeypatch):
+    bucket_name = "bucket"
+    monkeypatch.setenv("BUCKET_NAME", bucket_name)
+    monkeypatch.setattr(
+        data_product_metadata,
+        "get_filepaths_from_s3_folder",
+        lambda _name: ["v1/foo/bar", "v2/foo/bar"],
+    )
+
+    path = data_product_metadata.get_data_product_metadata_spec_path("v1")
+    assert (
+        path
+        == "s3://bucket/data_product_metadata_spec/v1/moj_data_product_metadata_spec.json"
+    )


### PR DESCRIPTION
This refactors the recently added metadata module to use the new path construction module in our python base image.

I've also added a method to produce the metadata spec path.

I've kept the logic for looking up the latest spec version in the metadata module, since I think the path module shouldn't make any AWS calls - it should just be concerned with our naming/path conventions.