### PR TITLE
♻️  Refactor `additional` security groups

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/network.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/network.tf
@@ -150,27 +150,6 @@ resource "aws_flow_log" "airflow_dev" {
   }
 }
 
-# Additional Security Group (Define as additional security group in AWS)
-resource "aws_security_group" "airflow_dev_security_group" {
-  name        = var.dev_cluster_sg_name
-  description = "Managed by Pulumi"
-  vpc_id      = aws_vpc.airflow_dev.id
-  ingress {
-    description     = "Allow pods to communicate with the cluster API Server"
-    protocol        = "tcp"
-    from_port       = 443
-    to_port         = 443
-    security_groups = [var.dev_node_sg_id]
-  }
-  egress {
-    description = "Allow internet access."
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 0
-    to_port     = 0
-  }
-}
-
 #      _     _         __  _                   ____                   _               _    _
 #     / \   (_) _ __  / _|| |  ___ __      __ |  _ \  _ __  ___    __| | _   _   ___ | |_ (_)  ___   _ __
 #    / _ \  | || '__|| |_ | | / _ \\ \ /\ / / | |_) || '__|/ _ \  / _` || | | | / __|| __|| | / _ \ | '_ \
@@ -327,27 +306,5 @@ resource "aws_flow_log" "airflow_prod" {
 
   tags = {
     Name = "airflow-prod"
-  }
-}
-
-# Additional Security Group (Define as additional security group in AWS)
-resource "aws_security_group" "airflow_prod_security_group" {
-  name        = var.prod_vpc_sg_name
-  description = "Managed by Pulumi"
-  vpc_id      = aws_vpc.airflow_prod.id
-  ingress {
-    description     = ""
-    protocol        = "-1"
-    from_port       = 0
-    to_port         = 0
-    security_groups = []
-    self            = true
-  }
-  egress {
-    description = ""
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    from_port   = 0
-    to_port     = 0
   }
 }

--- a/terraform/aws/analytical-platform-data-production/airflow/network.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/network.tf
@@ -150,6 +150,7 @@ resource "aws_flow_log" "airflow_dev" {
   }
 }
 
+# Additional Security Group (Define as additional security group in AWS)
 resource "aws_security_group" "airflow_dev_security_group" {
   name        = var.dev_cluster_sg_name
   description = "Managed by Pulumi"
@@ -329,6 +330,7 @@ resource "aws_flow_log" "airflow_prod" {
   }
 }
 
+# Additional Security Group (Define as additional security group in AWS)
 resource "aws_security_group" "airflow_prod_security_group" {
   name        = var.prod_vpc_sg_name
   description = "Managed by Pulumi"

--- a/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars
@@ -47,10 +47,16 @@ prod_vpc_sg_name = "airflow-prod"
 # EKS Cluster
 ##################################################
 
-dev_eks_role_arn    = "arn:aws:iam::593291632749:role/airflow-dev-eksRole-role-211908c"
-dev_cluster_sg_name = "airflow-dev-eksClusterSecurityGroup-6a4dde4"
-dev_node_sg_id      = "sg-01930457ae391c7f0"
+dev_eks_cluster_name           = "airflow-dev"
+dev_eks_role_arn               = "arn:aws:iam::593291632749:role/airflow-dev-eksRole-role-211908c"
+dev_cluster_additional_sg_name = "airflow-dev-eksClusterSecurityGroup-6a4dde4"
+dev_cluster_additional_sg_id   = "sg-0bcd3cf5dc6d7b314"
+dev_node_sg_id                 = "sg-01930457ae391c7f0"
 
-prod_eks_role_arn    = "arn:aws:iam::593291632749:role/airflow-prod-eksRole-role-de6b4f5"
-prod_cluster_sg_name = "airflow-prod-eksClusterSecurityGroup-6ab84a6"
-prod_node_sg_id      = "sg-0f73e78564012634a"
+################################################
+
+prod_eks_cluster_name           = "airflow-prod"
+prod_eks_role_arn               = "arn:aws:iam::593291632749:role/airflow-prod-eksRole-role-de6b4f5"
+prod_cluster_additional_sg_id   = "sg-0f73e78564012634a"
+prod_cluster_additional_sg_name = "airflow-prod-eksClusterSecurityGroup-6ab84a6"
+prod_node_sg_id                 = "sg-03ac19a2f24af23ad"

--- a/terraform/aws/analytical-platform-data-production/airflow/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/variables.tf
@@ -55,9 +55,19 @@ variable "dev_eks_role_arn" {
   description = "ARN of role used by EKS cluster for Airflow-Dev"
 }
 
-variable "dev_cluster_sg_name" {
+variable "dev_eks_cluster_name" {
   type        = string
-  description = "Name of cluster security group for Airflow-Dev"
+  description = "Name of cluster for Airflow-Dev"
+}
+
+variable "dev_cluster_additional_sg_id" {
+  type        = string
+  description = "Name of cluster additional security group for Airflow-Dev"
+}
+
+variable "dev_cluster_additional_sg_name" {
+  type        = string
+  description = "Name of cluster additional security group for Airflow-Dev"
 }
 
 variable "dev_node_sg_id" {
@@ -89,9 +99,19 @@ variable "prod_eks_role_arn" {
   description = "ARN of role used by EKS cluster for Airflow-Prod"
 }
 
-variable "prod_cluster_sg_name" {
+variable "prod_eks_cluster_name" {
   type        = string
-  description = "Name of cluster security group for Airflow-Prod"
+  description = "Name of cluster for Airflow-Prod"
+}
+
+variable "prod_cluster_additional_sg_id" {
+  type        = string
+  description = "Name of cluster additional security group for Airflow-Prod"
+}
+
+variable "prod_cluster_additional_sg_name" {
+  type        = string
+  description = "Name of cluster additional security group for Airflow-Prod"
 }
 
 variable "prod_node_sg_id" {


### PR DESCRIPTION
This PR uses the term `additional` when describing security groups. This is because the Cluster Security Group - as defined in the AWS console, is implicitly created when an EKS cluster is spun up. This security group is not explicitly managed in Pulumi, that is to say, it is managed, but as part of the creation of the EKS cluster. That is the approach we are also taking going forward in Terraform. 

More detail is [here](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html) but the key point is: _"When you create a cluster, Amazon EKS creates a security group that's named` eks-cluster-sg-my-cluster-uniqueID`. This security group has the following default rules..."_ This is the security group which will be implicitly created by Terraform when the EKS cluster is created. 

Another PR will follow this which will remove the `moved` and `import` blocks. 