### PR TITLE
Refactor create_curated_athena_table in athena data load lambda

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.5] 2023-09-26
+
 ### Changed
 
 - Refactor infer_glue_schema

--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -15,6 +15,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Remove unused argument from create_raw_athena_table
 - Ensure raw athena tables are deleted if there is an exception
 - Bump base image version
+- If curated table is missing when ingesting data for an existing data product,
+  we now throw a 500 error. This should not normally happen, and if it does
+  we can run reload_data_product to fix it.
 
 ## [1.1.4] 2023-09-21
 

--- a/containers/daap-athena-load/config.json
+++ b/containers/daap-athena-load/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-athena-load",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-athena-load/src/var/task/create_curated_athena_table.py
+++ b/containers/daap-athena-load/src/var/task/create_curated_athena_table.py
@@ -283,7 +283,7 @@ def create_curated_athena_table(
         )
         return
 
-    logger.info(
+    logger.error(
         f"{loader.curated_data_table} does not exist,"
         f" but files exist in {loader.curated_table_path}."
         " Run reload_data_product to recreate the data product before continuing."

--- a/containers/daap-athena-load/tests/unit/conftest.py
+++ b/containers/daap-athena-load/tests/unit/conftest.py
@@ -2,7 +2,6 @@ import os
 import sys
 from dataclasses import dataclass
 from os.path import dirname, join
-from unittest.mock import MagicMock
 
 import boto3
 import pytest
@@ -80,7 +79,7 @@ def data_product_element(monkeypatch):
 
 @pytest.fixture
 def logger():
-    return MagicMock(DataPlatformLogger)
+    return DataPlatformLogger()
 
 
 @pytest.fixture

--- a/containers/daap-athena-load/tests/unit/create_curated_athena_table_test.py
+++ b/containers/daap-athena-load/tests/unit/create_curated_athena_table_test.py
@@ -1,210 +1,245 @@
 from textwrap import dedent
-from unittest.mock import MagicMock
 
 import pytest
 from create_curated_athena_table import (
+    CuratedDataLoader,
+    CuratedDataQueryBuilder,
+    TableMissingForExistingDataProduct,
     create_curated_athena_table,
     does_partition_file_exist,
-    sql_create_table_partition,
-    sql_unload_table_partition,
 )
-from data_platform_logging import DataPlatformLogger
 from data_platform_paths import BucketPath, QueryTable
 
 
-@pytest.fixture
-def curated_athena_table_kwargs(
-    data_product_element, s3_client, glue_client, athena_client, logger
-):
-    """
-    Helper to construct the args to the function
-    """
-    return dict(
-        data_product_element=data_product_element,
-        raw_data_table=data_product_element.raw_data_table_unique(),
-        extraction_timestamp="20230101T000000Z",
-        metadata={
-            "TableInput": {"Name": "table", "StorageDescriptor": {"Columns": []}},
-            "DatabaseName": "data_products_raw",
-        },
-        logger=logger,
-        glue_client=glue_client,
-        s3_client=s3_client,
-        athena_client=athena_client,
-    )
+class TestCreateCuratedAthenaTable:
+    @pytest.fixture(autouse=True)
+    def setup(self, s3_client, athena_client):
+        s3_client.create_bucket(Bucket="bucket")
+        athena_client.create_work_group(Name="data_product_workgroup")
 
-
-def test_creates_glue_database_if_missing(
-    data_product_element,
-    curated_athena_table_kwargs,
-    s3_client,
-    glue_client,
-    athena_client,
-):
-    s3_client.create_bucket(Bucket="bucket")
-    athena_client.create_work_group(Name="data_product_workgroup")
-
-    create_curated_athena_table(**curated_athena_table_kwargs)
-
-    response = glue_client.get_database(
-        Name=data_product_element.curated_data_table.database
-    )
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-
-
-def test_no_error_if_table_exists(
-    curated_athena_table_kwargs,
-    data_product_element,
-    s3_client,
-    glue_client,
-    athena_client,
-):
-    s3_client.create_bucket(Bucket="bucket")
-    athena_client.create_work_group(Name="data_product_workgroup")
-    glue_client.create_database(
-        DatabaseInput={"Name": data_product_element.curated_data_table.database}
-    )
-    glue_client.create_table(
-        TableInput={"Name": data_product_element.curated_data_table.name},
-        DatabaseName=data_product_element.curated_data_table.database,
-    )
-
-    create_curated_athena_table(**curated_athena_table_kwargs)
-
-    response = glue_client.get_database(
-        Name=data_product_element.curated_data_table.database
-    )
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-
-
-def test_no_error_if_table_exists_and_partition_exists(
-    curated_athena_table_kwargs,
-    s3_client,
-    glue_client,
-    athena_client,
-    data_product_element,
-):
-    s3_client.create_bucket(Bucket="bucket")
-    s3_client.put_object(
-        Bucket="bucket",
-        Key=data_product_element.curated_data_prefix.key + "partition.parquet",
-        Body="",
-    )
-    athena_client.create_work_group(Name="data_product_workgroup")
-    glue_client.create_database(
-        DatabaseInput={"Name": data_product_element.curated_data_table.database}
-    )
-    glue_client.create_table(
-        TableInput={"Name": data_product_element.curated_data_table.name},
-        DatabaseName=data_product_element.curated_data_table.database,
-    )
-
-    create_curated_athena_table(**curated_athena_table_kwargs)
-
-    response = glue_client.get_database(
-        Name=data_product_element.curated_data_table.database
-    )
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
-
-
-def test_sql_unload_table_partition():
-    result = sql_unload_table_partition(
-        raw_table=QueryTable("data_products_raw", "table_raw"),
-        table_path="s3://bucket_name/curated_data/database_name=dataproduct/table_name=table_name/",
-        timestamp="20230101T000000Z",
-        metadata={
-            "TableInput": {
-                "StorageDescriptor": {
-                    "Columns": [
-                        {"Name": "foo", "Type": "string"},
-                        {"Name": "bar", "Type": None},
-                    ]
-                }
-            }
-        },
-    )
-
-    assert dedent(result) == dedent(
+    @pytest.fixture
+    def function_kwargs(
+        self, data_product_element, s3_client, glue_client, athena_client, logger
+    ):
         """
-        UNLOAD (
+        Helper to construct the args to the function
+        """
+        return dict(
+            data_product_element=data_product_element,
+            raw_data_table=data_product_element.raw_data_table_unique(),
+            extraction_timestamp="20230101T000000Z",
+            metadata={
+                "TableInput": {"Name": "table", "StorageDescriptor": {"Columns": []}},
+                "DatabaseName": "data_products_raw",
+            },
+            logger=logger,
+            glue_client=glue_client,
+            s3_client=s3_client,
+            athena_client=athena_client,
+        )
+
+    def test_creates_glue_database_for_new_product(
+        self, data_product_element, function_kwargs, glue_client, caplog
+    ):
+        create_curated_athena_table(**function_kwargs)
+        response = glue_client.get_database(
+            Name=data_product_element.curated_data_table.database
+        )
+
+        assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
+        assert "This is a new data product" in caplog.text
+
+    def test_no_error_if_table_exists(
+        self, function_kwargs, data_product_element, glue_client, caplog
+    ):
+        glue_client.create_database(
+            DatabaseInput={"Name": data_product_element.curated_data_table.database}
+        )
+        glue_client.create_table(
+            TableInput={"Name": data_product_element.curated_data_table.name},
+            DatabaseName=data_product_element.curated_data_table.database,
+        )
+
+        create_curated_athena_table(**function_kwargs)
+
+        assert "Table exists but partition does not" in caplog.text
+
+    def test_no_error_if_table_and_partition_exist(
+        self,
+        function_kwargs,
+        s3_client,
+        glue_client,
+        data_product_element,
+        caplog,
+    ):
+        glue_client.create_database(
+            DatabaseInput={"Name": data_product_element.curated_data_table.database}
+        )
+        glue_client.create_table(
+            TableInput={"Name": data_product_element.curated_data_table.name},
+            DatabaseName=data_product_element.curated_data_table.database,
+        )
+        s3_client.put_object(
+            Bucket="bucket",
+            Key=data_product_element.curated_data_prefix.key
+            + "extraction_timestamp=20230101T000000Z/partition.parquet",
+            Body="",
+        )
+
+        create_curated_athena_table(**function_kwargs)
+
+        assert (
+            "partition for extraction_timestamp and table already exists so nothing more to be done."
+            in caplog.text
+        )
+
+    def test_errors_if_table_is_missing_and_path_non_empty(
+        self,
+        data_product_element,
+        s3_client,
+        function_kwargs,
+    ):
+        s3_client.put_object(
+            Bucket="bucket",
+            Key=data_product_element.curated_data_prefix.key + "partition.parquet",
+            Body="",
+        )
+
+        with pytest.raises(TableMissingForExistingDataProduct):
+            create_curated_athena_table(**function_kwargs)
+
+
+class TestCuratedDataQueryBuilder:
+    def test_sql_unload_table_partition(self):
+        builder = CuratedDataQueryBuilder(
+            table_path="s3://bucket_name/curated_data/database_name=dataproduct/table_name=table_name/",
+            column_metadata=[
+                {"Name": "foo", "Type": "string"},
+                {"Name": "bar", "Type": None},
+            ],
+        )
+        result = builder.sql_unload_table_partition(
+            raw_table=QueryTable("data_products_raw", "table_raw"),
+            timestamp="20230101T000000Z",
+        )
+
+        assert dedent(result) == dedent(
+            """
+            UNLOAD (
+                SELECT
+                    CAST(NULLIF("foo",'') as VARCHAR) as "foo",CAST(NULLIF("bar",'') as None) as "bar",
+                    '20230101T000000Z' as extraction_timestamp
+                FROM data_products_raw.table_raw
+            )
+            TO 's3://bucket_name/curated_data/database_name=dataproduct/table_name=table_name/'
+            WITH(
+                format='parquet',
+                compression = 'SNAPPY',
+                partitioned_by=ARRAY['extraction_timestamp']
+            )
+            """
+        )
+
+    def test_sql_create_table_partition(self):
+        builder = CuratedDataQueryBuilder(
+            table_path="s3://bucket_name/curated_data/database_name=dataproduct/table_name=table_name/",
+            column_metadata=[
+                {"Name": "foo", "Type": "string"},
+                {"Name": "bar", "Type": None},
+            ],
+        )
+
+        result = builder.sql_create_table_partition(
+            raw_table=QueryTable("data_products_raw", "table_raw"),
+            curated_table=QueryTable("db", "table"),
+            timestamp="20230101T000000Z",
+        )
+
+        assert dedent(result) == dedent(
+            """
+            CREATE TABLE db.table
+            WITH(
+                format='parquet',
+                write_compression = 'SNAPPY',
+                external_location='s3://bucket_name/curated_data/database_name=dataproduct/table_name=table_name/',
+                partitioned_by=ARRAY['extraction_timestamp']
+            ) AS
             SELECT
                 CAST(NULLIF("foo",'') as VARCHAR) as "foo",CAST(NULLIF("bar",'') as None) as "bar",
                 '20230101T000000Z' as extraction_timestamp
             FROM data_products_raw.table_raw
+            """
         )
-        TO 's3://bucket_name/curated_data/database_name=dataproduct/table_name=table_name/'
-        WITH(
-            format='parquet',
-            compression = 'SNAPPY',
-            partitioned_by=ARRAY['extraction_timestamp']
+
+
+class TestDoesPartitionFileExist:
+    def test_returns_true(self, s3_client, logger):
+        s3_client.create_bucket(Bucket="bucket")
+        s3_client.put_object(
+            Key="curated_data/db/table_name/foo.parquet", Body="", Bucket="bucket"
         )
-        """
-    )
+
+        assert not does_partition_file_exist(
+            curated_data_prefix=BucketPath(
+                "bucket", "curated_data/database=db/table=table_name/"
+            ),
+            timestamp="20230101T0000Z",
+            logger=logger,
+            s3_client=s3_client,
+        )
+
+    def test_returns_false(self, s3_client, logger):
+        s3_client.create_bucket(Bucket="bucket")
+
+        assert not does_partition_file_exist(
+            curated_data_prefix=BucketPath(
+                "bucket", "curated_data/database=db/table=table_name/"
+            ),
+            timestamp="20230101T0000Z",
+            logger=logger,
+            s3_client=s3_client,
+        )
 
 
-def test_sql_create_table_partition():
-    result = sql_create_table_partition(
-        raw_table=QueryTable("data_products_raw", "table_raw"),
-        curated_table=QueryTable("db", "table"),
-        table_path="s3://bucket_name/curated_data/database_name=dataproduct/table_name=table_name/",
-        timestamp="20230101T000000Z",
-        metadata={
-            "TableInput": {
-                "StorageDescriptor": {
-                    "Columns": [
-                        {"Name": "foo", "Type": "string"},
-                        {"Name": "bar", "Type": None},
-                    ]
-                }
-            }
-        },
-    )
+class TestCuratedDataLoader:
+    @pytest.fixture(autouse=True)
+    def setup(self, athena_client):
+        athena_client.create_work_group(Name="data_product_workgroup")
 
-    assert dedent(result) == dedent(
-        """
-        CREATE TABLE db.table
-        WITH(
-            format='parquet',
-            write_compression = 'SNAPPY',
-            external_location='s3://bucket_name/curated_data/database_name=dataproduct/table_name=table_name/',
-            partitioned_by=ARRAY['extraction_timestamp']
-        ) AS
-        SELECT
-            CAST(NULLIF("foo",'') as VARCHAR) as "foo",CAST(NULLIF("bar",'') as None) as "bar",
-            '20230101T000000Z' as extraction_timestamp
-        FROM data_products_raw.table_raw
-        """
-    )
+    @pytest.fixture
+    def loader(self, logger, data_product_element, athena_client, glue_client):
+        return CuratedDataLoader(
+            column_metadata=[
+                {"Name": "foo", "Type": "string"},
+                {"Name": "bar", "Type": "string"},
+            ],
+            table=data_product_element.curated_data_table,
+            table_path="s3://foo",
+            athena_client=athena_client,
+            glue_client=glue_client,
+            logger=logger,
+        )
 
+    def test_create_for_new_data_product_executes_athena_query(
+        self,
+        loader,
+        athena_client,
+    ):
+        loader.create_for_new_data_product(
+            raw_data_table=QueryTable("data_products_raw", "table"),
+            extraction_timestamp="20000101T000000Z",
+        )
 
-def test_does_partition_file_exist_returns_false(s3_client):
-    logger = MagicMock(DataPlatformLogger)
+        assert len(athena_client.list_query_executions()["QueryExecutionIds"]) == 1
 
-    s3_client.create_bucket(Bucket="bucket")
+    def test_ingest_raw_data_executes_athena_query(
+        self,
+        loader,
+        athena_client,
+    ):
+        loader.ingest_raw_data(
+            raw_data_table=QueryTable("data_products_raw", "table"),
+            extraction_timestamp="20000101T000000Z",
+        )
 
-    assert not does_partition_file_exist(
-        curated_data_prefix=BucketPath(
-            "bucket", "curated_data/database=db/table=table_name/"
-        ),
-        timestamp="20230101T0000Z",
-        logger=logger,
-        s3_client=s3_client,
-    )
-
-
-def test_does_partition_file_exist_returns_true(s3_client):
-    logger = MagicMock(DataPlatformLogger)
-
-    s3_client.create_bucket(Bucket="bucket")
-    s3_client.put_object(
-        Key="curated_data/db/table_name/foo.parquet", Body="", Bucket="bucket"
-    )
-
-    assert not does_partition_file_exist(
-        curated_data_prefix=BucketPath(
-            "bucket", "curated_data/database=db/table=table_name/"
-        ),
-        timestamp="20230101T0000Z",
-        logger=logger,
-        s3_client=s3_client,
-    )
+        assert len(athena_client.list_query_executions()["QueryExecutionIds"]) == 2


### PR DESCRIPTION
This is the final part of #1310.

1. Extract CuratedDataQueryBuilder for building athena queries. These queries will change if we switch from parquet to iceberg format.

2. Extract CuratedDataLoader for executing athena queries and inspecting the glue catalog. This part will need to change if we replace athena with dbt.

3. Remove edge case logic: If the table doesn't exist, but partitioned files do, it means something has gone wrong, and we should run reload_data_product. In this case the lambda should just return a 500 error.

4. Since the number of tests has increased, I've grouped them into classes based on the thing they are testing

This leaves `create_curated_athena_tables` as a chain of if statements, so hopefully it's easier to see the different scenarios (previously we had nested ifs and a try/catch). 

This might be simplified further once we implement the ability to upload schemas, at which point we will fetch and validate schemas in athena data load, instead of inferring them from raw csv and/or parquet files.