### PR TITLE
Bump base version for Presigned URL lambda

### DIFF
--- a/containers/daap-presigned-url/CHANGELOG.md
+++ b/containers/daap-presigned-url/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3]
+
+### Changed
+
+- Use new version of base image paths module
+
 ## [1.2.2] 2023-09-15
 
 ### Changed

--- a/containers/daap-presigned-url/Dockerfile
+++ b/containers/daap-presigned-url/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:1.0.2
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:2.0.0
 
 ARG VERSION
 

--- a/containers/daap-presigned-url/config.json
+++ b/containers/daap-presigned-url/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-presigned-url",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-presigned-url/src/var/task/presigned_url.py
+++ b/containers/daap-presigned-url/src/var/task/presigned_url.py
@@ -5,7 +5,7 @@ from datetime import datetime
 
 import boto3
 from data_platform_logging import DataPlatformLogger
-from data_platform_paths import DataProductConfig
+from data_platform_paths import DataProductElement
 
 s3 = boto3.client("s3")
 
@@ -18,10 +18,10 @@ logger = DataPlatformLogger(
 
 
 def handler(event, context):
-    bucket_name = os.environ["BUCKET_NAME"]
     database = event["queryStringParameters"]["database"]
     table = event["queryStringParameters"]["table"]
     amz_date = datetime.utcnow()
+    formatted_date = amz_date.strftime("%Y%m%dT%H%M%SZ")
     md5 = str(event["queryStringParameters"]["contentMD5"])
     uuid_value = uuid.uuid4()
 
@@ -39,17 +39,14 @@ def handler(event, context):
             ),
         }
 
-    data_product = DataProductConfig(
-        name=database, table_name=table, bucket_name=bucket_name
-    )
-    file_name = data_product.raw_data_path(
-        timestamp=amz_date, uuid_value=uuid_value
-    ).key
+    model = DataProductElement.load(data_product_name=database, element_name=table)
+    data_product = model.data_product
+    raw_data_path = model.raw_data_path(timestamp=amz_date, uuid_value=uuid_value)
 
     fields = {
         "x-amz-server-side-encryption": "AES256",
         "x-amz-acl": "bucket-owner-full-control",
-        "x-amz-date": amz_date,
+        "x-amz-date": formatted_date,
         "Content-MD5": md5,
         "Content-Type": "binary/octet-stream",
     }
@@ -58,11 +55,11 @@ def handler(event, context):
     conditions = [
         {"x-amz-server-side-encryption": "AES256"},
         {"x-amz-acl": "bucket-owner-full-control"},
-        {"x-amz-date": amz_date.strftime("%Y%m%dT%H%M%SZ")},
+        {"x-amz-date": formatted_date},
         {"Content-MD5": md5},
         ["starts-with", "$Content-MD5", ""],
         ["starts-with", "$Content-Type", ""],
-        ["starts-with", "$key", file_name],
+        ["starts-with", "$key", raw_data_path.key],
         ["content-length-range", 0, 5000000000],
     ]
 
@@ -74,8 +71,7 @@ def handler(event, context):
         }
     )
 
-    logger.info(f"s3 bucket: {bucket_name}")
-    logger.info(f"s3 key: {file_name}")
+    logger.info(f"s3 path: {raw_data_path}")
     logger.info(f"database: {database}")
     logger.info(f"table: {table}")
     logger.info(f"amz_date: {amz_date}")
@@ -103,16 +99,15 @@ def handler(event, context):
             ),
         }
 
-    if any(data_product_registration):
-        URL = s3.generate_presigned_post(
-            Bucket=bucket_name,
-            Key=file_name,
-            Fields=fields,
-            Conditions=conditions,
-            ExpiresIn=200,
-        )
-        return {
-            "statusCode": 200,
-            "headers": {"Content-Type": "application/json"},
-            "body": json.dumps({"URL": URL}, default=str),
-        }
+    URL = s3.generate_presigned_post(
+        Bucket=raw_data_path.bucket,
+        Key=raw_data_path.key,
+        Fields=fields,
+        Conditions=conditions,
+        ExpiresIn=200,
+    )
+    return {
+        "statusCode": 200,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"URL": URL}),
+    }

--- a/containers/daap-presigned-url/src/var/task/presigned_url.py
+++ b/containers/daap-presigned-url/src/var/task/presigned_url.py
@@ -39,9 +39,9 @@ def handler(event, context):
             ),
         }
 
-    model = DataProductElement.load(data_product_name=database, element_name=table)
-    data_product = model.data_product
-    raw_data_path = model.raw_data_path(timestamp=amz_date, uuid_value=uuid_value)
+    element = DataProductElement.load(data_product_name=database, element_name=table)
+    data_product = element.data_product
+    raw_data_path = element.raw_data_path(timestamp=amz_date, uuid_value=uuid_value)
 
     fields = {
         "x-amz-server-side-encryption": "AES256",


### PR DESCRIPTION
Update the base image to pick up the latest change to data_platform_paths.

The main change is to use the `DataProductElement` object for anything that requires a `table_name` instead of a `DataProductConfig` (which should be for configuration common to the whole data product`.