### PR TITLE
Change data_platform_paths module to separate data products from data product elements, and allow multiple buckets

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -1,4 +1,5 @@
 <!-- markdownlint-disable MD003 -->
+
 # Changelog
 
 All notable changes to this project will be documented in this file.
@@ -8,12 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-09-15
+
+Many changes to `data_platform_paths` to separate out the concept of
+"data product element" from "data product", and to account for data being
+stored in different S3 buckets.
+
+### Added
+
+- `DataProductElement` class added to represent the many elements belonging to
+  a data product that produce the resulting tables
+- `get_raw_data_bucket()`, `get_curated_data_bucket()`,
+  `get_metadata_bucket` and `get_log_bucket` functions
+
+### Changed
+
+- Renamed `ExtractionConfig` to `RawDataExtraction`. This now has an `element` attribute
+  instead of `data_product_config`.
+
+### Removed
+
+- `DataProductConfig` no longer takes a `table_name` argument. Instead, call
+  `data_product_config.model(name)` or `DataProductModel.load` to get a
+  `DataProductModel` instance.
+- `raw_data_prefix`, `curated_data_prefix` and `curated_data_table` on
+  `DataProductConfig` now exclude the table name part. Use `DataProductElement`
+  to get the prefix including table name.
+- `raw_data_table` is now a method of `DataProductModel`, and returns a unique
+  name each call.
+- `get_bucket_name()` function is replaced by `get_raw_data_bucket()`,
+  `get_curated_data_bucket()`, `get_metadata_bucket` and `get_log_bucket`.
+- `DataProductConfig` `bucket_name` attribute is replaced by `raw_data_bucket`
+  and `curated_data_bucket`, and `metadata_bucket`.
+- `bucket_name` is no longer a supported parameter of the
+  `data_product_raw_data_file_path`, `data_product_curated_data_prefix`,
+  `data_product_metadata_file_path` and `data_product_log_bucket_and_key`
+  helper functions (this was only used in unit tests).
+
 ## [1.0.2] - 2023-09-15
 
 ### Changed
 
 - `get_data_product_metadata_spec_path` to better handle sorting of semantic
-versioning.
+  versioning.
 
 ## [1.0.1] - 2023-09-13
 
@@ -26,46 +64,46 @@ versioning.
 ### Added
 
 - `data_platform_paths.DataProductConfig._log_file_path`
-(method moved from `data_platform_logging` module)
+  (method moved from `data_platform_logging` module)
 
 ### Changed
 
 - `data_platform_logging.DataPlatformLogger.write_log_dict_to_s3_json` to
-`_write_log_dict_to_s3_json`, with the method now writing to an s3 json file
-on every log call
+  `_write_log_dict_to_s3_json`, with the method now writing to an s3 json file
+  on every log call
 - `data_platform_logging.DataPlatformLogger` gets log file path from
-`data_platform_paths`
+  `data_platform_paths`
 - `data_platform_logging` now includes `security_opts` dict, the extra arguments
-to satisfy bucket security config in the data platform
+  to satisfy bucket security config in the data platform
 
 ## [0.6.0] - 2023-09-08
 
 ### Added
 
 - `data_platform_paths.DataProductConfig.metadata_spec_path`
-(method moved from `data_product_metadata` module)
+  (method moved from `data_product_metadata` module)
 
 ### Removed
 
 - `data_product_metadata.get_bucket_name`
-(use `data_platform_paths.get_bucket_name` instead)
+  (use `data_platform_paths.get_bucket_name` instead)
 - `data_product_metadata.get_data_product_metadata_path`
-(use `data_platform_paths.get_data_product_metadata_path` instead)
+  (use `data_platform_paths.get_data_product_metadata_path` instead)
 
 ## [0.5.0] - 2023-09-07
 
 ### Added
 
 - data_platform_paths module. This contains code for generating paths to files
-in S3 and names of tables in Athena.
+  in S3 and names of tables in Athena.
 
 ## [0.4.0] - 2023-09-01
 
 ### Added
 
 - data_product_metadata python module. This contains code that will be used,
-intially by an API endpoint to create data product metadata, but in future,
-expanded to be usedin other endpoints too, such as an update_metadata endpoint.
+  intially by an API endpoint to create data product metadata, but in future,
+  expanded to be usedin other endpoints too, such as an update_metadata endpoint.
 
 ## [0.3.0] - 2023-08-11
 

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -41,10 +41,10 @@ stored in different S3 buckets.
   `get_curated_data_bucket()`, `get_metadata_bucket` and `get_log_bucket`.
 - `DataProductConfig` `bucket_name` attribute is replaced by `raw_data_bucket`
   and `curated_data_bucket`, and `metadata_bucket`.
-- `bucket_name` is no longer a supported parameter of the
+- Removed
   `data_product_raw_data_file_path`, `data_product_curated_data_prefix`,
   `data_product_metadata_file_path` and `data_product_log_bucket_and_key`
-  helper functions (this was only used in unit tests).
+  (use `DataProductConfig` and `DataProductElement` classes instead).
 
 ## [1.0.2] - 2023-09-15
 

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
     "name": "daap-python-base",
-    "version": "1.0.2",
+    "version": "2.0.0",
     "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -112,7 +112,7 @@ def get_account_id() -> str:
 @dataclass
 class DataProductElement:
     """
-    A dataset within the data product. The curated data for each element
+    An entity within the data product. The curated data for each element
     is queryable in its own athena table.
     """
 

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -120,9 +120,9 @@ class DataProductElement:
     data_product: DataProductConfig
 
     @staticmethod
-    def load(name, data_product_name):
+    def load(element_name, data_product_name):
         data_product = DataProductConfig(name=data_product_name)
-        return DataProductElement(data_product=data_product, name=name)
+        return DataProductElement(data_product=data_product, name=element_name)
 
     @property
     def raw_data_prefix(self):
@@ -142,8 +142,8 @@ class DataProductElement:
         e.g. curated_data/database_name=my-data-product/table_name=some-element/
         """
         return BucketPath(
-            self.data_product.curated_data_bucket,
-            os.path.join(
+            bucket=self.data_product.curated_data_bucket,
+            key=os.path.join(
                 "curated_data",
                 f"database_name={self.data_product.name}",
                 f"table_name={self.name}",
@@ -178,13 +178,13 @@ class DataProductElement:
         E.g. raw_data/my-data-product/some-element/extraction_timestamp=
              20230101T000000Z/3d95ff89-b063-484d-b510-53742d0a6a64
         """
-        return self.extraction_config(timestamp, uuid_value).path
+        return self.extraction_instance(timestamp, uuid_value).path
 
-    def extraction_config(
+    def extraction_instance(
         self, timestamp: datetime, uuid_value: UUID
     ) -> RawDataExtraction:
         """
-        Config for the data extraction identified by uuid_value and timestamp.
+        Instance of the data extraction identified by uuid_value and timestamp.
         """
         amz_date = timestamp.strftime(EXTRACTION_TIMESTAMP_FORMAT)
 
@@ -203,7 +203,7 @@ class DataProductElement:
 @dataclass
 class DataProductConfig:
     """
-    Configures the name, and S3 buckets for a data product.
+    Configures the name, elements, S3 buckets, and related paths for a data product.
 
     A data product may contain many `data product elements`. To construct
     paths for each one, call `.element()` with the name of the element.

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -4,7 +4,7 @@ import traceback
 import boto3
 import botocore
 from data_platform_logging import DataPlatformLogger
-from data_platform_paths import DataProductConfig, data_product_metadata_file_path
+from data_platform_paths import DataProductConfig
 from dataengineeringutils3.s3 import get_filepaths_from_s3_folder, read_json_from_s3
 from jsonschema import validate
 from jsonschema.exceptions import ValidationError
@@ -46,7 +46,7 @@ class DataProductMetadata:
         self.data_product_name = data_product_name
         self.logger = logger
         bucket, key = split_bucket_and_key(
-            data_product_metadata_file_path(data_product_name)
+            DataProductConfig(data_product_name).metadata_path().uri
         )
         self.metadata_bucket = bucket
         self.metadata_key = key

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -46,7 +46,7 @@ class DataProductMetadata:
         self.data_product_name = data_product_name
         self.logger = logger
         bucket, key = split_bucket_and_key(
-            DataProductConfig(data_product_name).metadata_path().uri
+            DataProductConfig(name=data_product_name).metadata_path().uri
         )
         self.metadata_bucket = bucket
         self.metadata_key = key

--- a/containers/daap-python-base/tests/unit/data_platform_paths_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_paths_test.py
@@ -7,10 +7,7 @@ from data_platform_paths import (
     DataProductConfig,
     DataProductElement,
     RawDataExtraction,
-    data_product_curated_data_prefix,
     data_product_log_bucket_and_key,
-    data_product_metadata_file_path,
-    data_product_raw_data_file_path,
     get_curated_data_bucket,
     get_landing_zone_bucket,
     get_log_bucket,
@@ -72,51 +69,6 @@ def test_metdata_bucket(monkeypatch):
 def test_raw_data_bucket_defaults_to_old_environment_variable(monkeypatch):
     monkeypatch.setenv("BUCKET_NAME", "a-bucket")
     assert get_raw_data_bucket() == "a-bucket"
-
-
-def test_data_product_metadata_file_path(monkeypatch):
-    monkeypatch.setenv("RAW_DATA_BUCKET", "bucket1")
-    monkeypatch.setenv("CURATED_DATA_BUCKET", "bucket2")
-    monkeypatch.setenv("METADATA_BUCKET", "bucket3")
-    monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket4")
-
-    metadata_path = data_product_metadata_file_path("delicious-data-product")
-
-    assert (
-        metadata_path
-        == "s3://bucket3/metadata/delicious-data-product/v1.0/metadata.json"
-    )
-
-
-def test_data_product_raw_data_file_path(monkeypatch):
-    monkeypatch.setenv("RAW_DATA_BUCKET", "bucket1")
-    monkeypatch.setenv("CURATED_DATA_BUCKET", "bucket2")
-    monkeypatch.setenv("METADATA_BUCKET", "bucket3")
-    monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket4")
-
-    uuid_value = uuid.uuid4()
-    timestamp = datetime(2023, 9, 6)
-    path = data_product_raw_data_file_path(
-        data_product_name="data-product",
-        table_name="table",
-        extraction_timestamp=timestamp,
-        uuid_value=uuid_value,
-    )
-
-    assert (
-        path
-        == f"s3://bucket1/raw_data/data-product/table/extraction_timestamp=20230906T000000Z/{uuid_value}"
-    )
-
-
-def test_get_data_product_curated_data_prefix(monkeypatch):
-    monkeypatch.setenv("RAW_DATA_BUCKET", "bucket")
-    monkeypatch.setenv("CURATED_DATA_BUCKET", "bucket")
-    monkeypatch.setenv("METADATA_BUCKET", "bucket")
-    monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket")
-
-    uri = data_product_curated_data_prefix(data_product_name="foo", table_name="table")
-    assert uri == "s3://bucket/curated_data/database_name=foo/table_name=table/"
 
 
 def test_data_product_config_metadata_spec_prefix():

--- a/containers/daap-python-base/tests/unit/data_platform_paths_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_paths_test.py
@@ -188,7 +188,7 @@ def test_extraction_config():
 
     element = config.element("some-table")
 
-    extraction = element.extraction_config(uuid_value=uuid_value, timestamp=timestamp)
+    extraction = element.extraction_instance(uuid_value=uuid_value, timestamp=timestamp)
 
     assert extraction.timestamp == timestamp
     assert extraction.path == BucketPath(

--- a/containers/daap-python-base/tests/unit/data_platform_paths_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_paths_test.py
@@ -1,16 +1,21 @@
+import re
 import uuid
 from datetime import datetime
 
 from data_platform_paths import (
     BucketPath,
     DataProductConfig,
-    ExtractionConfig,
-    QueryTable,
+    DataProductElement,
+    RawDataExtraction,
     data_product_curated_data_prefix,
     data_product_log_bucket_and_key,
     data_product_metadata_file_path,
     data_product_raw_data_file_path,
-    get_bucket_name,
+    get_curated_data_bucket,
+    get_landing_zone_bucket,
+    get_log_bucket,
+    get_metadata_bucket,
+    get_raw_data_bucket,
 )
 from freezegun import freeze_time
 
@@ -39,79 +44,160 @@ def test_bucket_path_parent():
     assert path.parent.key == "path/to"
 
 
-def test_bucket_name_returns_environment_variable(monkeypatch):
+def test_raw_data_bucket(monkeypatch):
+    monkeypatch.setenv("RAW_DATA_BUCKET", "a-bucket")
+    assert get_raw_data_bucket() == "a-bucket"
+
+
+def test_curated_data_bucket(monkeypatch):
+    monkeypatch.setenv("CURATED_DATA_BUCKET", "a-bucket")
+    assert get_curated_data_bucket() == "a-bucket"
+
+
+def test_landing_zone_bucket(monkeypatch):
+    monkeypatch.setenv("LANDING_ZONE_BUCKET", "a-bucket")
+    assert get_landing_zone_bucket() == "a-bucket"
+
+
+def test_log_bucket(monkeypatch):
+    monkeypatch.setenv("LOG_BUCKET", "a-bucket")
+    assert get_log_bucket() == "a-bucket"
+
+
+def test_metdata_bucket(monkeypatch):
+    monkeypatch.setenv("METADATA_BUCKET", "a-bucket")
+    assert get_metadata_bucket() == "a-bucket"
+
+
+def test_raw_data_bucket_defaults_to_old_environment_variable(monkeypatch):
     monkeypatch.setenv("BUCKET_NAME", "a-bucket")
-    assert get_bucket_name() == "a-bucket"
+    assert get_raw_data_bucket() == "a-bucket"
 
 
 def test_data_product_metadata_file_path(monkeypatch):
-    monkeypatch.setenv("BUCKET_NAME", "a-bucket")
+    monkeypatch.setenv("RAW_DATA_BUCKET", "bucket1")
+    monkeypatch.setenv("CURATED_DATA_BUCKET", "bucket2")
+    monkeypatch.setenv("METADATA_BUCKET", "bucket3")
+    monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket4")
+
     metadata_path = data_product_metadata_file_path("delicious-data-product")
 
     assert (
         metadata_path
-        == "s3://a-bucket/metadata/delicious-data-product/v1.0/metadata.json"
+        == "s3://bucket3/metadata/delicious-data-product/v1.0/metadata.json"
     )
 
 
-def test_data_product_raw_data_file_path():
+def test_data_product_raw_data_file_path(monkeypatch):
+    monkeypatch.setenv("RAW_DATA_BUCKET", "bucket1")
+    monkeypatch.setenv("CURATED_DATA_BUCKET", "bucket2")
+    monkeypatch.setenv("METADATA_BUCKET", "bucket3")
+    monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket4")
+
     uuid_value = uuid.uuid4()
     timestamp = datetime(2023, 9, 6)
     path = data_product_raw_data_file_path(
         data_product_name="data-product",
         table_name="table",
-        bucket_name="bucket",
         extraction_timestamp=timestamp,
         uuid_value=uuid_value,
     )
 
     assert (
         path
-        == f"s3://bucket/raw_data/data-product/table/extraction_timestamp=20230906T000000Z/{uuid_value}"
+        == f"s3://bucket1/raw_data/data-product/table/extraction_timestamp=20230906T000000Z/{uuid_value}"
     )
 
 
-def test_get_data_product_curated_data_prefix():
-    uri = data_product_curated_data_prefix(
-        data_product_name="foo", table_name="table", bucket_name="bucket"
-    )
+def test_get_data_product_curated_data_prefix(monkeypatch):
+    monkeypatch.setenv("RAW_DATA_BUCKET", "bucket")
+    monkeypatch.setenv("CURATED_DATA_BUCKET", "bucket")
+    monkeypatch.setenv("METADATA_BUCKET", "bucket")
+    monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket")
+
+    uri = data_product_curated_data_prefix(data_product_name="foo", table_name="table")
     assert uri == "s3://bucket/curated_data/database_name=foo/table_name=table/"
 
 
-def test_data_product_config():
+def test_data_product_config_metadata_spec_prefix():
+    assert DataProductConfig.metadata_spec_prefix("bucket") == BucketPath(
+        bucket="bucket", key="data_product_metadata_spec"
+    )
+
+
+def test_data_product_element_config(monkeypatch):
+    monkeypatch.setenv("RAW_DATA_BUCKET", "bucket")
+    monkeypatch.setenv("CURATED_DATA_BUCKET", "bucket")
+    monkeypatch.setenv("METADATA_BUCKET", "bucket")
+    monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket")
+
+    element = DataProductElement.load("some-table", "data-product")
+
+    raw_data_table = element.raw_data_table_unique()
+
+    assert re.match(
+        r"some-table_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_raw",
+        raw_data_table.name,
+    )
+    assert raw_data_table.database == "data_products_raw"
+    assert element.curated_data_table.name == "some-table"
+    assert element.curated_data_table.database == "data-product"
+
+    assert element.raw_data_prefix == BucketPath(
+        bucket="bucket",
+        key="raw_data/data-product/some-table/",
+    )
+
+    assert element.curated_data_prefix == BucketPath(
+        bucket="bucket",
+        key="curated_data/database_name=data-product/table_name=some-table/",
+    )
+
+
+def test_data_product_config_path_prefixes():
     config = DataProductConfig(
         name="my-database",
-        table_name="some-table",
-        bucket_name="a-bucket",
+        raw_data_bucket="raw-bucket",
+        curated_data_bucket="curated-bucket",
+        metadata_bucket="a-bucket",
+        landing_zone_bucket="a-bucket",
     )
-
-    assert config.raw_data_table.name == "some-table_raw"
-    assert config.raw_data_table.database == "data_products_raw"
-    assert config.curated_data_table.name == "some-table"
-    assert config.curated_data_table.database == "my-database"
 
     assert config.raw_data_prefix == BucketPath(
-        bucket="a-bucket",
-        key="raw_data/my-database/some-table/",
+        bucket="raw-bucket", key="raw_data/my-database/"
     )
-
     assert config.curated_data_prefix == BucketPath(
-        bucket="a-bucket",
-        key="curated_data/database_name=my-database/table_name=some-table/",
+        bucket="curated-bucket", key="curated_data/database_name=my-database/"
     )
 
 
-def test_data_product_config_raw_data_path():
+def test_data_product_config_get_element():
+    config = DataProductConfig(
+        name="my-database",
+        raw_data_bucket="a-bucket",
+        curated_data_bucket="a-bucket",
+        metadata_bucket="a-bucket",
+        landing_zone_bucket="a-bucket",
+    )
+
+    element = config.element("some-table")
+    assert element.name == "some-table"
+
+
+def test_data_product_element_raw_data_path():
     uuid_value = uuid.uuid4()
     timestamp = datetime(2023, 9, 5, 16, 53)
 
     config = DataProductConfig(
         name="my-database",
-        table_name="some-table",
-        bucket_name="a-bucket",
+        raw_data_bucket="a-bucket",
+        curated_data_bucket="a-bucket",
+        metadata_bucket="a-bucket",
+        landing_zone_bucket="a-bucket",
     )
+    element = config.element("some-table")
 
-    path = config.raw_data_path(timestamp=timestamp, uuid_value=uuid_value)
+    path = element.raw_data_path(timestamp=timestamp, uuid_value=uuid_value)
 
     assert path == BucketPath(
         bucket="a-bucket",
@@ -122,8 +208,10 @@ def test_data_product_config_raw_data_path():
 def test_data_product_config_metadata_path():
     config = DataProductConfig(
         name="my-database",
-        table_name="some-table",
-        bucket_name="a-bucket",
+        curated_data_bucket="a-bucket",
+        raw_data_bucket="a-bucket",
+        landing_zone_bucket="a-bucket",
+        metadata_bucket="a-bucket",
     )
 
     path = config.metadata_path()
@@ -140,11 +228,15 @@ def test_extraction_config():
 
     config = DataProductConfig(
         name="my-database",
-        table_name="some-table",
-        bucket_name="a-bucket",
+        raw_data_bucket="a-bucket",
+        curated_data_bucket="a-bucket",
+        landing_zone_bucket="a-bucket",
+        metadata_bucket="a-bucket",
     )
 
-    extraction = config.extraction_config(uuid_value=uuid_value, timestamp=timestamp)
+    element = config.element("some-table")
+
+    extraction = element.extraction_config(uuid_value=uuid_value, timestamp=timestamp)
 
     assert extraction.timestamp == timestamp
     assert extraction.path == BucketPath(
@@ -153,35 +245,32 @@ def test_extraction_config():
     )
 
 
-def test_extraction_config_parse_from_raw_uri():
+def test_extraction_config_parse_from_raw_uri(monkeypatch):
+    monkeypatch.setenv("CURATED_DATA_BUCKET", "bucket2")
+    monkeypatch.setenv("METADATA_BUCKET", "bucket3")
+    monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket4")
+
     raw_data_uri = (
-        "s3://a-bucket/raw_data/database-name/table-name/extraction_timestamp=20230905T162700Z/"
+        "s3://bucket1/raw_data/database-name/table-name/extraction_timestamp=20230905T162700Z/"
         + "7cf8e644-06af-47ce-8f5f-b53c22a35f2e"
     )
 
-    config = ExtractionConfig.parse_from_uri(raw_data_uri)
+    config = RawDataExtraction.parse_from_uri(raw_data_uri)
 
     assert config.path == BucketPath(
-        bucket="a-bucket",
+        bucket="bucket1",
         key=(
             "raw_data/database-name/table-name/extraction_timestamp=20230905T162700Z/"
             + "7cf8e644-06af-47ce-8f5f-b53c22a35f2e"
         ),
     )
     assert config.timestamp == datetime(2023, 9, 5, 16, 27)
-
-    assert config.data_product_config.name == "database-name"
-    assert config.data_product_config.curated_data_table == QueryTable(
-        "database-name", "table-name"
-    )
-    assert config.data_product_config.raw_data_table == QueryTable(
-        "data_products_raw", "table-name_raw"
-    )
-    assert config.data_product_config.raw_data_prefix == BucketPath(
-        "a-bucket", "raw_data/database-name/table-name/"
-    )
-    assert config.data_product_config.curated_data_prefix == BucketPath(
-        "a-bucket", "curated_data/database_name=database-name/table_name=table-name/"
+    assert config.element.data_product == DataProductConfig(
+        name="database-name",
+        raw_data_bucket="bucket1",
+        curated_data_bucket="bucket2",
+        metadata_bucket="bucket3",
+        landing_zone_bucket="bucket4",
     )
 
 


### PR DESCRIPTION
This is a breaking change to the data_platform_paths module in the python base image.

1. Separate out the different buckets, and make them all attributes of  `DataProductConfig`. By default, these will be read from environment variables,  falling back to the `BUCKET_NAME` environment variable for backwards compatibility while we switch over. Note that all buckets must be provided in order to instantiate DataProductConfig objects, so we should set all the environment variables on all the lambdas.

2. Extract `DataProductElement` from `DataProductConfig`, so that a data product can have many elements, each with their own raw/curated tables and paths. This is needed to extract path logic from the `reload_data_product` lambda.

3. Add a random suffix to raw table names, as suggested in https://app.zenhub.com/workspaces/data-platform-labs-6439239ff652d87aef65297a/issues/gh/ministryofjustice/data-platform/1310