### PR TITLE
Refactor athena load module for inferring schemas

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Refactor infer_glue_schema
+
 ## [1.1.4] 2023-09-21
 
 ### Changed

--- a/containers/daap-athena-load/src/var/task/athena_load_handler.py
+++ b/containers/daap-athena-load/src/var/task/athena_load_handler.py
@@ -5,7 +5,7 @@ from create_curated_athena_table import create_curated_athena_table
 from create_raw_athena_table import create_raw_athena_table
 from data_platform_logging import DataPlatformLogger
 from data_platform_paths import QueryTable, RawDataExtraction
-from infer_glue_schema import infer_glue_schema
+from infer_glue_schema import infer_glue_schema_from_raw_csv
 
 athena_client = boto3.client("athena")
 s3_client = boto3.client("s3")
@@ -37,18 +37,18 @@ def handler(
 
     logger.info(f"file is: {full_s3_path}")
 
-    metadata_types, metadata_str = infer_glue_schema(
+    inferred_metadata = infer_glue_schema_from_raw_csv(
         extraction.path, data_product_element, logger=logger
     )
 
-    temp_table_name = metadata_types["TableInput"]["Name"]
-    temp_database_name = metadata_types["DatabaseName"]
+    temp_table_name = inferred_metadata.table_name
+    temp_database_name = inferred_metadata.database_name
     logger.info(f"{temp_table_name=} {temp_database_name=}")
     logger.info(f"{extraction.timestamp=} {data_product_element.curated_data_table=}")
 
     # Create a table of all string-type columns, to load raw data into
     create_raw_athena_table(
-        metadata_glue=metadata_str,
+        metadata_glue=inferred_metadata.metadata_str,
         logger=logger,
         glue_client=glue_client,
         bucket=extraction.path.bucket,
@@ -62,7 +62,7 @@ def handler(
         data_product_element=data_product_element,
         raw_data_table=QueryTable(database=temp_database_name, name=temp_table_name),
         extraction_timestamp=extraction.timestamp.strftime("%Y%m%dT%H%M%SZ"),
-        metadata=metadata_types,
+        metadata=inferred_metadata.metadata,
         logger=logger,
         glue_client=glue_client,
         s3_client=s3_client,

--- a/containers/daap-athena-load/tests/unit/athena_load_handler_test.py
+++ b/containers/daap-athena-load/tests/unit/athena_load_handler_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import athena_load_handler
+from infer_glue_schema import InferredMetadata
 from moto import mock_sts
 
 
@@ -21,12 +22,14 @@ def test_handler_does_not_error(
     )
     mocker.patch("athena_load_handler.create_raw_athena_table", autospec=True)
     mock_infer_schema = mocker.patch(
-        "athena_load_handler.infer_glue_schema", autospec=True
+        "athena_load_handler.infer_glue_schema_from_raw_csv", autospec=True
     )
 
-    mock_infer_schema.return_value = (
-        {"DatabaseName": "data_products_raw", "TableInput": {"Name": "temp"}},
-        {"DatabaseName": "data_products_raw", "TableInput": {"Name": "temp"}},
+    mock_infer_schema.return_value = InferredMetadata(
+        {
+            "DatabaseName": "data_products_raw",
+            "TableInput": {"Name": "temp", "StorageDescriptor": {"Columns": []}},
+        },
     )
 
     athena_load_handler.handler(

--- a/containers/daap-athena-load/tests/unit/conftest.py
+++ b/containers/daap-athena-load/tests/unit/conftest.py
@@ -81,3 +81,30 @@ def data_product_element(monkeypatch):
 @pytest.fixture
 def logger():
     return MagicMock(DataPlatformLogger)
+
+
+@pytest.fixture
+def raw_data_table(data_product_element):
+    return data_product_element.raw_data_table_unique()
+
+
+@pytest.fixture
+def raw_table_metadata(raw_data_table):
+    return {
+        "DatabaseName": raw_data_table.database,
+        "TableInput": {
+            "Name": raw_data_table.name,
+            "StorageDescriptor": {
+                "Columns": [
+                    {
+                        "Name": "col1",
+                        "Type": "type1",
+                    },
+                    {
+                        "Name": "col2",
+                        "Type": "type2",
+                    },
+                ]
+            },
+        },
+    }

--- a/containers/daap-athena-load/tests/unit/infer_glue_schema_test.py
+++ b/containers/daap-athena-load/tests/unit/infer_glue_schema_test.py
@@ -1,11 +1,29 @@
 from datetime import datetime
 from textwrap import dedent
 from uuid import uuid4
+from io import BytesIO
 
 import pyarrow as pa
 from data_platform_paths import BucketPath
-from infer_glue_schema import infer_glue_schema
+from infer_glue_schema import infer_glue_schema, csv_sample
 from pyarrow import parquet as pq
+import pytest
+
+
+@pytest.mark.parametrize(
+    "test_input,sample_size_in_bytes,expected",
+    [
+        (b"a,b,c", 10, b"a,b,c"),
+        (b"a,b,c\nd,e,f", 1, b"a,b,c\n"),
+    ],
+)
+def test_csv_sample(test_input, expected, sample_size_in_bytes, logger):
+    bytes_stream = BytesIO(test_input)
+    output = csv_sample(
+        bytes_stream, logger=logger, sample_size_in_bytes=sample_size_in_bytes
+    ).getvalue()
+
+    assert output == expected
 
 
 def test_infer_schema_from_csv(s3_client, logger, data_product_element):

--- a/containers/daap-athena-load/tests/unit/infer_glue_schema_test.py
+++ b/containers/daap-athena-load/tests/unit/infer_glue_schema_test.py
@@ -1,13 +1,18 @@
 from datetime import datetime
+from io import BytesIO
 from textwrap import dedent
 from uuid import uuid4
-from io import BytesIO
 
 import pyarrow as pa
-from data_platform_paths import BucketPath
-from infer_glue_schema import infer_glue_schema, csv_sample
-from pyarrow import parquet as pq
 import pytest
+from data_platform_paths import BucketPath
+from infer_glue_schema import (
+    InferredMetadata,
+    csv_sample,
+    infer_glue_schema_from_parquet,
+    infer_glue_schema_from_raw_csv,
+)
+from pyarrow import parquet as pq
 
 
 @pytest.mark.parametrize(
@@ -61,18 +66,20 @@ def test_infer_schema_from_csv(s3_client, logger, data_product_element):
         Bucket="bucket",
     )
 
-    metadata_glue, metadata_glue_str = infer_glue_schema(
+    inferred_metadata = infer_glue_schema_from_raw_csv(
         file_path=BucketPath(path.bucket, path.key),
         data_product_element=data_product_element,
         logger=logger,
     )
 
-    assert metadata_glue["TableInput"]["StorageDescriptor"]["Columns"] == [
+    assert inferred_metadata.metadata["TableInput"]["StorageDescriptor"]["Columns"] == [
         {"Name": "some_string", "Type": "string"},
         {"Name": "some_number", "Type": "bigint"},
     ]
 
-    assert metadata_glue_str["TableInput"]["StorageDescriptor"]["Columns"] == [
+    assert inferred_metadata.metadata_str["TableInput"]["StorageDescriptor"][
+        "Columns"
+    ] == [
         {"Name": "some_string", "Type": "string"},
         {"Name": "some_number", "Type": "string"},
     ]
@@ -97,20 +104,42 @@ def test_infer_schema_from_parquet(s3_client, logger, data_product_element):
         Bucket="bucket",
     )
 
-    metadata_glue, metadata_glue_str = infer_glue_schema(
+    inferred_metadata = infer_glue_schema_from_parquet(
         file_path=data_product_element.curated_data_prefix,
         data_product_element=data_product_element,
         logger=logger,
-        table_type="curated",
-        file_type="parquet",
+        s3_client=s3_client,
     )
 
-    assert metadata_glue["TableInput"]["StorageDescriptor"]["Columns"] == [
+    assert inferred_metadata.metadata["TableInput"]["StorageDescriptor"]["Columns"] == [
         {"Name": "n_legs", "Type": "bigint"},
         {"Name": "animals", "Type": "string"},
     ]
 
-    assert metadata_glue_str["TableInput"]["StorageDescriptor"]["Columns"] == [
+    assert inferred_metadata.metadata_str["TableInput"]["StorageDescriptor"][
+        "Columns"
+    ] == [
         {"Name": "n_legs", "Type": "string"},
         {"Name": "animals", "Type": "string"},
     ]
+
+
+def test_inferred_metadata(raw_data_table, raw_table_metadata):
+    result = InferredMetadata(raw_table_metadata)
+
+    assert result.database_name == raw_data_table.database
+    assert result.table_name == raw_data_table.name
+    assert result.metadata == raw_table_metadata
+
+
+def test_copy_inferred_metadata(raw_table_metadata):
+    original = InferredMetadata(raw_table_metadata)
+    result = original.copy(database_name="abc", table_name="def")
+
+    assert result.database_name == "abc"
+    assert result.table_name == "def"
+    assert result.metadata != original.metadata
+    assert (
+        result.metadata["TableInput"]["StorageDescriptor"]["Columns"]
+        == original.metadata["TableInput"]["StorageDescriptor"]["Columns"]
+    )

--- a/containers/daap-athena-load/tests/unit/infer_glue_schema_test.py
+++ b/containers/daap-athena-load/tests/unit/infer_glue_schema_test.py
@@ -13,8 +13,26 @@ import pytest
 @pytest.mark.parametrize(
     "test_input,sample_size_in_bytes,expected",
     [
-        (b"a,b,c", 10, b"a,b,c"),
-        (b"a,b,c\nd,e,f", 1, b"a,b,c\n"),
+        (
+            b"a,b,c",
+            10,
+            b"a,b,c",
+        ),  # Should read to the end of the stream without encountering the line separator
+        (
+            b"a,b,c\nd,e,f",
+            1,
+            b"a,b,c\n",
+        ),  # The sample size is the absolute minimum; should stop when hitting the line separator
+        (
+            b"a,b,c\nd,e,f\n",
+            6,
+            b"a,b,c\n",
+        ),  # The sample size aligns with a line break. The following line shouldn't be read.
+        (
+            b"a,b,c\ndddddddddddd,eeeeeeeeeee,fffffffff",
+            4,
+            b"a,b,c\n",
+        ),  # The sample size doesn't align with a line break. Stop when hitting the following line separator.
     ],
 )
 def test_csv_sample(test_input, expected, sample_size_in_bytes, logger):


### PR DESCRIPTION
This refactor introduces an abstraction around the glue metadata to make it easier to pass data around and avoid having to parse the dict structure to access table name and database name elsewhere. I think this will also help with the refactor of `create_curated_table`.

I've also split the infer_glue_schema function into two distinct functions, one for raw CSVs and one for parquet files. Previously the logic dependend on the combination of `file_type` and `table_type` flags, and it was possible to pass a combination other than the 2 use cases we have properly implemented.

In the previous version `infer_glue_schema` handled a lot of different concerns: 
- loading either a single file, or choosing a file from s3
- preparing a sample of data in the case of s3
- the actual conversion of an arrow dataset to a glue schema
- standardising and setting table and column names
- converting column types to strings

In the new version:
- instead of calling infer_glue_schema, calling code calls `infer_glue_schema_for_raw_csv` or `infer_glue_schema_for_parquet`
- there is a GlueSchemaGenerator which operates on file-like objects, so that the s3 logic can be separated out
- there is a csv_sample function, which does the csv sampling on a file like object