### PR TITLE
DPL-1316 update reload data product lambda

### DIFF
--- a/containers/daap-reload-data-product/CHANGELOG.md
+++ b/containers/daap-reload-data-product/CHANGELOG.md
@@ -9,9 +9,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.4]
+
+### Changed
+
+- Update to latest base image
+- Use shared library for S3 paths
+
 ## [1.0.3]
 
-## Changed
+### Changed
 
 - Update to latest base image
 - Add unit tests

--- a/containers/daap-reload-data-product/Dockerfile
+++ b/containers/daap-reload-data-product/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:1.0.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:2.0.0
 
 ARG VERSION
 

--- a/containers/daap-reload-data-product/config.json
+++ b/containers/daap-reload-data-product/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-reload-data-product",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-reload-data-product/src/var/task/reload_data_product.py
+++ b/containers/daap-reload-data-product/src/var/task/reload_data_product.py
@@ -4,6 +4,7 @@ import time
 import boto3
 from botocore.paginate import PageIterator
 from data_platform_logging import DataPlatformLogger
+from data_platform_paths import DataProductConfig
 
 s3 = boto3.client("s3")
 glue = boto3.client("glue")
@@ -19,10 +20,6 @@ s3_security_opts = {
     "ServerSideEncryption": "AES256",
 }
 
-raw_data_bucket = os.environ.get("RAW_DATA_BUCKET", "")
-curated_data_bucket = os.environ.get("CURATED_DATA_BUCKET", "")
-athena_load_lambda = os.environ.get("ATHENA_LOAD_LAMBDA", "")
-
 
 def handler(
     event,
@@ -30,13 +27,14 @@ def handler(
     glue=glue,
     s3=s3,
     aws_lambda=boto3.client("lambda"),
-    raw_data_bucket=raw_data_bucket,
-    curated_data_bucket=curated_data_bucket,
-    athena_load_lambda=athena_load_lambda,
+    athena_load_lambda=os.environ.get("ATHENA_LOAD_LAMBDA", ""),
 ):
-    data_product_to_recreate = event.get("data_product", "")
-    raw_prefix = f"raw_data/{data_product_to_recreate}"
-    logger.info(f"Data product to recreate: {data_product_to_recreate}")
+    data_product_name = event.get("data_product", "")
+    data_product = DataProductConfig(name=data_product_name)
+    raw_prefix = data_product.raw_data_prefix.key
+    raw_data_bucket = data_product.raw_data_bucket
+    curated_data_bucket = data_product.curated_data_bucket
+    logger.info(f"Data product to recreate: {data_product.name}")
     logger.info(f"Raw prefix: {raw_prefix}")
 
     # Check data product has associated data
@@ -45,18 +43,18 @@ def handler(
     )
 
     # Drop existing athena tables for that data product
-    glue_response = glue.get_tables(DatabaseName=data_product_to_recreate)
+    glue_response = glue.get_tables(DatabaseName=data_product.name)
     data_product_tables = glue_response.get("TableList", [])
     if not any(data_product_tables):
-        logger.info(f"No tables found for data product {data_product_to_recreate}")
+        logger.info(f"No tables found for data product {data_product.name}")
     for table in data_product_tables:
         table_name = table["Name"]
-        glue.delete_table(DatabaseName=data_product_to_recreate, Name=table_name)
-        logger.info(f"Deleted glue table {data_product_to_recreate}.{table_name}")
+        glue.delete_table(DatabaseName=data_product.name, Name=table_name)
+        logger.info(f"Deleted glue table {data_product.name}.{table_name}")
     # Remove curated data files for that data product
     s3_recursive_delete(
         bucket=curated_data_bucket,
-        prefix=f"curated_data/database_name={data_product_to_recreate}/",
+        prefix=data_product.curated_data_prefix.key,
         s3_client=s3,
     )
 
@@ -75,7 +73,7 @@ def handler(
             FunctionName=athena_load_lambda, InvocationType="Event", Payload=payload
         )
 
-    logger.info(f"data product {data_product_to_recreate} recreated")
+    logger.info(f"data product {data_product_name} recreated")
 
 
 def s3_recursive_delete(bucket, prefix, s3_client) -> None:

--- a/containers/daap-reload-data-product/src/var/task/reload_data_product.py
+++ b/containers/daap-reload-data-product/src/var/task/reload_data_product.py
@@ -83,6 +83,9 @@ def s3_recursive_delete(bucket, prefix, s3_client) -> None:
 
     delete_us: dict = dict(Objects=[])
     for item in pages.search("Contents"):
+        if item is None:
+            continue
+
         delete_us["Objects"].append(dict(Key=item["Key"]))
 
         # delete once aws limit reached

--- a/containers/daap-reload-data-product/tests/unit/conftest.py
+++ b/containers/daap-reload-data-product/tests/unit/conftest.py
@@ -23,9 +23,6 @@ sys.path.append(
 )
 
 
-from data_platform_paths import DataProductConfig  # noqa: E402
-
-
 @dataclass
 class FakeContext:
     function_name: str
@@ -75,13 +72,3 @@ def lambda_client():
 @pytest.fixture()
 def do_nothing_lambda_client(lambda_client):
     return MagicMock(spec=lambda_client, auto_spec=True)
-
-
-@pytest.fixture
-def bucket_name():
-    return "bucket"
-
-
-@pytest.fixture
-def data_product(bucket_name):
-    return DataProductConfig("foo", "bar", bucket_name)

--- a/containers/daap-reload-data-product/tests/unit/reload_data_product_test.py
+++ b/containers/daap-reload-data-product/tests/unit/reload_data_product_test.py
@@ -69,6 +69,16 @@ def test_s3_recursive_delete(s3_client, curated_data_bucket, data_product):
     assert keys == ["some-other"]
 
 
+def test_s3_recursive_delete_empty_bucket(
+    s3_client, empty_curated_data_bucket, data_product
+):
+    s3_recursive_delete(
+        bucket=empty_curated_data_bucket,
+        s3_client=s3_client,
+        prefix=data_product.curated_data_prefix.key,
+    )
+
+
 def test_get_data_product_pages(s3_client, raw_data_bucket, data_product):
     pages = list(
         get_data_product_pages(

--- a/containers/daap-reload-data-product/tests/unit/reload_data_product_test.py
+++ b/containers/daap-reload-data-product/tests/unit/reload_data_product_test.py
@@ -1,11 +1,13 @@
 import pytest
+from data_platform_paths import DataProductConfig
 from reload_data_product import get_data_product_pages, handler, s3_recursive_delete
 
 
 @pytest.fixture
-def empty_curated_data_bucket(s3_client):
+def empty_curated_data_bucket(s3_client, monkeypatch):
     bucket_name = "curated"
     s3_client.create_bucket(Bucket=bucket_name)
+    monkeypatch.setenv("CURATED_DATA_BUCKET", bucket_name)
     return bucket_name
 
 
@@ -13,7 +15,9 @@ def empty_curated_data_bucket(s3_client):
 def curated_data_bucket(s3_client, empty_curated_data_bucket, data_product):
     bucket_name = empty_curated_data_bucket
     s3_client.put_object(
-        Bucket=bucket_name, Key=f"{data_product.curated_data_prefix.key}baz", Body=""
+        Bucket=bucket_name,
+        Key=f"{data_product.curated_data_prefix.key}table=bar/baz",
+        Body="",
     )
     s3_client.put_object(
         Bucket=bucket_name,
@@ -25,20 +29,28 @@ def curated_data_bucket(s3_client, empty_curated_data_bucket, data_product):
 
 
 @pytest.fixture
-def empty_raw_data_bucket(s3_client):
+def empty_raw_data_bucket(s3_client, monkeypatch):
     bucket_name = "raw"
     s3_client.create_bucket(Bucket=bucket_name)
+    monkeypatch.setenv("RAW_DATA_BUCKET", bucket_name)
     return bucket_name
+
+
+@pytest.fixture
+def data_product(empty_raw_data_bucket, empty_curated_data_bucket):
+    return DataProductConfig(
+        "foo", raw_data_bucket=raw_data_bucket, curated_data_bucket=curated_data_bucket
+    )
 
 
 @pytest.fixture
 def raw_data_bucket(s3_client, empty_raw_data_bucket, data_product):
     bucket_name = empty_raw_data_bucket
     s3_client.put_object(
-        Bucket=bucket_name, Key=data_product.raw_data_prefix.key + "abc", Body=""
+        Bucket=bucket_name, Key=data_product.raw_data_prefix.key + "bar/abc", Body=""
     )
     s3_client.put_object(
-        Bucket=bucket_name, Key=data_product.raw_data_prefix.key + "baz", Body=""
+        Bucket=bucket_name, Key=data_product.raw_data_prefix.key + "bar/baz", Body=""
     )
     return bucket_name
 
@@ -90,9 +102,7 @@ def test_handler_recursively_deletes_curated_data(
     raw_data_bucket,
     fake_context,
 ):
-    glue_client.create_database(
-        DatabaseInput={"Name": data_product.curated_data_table.database}
-    )
+    glue_client.create_database(DatabaseInput={"Name": data_product.name})
 
     handler(
         event={"data_product": data_product.name},
@@ -101,8 +111,6 @@ def test_handler_recursively_deletes_curated_data(
         s3=s3_client,
         aws_lambda=do_nothing_lambda_client,
         athena_load_lambda="athena_load_lambda",
-        raw_data_bucket=raw_data_bucket,
-        curated_data_bucket=curated_data_bucket,
     )
 
     keys = [
@@ -121,9 +129,7 @@ def test_handler_invokes_lambda_for_each_raw_file(
     raw_data_bucket,
     fake_context,
 ):
-    glue_client.create_database(
-        DatabaseInput={"Name": data_product.curated_data_table.database}
-    )
+    glue_client.create_database(DatabaseInput={"Name": data_product.name})
 
     handler(
         event={"data_product": data_product.name},
@@ -132,8 +138,6 @@ def test_handler_invokes_lambda_for_each_raw_file(
         s3=s3_client,
         aws_lambda=do_nothing_lambda_client,
         athena_load_lambda="athena_load_lambda",
-        raw_data_bucket=raw_data_bucket,
-        curated_data_bucket=curated_data_bucket,
     )
 
     do_nothing_lambda_client.invoke.assert_any_call(
@@ -158,12 +162,10 @@ def test_handler_deletes_glue_table(
     raw_data_bucket,
     fake_context,
 ):
-    glue_client.create_database(
-        DatabaseInput={"Name": data_product.curated_data_table.database}
-    )
+    glue_client.create_database(DatabaseInput={"Name": data_product.name})
     glue_client.create_table(
         TableInput={"Name": "foo"},
-        DatabaseName=data_product.curated_data_table.database,
+        DatabaseName=data_product.name,
     )
 
     handler(
@@ -173,11 +175,7 @@ def test_handler_deletes_glue_table(
         s3=s3_client,
         aws_lambda=do_nothing_lambda_client,
         athena_load_lambda="athena_load_lambda",
-        raw_data_bucket=raw_data_bucket,
-        curated_data_bucket=curated_data_bucket,
     )
 
-    response = glue_client.get_tables(
-        DatabaseName=data_product.curated_data_table.database
-    )
+    response = glue_client.get_tables(DatabaseName=data_product.name)
     assert response["TableList"] == []


### PR DESCRIPTION
Refactor the lambda to use the shared library for constructing s3 paths.

Note that since the tests were written, we split out `DataProductConfig` and `DataProductElement` (https://github.com/ministryofjustice/data-platform/pull/1549) so some of the tests need updating as well.