### PR TITLE
🔥 Remove `import` + `moved` blocks

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -78,11 +78,6 @@ moved {
   to   = aws_security_group.airflow_dev_cluster_additional_security_group
 }
 
-import {
-  to = aws_security_group.airflow_dev_cluster_node_security_group
-  id = "sg-01930457ae391c7f0"
-}
-
 output "endpoint" {
   value = aws_eks_cluster.airflow_dev_eks_cluster.endpoint
 }
@@ -160,11 +155,6 @@ resource "kubernetes_namespace" "dev_kube2iam" {
   timeouts {}
 }
 
-import {
-  to = kubernetes_namespace.dev_kube2iam
-  id = "kube2iam-system"
-}
-
 resource "kubernetes_config_map" "dev_aws_auth_configmap" {
   provider = kubernetes.dev-airflow-cluster
   metadata {
@@ -181,11 +171,6 @@ resource "kubernetes_config_map" "dev_aws_auth_configmap" {
 
 }
 
-import {
-  to = kubernetes_config_map.dev_aws_auth_configmap
-  id = "kube-system/aws-auth"
-}
-
 resource "kubernetes_namespace" "dev_airflow" {
   provider = kubernetes.dev-airflow-cluster
   metadata {
@@ -200,10 +185,7 @@ resource "kubernetes_namespace" "dev_airflow" {
   }
   timeouts {}
 }
-import {
-  to = kubernetes_namespace.dev_airflow
-  id = "airflow"
-}
+
 resource "kubernetes_namespace" "kyverno" {
   provider = kubernetes.dev-airflow-cluster
   metadata {
@@ -213,10 +195,6 @@ resource "kubernetes_namespace" "kyverno" {
     }
   }
   timeouts {}
-}
-import {
-  to = kubernetes_namespace.kyverno
-  id = "kyverno"
 }
 
 resource "kubernetes_namespace" "cluster-autoscaler-system" {
@@ -232,13 +210,6 @@ resource "kubernetes_namespace" "cluster-autoscaler-system" {
   }
   timeouts {}
 }
-
-import {
-  to = kubernetes_namespace.cluster-autoscaler-system
-  id = "cluster-autoscaler-system"
-}
-
-
 
 ######################################
 ########### EKS PRODUCTION ###########

--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -73,11 +73,6 @@ resource "aws_security_group" "airflow_dev_cluster_node_security_group" {
   }
 }
 
-moved {
-  from = aws_security_group.airflow_dev_security_group
-  to   = aws_security_group.airflow_dev_cluster_additional_security_group
-}
-
 output "endpoint" {
   value = aws_eks_cluster.airflow_dev_eks_cluster.endpoint
 }

--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -192,7 +192,7 @@ resource "kubernetes_namespace" "kyverno" {
   timeouts {}
 }
 
-resource "kubernetes_namespace" "cluster-autoscaler-system" {
+resource "kubernetes_namespace" "cluster_autoscaler_system" {
   provider = kubernetes.dev-airflow-cluster
   metadata {
     name = "cluster-autoscaler-system"
@@ -204,6 +204,11 @@ resource "kubernetes_namespace" "cluster-autoscaler-system" {
     }
   }
   timeouts {}
+}
+
+moved {
+  from = kubernetes_namespace.cluster-autoscaler-system
+  to = kubernetes_namespace.cluster_autoscaler_system
 }
 
 ######################################

--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -208,7 +208,7 @@ resource "kubernetes_namespace" "cluster_autoscaler_system" {
 
 moved {
   from = kubernetes_namespace.cluster-autoscaler-system
-  to = kubernetes_namespace.cluster_autoscaler_system
+  to   = kubernetes_namespace.cluster_autoscaler_system
 }
 
 ######################################

--- a/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
@@ -136,7 +136,3 @@ resource "aws_iam_role" "airflow_prod_eks_role" {
   ]
 }
 
-import {
-  to = aws_iam_role.airflow_prod_eks_role
-  id = "airflow-prod-eksRole-role-de6b4f5"
-}


### PR DESCRIPTION
This PR removes any existing `moved` and `import` blocks from the code. These have came to exist during the [Airflow:  Pulumi -> Terraform](https://github.com/ministryofjustice/data-platform/issues/1625) import. 