### PR TITLE
DPL-1316 Update daap-athena-load to latest base image and generate unique names for raw athena table

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.4] 2023-09-21
+
+### Changed
+
+- The temporary raw athena table is created with a unique name per invocation
+- Use new version of base image paths module
+
 ## [1.1.4] 2023-09-15
 
 ### Changed

--- a/containers/daap-athena-load/Dockerfile
+++ b/containers/daap-athena-load/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:1.0.2
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:2.0.0
 
 ARG VERSION
 

--- a/containers/daap-athena-load/src/var/task/athena_load_handler.py
+++ b/containers/daap-athena-load/src/var/task/athena_load_handler.py
@@ -4,7 +4,7 @@ import boto3
 from create_curated_athena_table import create_curated_athena_table
 from create_raw_athena_table import create_raw_athena_table
 from data_platform_logging import DataPlatformLogger
-from data_platform_paths import RawDataExtraction, QueryTable
+from data_platform_paths import QueryTable, RawDataExtraction
 from infer_glue_schema import infer_glue_schema
 
 athena_client = boto3.client("athena")
@@ -43,9 +43,8 @@ def handler(
 
     temp_table_name = metadata_types["TableInput"]["Name"]
     temp_database_name = metadata_types["DatabaseName"]
-    logger.info(
-        f"config: {extraction.timestamp=} {temp_table_name=} {temp_database_name=} {data_product_element.curated_data_table=}"
-    )
+    logger.info(f"{temp_table_name=} {temp_database_name=}")
+    logger.info(f"{extraction.timestamp=} {data_product_element.curated_data_table=}")
 
     # Create a table of all string-type columns, to load raw data into
     create_raw_athena_table(

--- a/containers/daap-athena-load/tests/unit/athena_load_handler_test.py
+++ b/containers/daap-athena-load/tests/unit/athena_load_handler_test.py
@@ -1,4 +1,4 @@
-from unittest.mock import MagicMock, sentinel
+from unittest.mock import MagicMock
 
 import athena_load_handler
 from moto import mock_sts
@@ -25,8 +25,8 @@ def test_handler_does_not_error(
     )
 
     mock_infer_schema.return_value = (
-        sentinel.metadata_glue,
-        sentinel.metadata_glue_str,
+        {"DatabaseName": "data_products_raw", "TableInput": {"Name": "temp"}},
+        {"DatabaseName": "data_products_raw", "TableInput": {"Name": "temp"}},
     )
 
     athena_load_handler.handler(

--- a/containers/daap-athena-load/tests/unit/conftest.py
+++ b/containers/daap-athena-load/tests/unit/conftest.py
@@ -16,7 +16,7 @@ sys.path.append(
 )
 
 from data_platform_logging import DataPlatformLogger  # noqa E402
-from data_platform_paths import DataProductConfig  # noqa E402
+from data_platform_paths import DataProductElement  # noqa E402
 
 os.environ["AWS_ACCESS_KEY_ID"] = "testing"
 os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
@@ -73,8 +73,9 @@ def athena_client():
 
 
 @pytest.fixture
-def data_product():
-    return DataProductConfig(name="foo", table_name="bar", bucket_name="bucket")
+def data_product_element(monkeypatch):
+    monkeypatch.setenv("BUCKET_NAME", "bucket")
+    return DataProductElement.load(element_name="foo", data_product_name="bar")
 
 
 @pytest.fixture

--- a/containers/daap-athena-load/tests/unit/infer_glue_schema_test.py
+++ b/containers/daap-athena-load/tests/unit/infer_glue_schema_test.py
@@ -8,10 +8,10 @@ from infer_glue_schema import infer_glue_schema
 from pyarrow import parquet as pq
 
 
-def test_infer_schema_from_csv(s3_client, logger, data_product):
+def test_infer_schema_from_csv(s3_client, logger, data_product_element):
     s3_client.create_bucket(Bucket="bucket")
     uuid_value = uuid4()
-    path = data_product.raw_data_path(datetime(2023, 1, 1), uuid_value)
+    path = data_product_element.raw_data_path(datetime(2023, 1, 1), uuid_value)
 
     s3_client.put_object(
         Key=path.key,
@@ -27,7 +27,7 @@ def test_infer_schema_from_csv(s3_client, logger, data_product):
 
     metadata_glue, metadata_glue_str = infer_glue_schema(
         file_path=BucketPath(path.bucket, path.key),
-        data_product_config=data_product,
+        data_product_element=data_product_element,
         logger=logger,
     )
 
@@ -42,7 +42,7 @@ def test_infer_schema_from_csv(s3_client, logger, data_product):
     ]
 
 
-def test_infer_schema_from_parquet(s3_client, logger, data_product):
+def test_infer_schema_from_parquet(s3_client, logger, data_product_element):
     table = pa.Table.from_arrays(
         [
             pa.array([2, 4, 5, 100]),
@@ -53,7 +53,7 @@ def test_infer_schema_from_parquet(s3_client, logger, data_product):
     output = pa.BufferOutputStream()
     pq.write_table(table, output)
 
-    path = data_product.curated_data_prefix.key + "foo.parquet"
+    path = data_product_element.curated_data_prefix.key + "foo.parquet"
     s3_client.create_bucket(Bucket="bucket")
     s3_client.put_object(
         Key=path,
@@ -62,8 +62,8 @@ def test_infer_schema_from_parquet(s3_client, logger, data_product):
     )
 
     metadata_glue, metadata_glue_str = infer_glue_schema(
-        file_path=data_product.curated_data_prefix,
-        data_product_config=data_product,
+        file_path=data_product_element.curated_data_prefix,
+        data_product_element=data_product_element,
         logger=logger,
         table_type="curated",
         file_type="parquet",

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -30,12 +30,12 @@ stored in different S3 buckets.
 ### Removed
 
 - `DataProductConfig` no longer takes a `table_name` argument. Instead, call
-  `data_product_config.model(name)` or `DataProductModel.load` to get a
-  `DataProductModel` instance.
+  `data_product_config.element(name)` or `DataProductElement.load` to get a
+  `DataProductElement` instance.
 - `raw_data_prefix`, `curated_data_prefix` and `curated_data_table` on
   `DataProductConfig` now exclude the table name part. Use `DataProductElement`
   to get the prefix including table name.
-- `raw_data_table` is now a method of `DataProductModel`, and returns a unique
+- `raw_data_table` is now a method of `DataProductElement`, and returns a unique
   name each call.
 - `get_bucket_name()` function is replaced by `get_raw_data_bucket()`,
   `get_curated_data_bucket()`, `get_metadata_bucket` and `get_log_bucket`.


### PR DESCRIPTION
1. Use latest API for data_platform_paths - this means changing DataProductConfig to DataProductElement
2. Create the raw athena table with a unique name for every invocation as suggested in #1310

Note: when I deploy this, I'll need to make sure the bucket name environment variables are set in terraform, since we can no longer infer everything from the bucket that triggered the event. 