### PR TITLE
:fire: Remove `import` blocks

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
@@ -98,11 +98,6 @@ resource "aws_iam_role" "airflow_prod_flow_log_role" {
   }
 }
 
-import {
-  to = aws_iam_role.airflow_prod_flow_log_role
-  id = "airflow-prod-flow-log-role"
-}
-
 ########################Airflow dev EKS Role###########################
 
 resource "aws_iam_role" "airflow_dev_eks_role" {

--- a/terraform/aws/analytical-platform-data-production/airflow/network.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/network.tf
@@ -184,22 +184,12 @@ resource "aws_vpc" "airflow_prod" {
   }
 }
 
-import {
-  to = aws_vpc.airflow_prod
-  id = "vpc-047b97f77da3ab143"
-}
-
 resource "aws_vpn_gateway" "airflow_prod" {
   vpc_id = aws_vpc.airflow_prod.id
 
   tags = {
     Name = "airflow-prod"
   }
-}
-
-import {
-  to = aws_vpn_gateway.airflow_prod
-  id = "vgw-099d9b2d0d3576880"
 }
 
 resource "aws_internet_gateway" "airflow_prod" {
@@ -210,11 +200,6 @@ resource "aws_internet_gateway" "airflow_prod" {
   }
 }
 
-import {
-  to = aws_internet_gateway.airflow_prod
-  id = "igw-02079c6025e743da9"
-}
-
 resource "aws_eip" "airflow_prod_eip" {
   domain     = "vpc"
   count      = length(var.azs)
@@ -222,21 +207,6 @@ resource "aws_eip" "airflow_prod_eip" {
   tags = {
     Name = "airflow-prod-${element(var.azs, count.index)}"
   }
-}
-
-import {
-  to = aws_eip.airflow_prod_eip[0]
-  id = "eipalloc-004b4c772fe008f20"
-}
-
-import {
-  to = aws_eip.airflow_prod_eip[1]
-  id = "eipalloc-0662dcc8c3021166d"
-}
-
-import {
-  to = aws_eip.airflow_prod_eip[2]
-  id = "eipalloc-06014aa6601f513cc"
 }
 
 resource "aws_subnet" "public_subnet_prod" {
@@ -250,21 +220,6 @@ resource "aws_subnet" "public_subnet_prod" {
   }
 }
 
-import {
-  to = aws_subnet.public_subnet_prod[0]
-  id = "subnet-0f54bacad347f9655"
-}
-
-import {
-  to = aws_subnet.public_subnet_prod[1]
-  id = "subnet-05bb7417f09a6e793"
-}
-
-import {
-  to = aws_subnet.public_subnet_prod[2]
-  id = "subnet-06a2a1bedf4b15c59"
-}
-
 resource "aws_subnet" "private_subnet_prod" {
   vpc_id            = aws_vpc.airflow_prod.id
   count             = length(var.prod_private_subnet_cidrs)
@@ -273,21 +228,6 @@ resource "aws_subnet" "private_subnet_prod" {
   tags = {
     Name = "airflow-prod-private-${element(var.azs, count.index)}"
   }
-}
-
-import {
-  to = aws_subnet.private_subnet_prod[0]
-  id = "subnet-03ffba4faab8b77e7"
-}
-
-import {
-  to = aws_subnet.private_subnet_prod[1]
-  id = "subnet-076487802dbb8abd5"
-}
-
-import {
-  to = aws_subnet.private_subnet_prod[2]
-  id = "subnet-026210746906f54d3"
 }
 
 resource "aws_nat_gateway" "airflow_prod" {
@@ -300,21 +240,6 @@ resource "aws_nat_gateway" "airflow_prod" {
   }
 
   depends_on = [aws_subnet.public_subnet_prod]
-}
-
-import {
-  to = aws_nat_gateway.airflow_prod[0]
-  id = "nat-025030526a14d65af"
-}
-
-import {
-  to = aws_nat_gateway.airflow_prod[1]
-  id = "nat-01ed37c242b6adb5a"
-}
-
-import {
-  to = aws_nat_gateway.airflow_prod[2]
-  id = "nat-08926bf064929356a"
 }
 
 resource "aws_route_table" "airflow_prod_public" {
@@ -330,30 +255,10 @@ resource "aws_route_table" "airflow_prod_public" {
   }
 }
 
-import {
-  to = aws_route_table.airflow_prod_public
-  id = "rtb-004834ed1981fdd94"
-}
-
 resource "aws_route_table_association" "airflow_prod_public_route_table_assoc" {
   count          = length(var.azs)
   subnet_id      = aws_subnet.public_subnet_prod[count.index].id
   route_table_id = aws_route_table.airflow_prod_public.id
-}
-
-import {
-  to = aws_route_table_association.airflow_prod_public_route_table_assoc[0]
-  id = "subnet-0f54bacad347f9655/rtb-004834ed1981fdd94"
-}
-
-import {
-  to = aws_route_table_association.airflow_prod_public_route_table_assoc[1]
-  id = "subnet-05bb7417f09a6e793/rtb-004834ed1981fdd94"
-}
-
-import {
-  to = aws_route_table_association.airflow_prod_public_route_table_assoc[2]
-  id = "subnet-06a2a1bedf4b15c59/rtb-004834ed1981fdd94"
 }
 
 resource "aws_route_table" "airflow_prod_private" {
@@ -382,40 +287,10 @@ resource "aws_route_table" "airflow_prod_private" {
   }
 }
 
-import {
-  to = aws_route_table.airflow_prod_private[0]
-  id = "rtb-0ad1ea83e40664bc1"
-}
-
-import {
-  to = aws_route_table.airflow_prod_private[1]
-  id = "rtb-045cda0b792473e86"
-}
-
-import {
-  to = aws_route_table.airflow_prod_private[2]
-  id = "rtb-06500bda1e9933d28"
-}
-
 resource "aws_route_table_association" "airflow_prod_private_route_table_assoc" {
   count          = length(var.azs)
   subnet_id      = aws_subnet.private_subnet_prod[count.index].id
   route_table_id = aws_route_table.airflow_prod_private[count.index].id
-}
-
-import {
-  to = aws_route_table_association.airflow_prod_private_route_table_assoc[0]
-  id = "subnet-03ffba4faab8b77e7/rtb-0ad1ea83e40664bc1"
-}
-
-import {
-  to = aws_route_table_association.airflow_prod_private_route_table_assoc[1]
-  id = "subnet-076487802dbb8abd5/rtb-045cda0b792473e86"
-}
-
-import {
-  to = aws_route_table_association.airflow_prod_private_route_table_assoc[2]
-  id = "subnet-026210746906f54d3/rtb-06500bda1e9933d28"
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "airflow_prod_cloud_platform" {
@@ -425,11 +300,6 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "airflow_prod_cloud_platform" 
   tags = {
     Name = "airflow-cloud-platform"
   }
-}
-
-import {
-  to = aws_ec2_transit_gateway_vpc_attachment.airflow_prod_cloud_platform
-  id = "tgw-attach-0b2c29f4fcb9de1a4"
 }
 
 resource "aws_ec2_transit_gateway_vpc_attachment" "airflow_prod_moj" {
@@ -442,20 +312,10 @@ resource "aws_ec2_transit_gateway_vpc_attachment" "airflow_prod_moj" {
   }
 }
 
-import {
-  to = aws_ec2_transit_gateway_vpc_attachment.airflow_prod_moj
-  id = "tgw-attach-0a95490e9dca306be"
-}
-
 resource "aws_cloudwatch_log_group" "airflow_prod_vpc_flow_log" {
   name              = "airflow-prod-vpc-flow-log"
   retention_in_days = 400
   skip_destroy      = true
-}
-
-import {
-  to = aws_cloudwatch_log_group.airflow_prod_vpc_flow_log
-  id = "airflow-prod-vpc-flow-log"
 }
 
 resource "aws_flow_log" "airflow_prod" {
@@ -467,11 +327,6 @@ resource "aws_flow_log" "airflow_prod" {
   tags = {
     Name = "airflow-prod"
   }
-}
-
-import {
-  to = aws_flow_log.airflow_prod
-  id = "fl-06f1a246ed4ecb51d"
 }
 
 resource "aws_security_group" "airflow_prod_security_group" {
@@ -493,9 +348,4 @@ resource "aws_security_group" "airflow_prod_security_group" {
     from_port   = 0
     to_port     = 0
   }
-}
-
-import {
-  to = aws_security_group.airflow_prod_security_group
-  id = "sg-0d278497bb1ee3617"
 }


### PR DESCRIPTION
This PR removes the import blocks which were used a previous [PR](https://github.com/ministryofjustice/data-platform/pull/1400). 