### PR TITLE
Replace dashes with underscores in random table name

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.3] - 2023-09-27
+
+Changed the name of the temporary raw table to replace dashes with underscores.
+
 ## [2.0.2] - 2023-09-26
 
 Changed the regular expression pattern to get more specific output
@@ -22,7 +26,7 @@ container to base container
 
 `extract_table_name_from_curated_path`
 `extract_database_name_from_curated_path`
-`extract_timestamp_from_curated_path`  functions
+`extract_timestamp_from_curated_path` functions
 
 ## [2.0.0] - 2023-09-15
 

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
     "name": "daap-python-base",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -183,7 +183,7 @@ class DataProductElement:
         E.g. ('data_products_raw', 'some_element_3d95ff89-b063-484d-b510-53742d0a6a64_raw)
         """
         suffix = uuid4()
-        name = f"{self.name}_{suffix}_raw"
+        name = f"{self.name}_{suffix}_raw".replace("-", "_")
         if len(name) > MAX_IDENTIFIER_LENGTH:
             raise ValueError(f"Generated table name too long: {name}")
 

--- a/containers/daap-python-base/tests/unit/data_platform_paths_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_paths_test.py
@@ -93,26 +93,26 @@ def test_data_product_element_config(monkeypatch):
     monkeypatch.setenv("METADATA_BUCKET", "bucket")
     monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket")
 
-    element = DataProductElement.load("some-table", "data-product")
+    element = DataProductElement.load("some_table", "data_product")
 
     raw_data_table = element.raw_data_table_unique()
 
     assert re.match(
-        r"some-table_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}_raw",
+        r"some_table_[0-9a-f]{8}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{4}_[0-9a-f]{12}_raw",
         raw_data_table.name,
     )
     assert raw_data_table.database == "data_products_raw"
-    assert element.curated_data_table.name == "some-table"
-    assert element.curated_data_table.database == "data-product"
+    assert element.curated_data_table.name == "some_table"
+    assert element.curated_data_table.database == "data_product"
 
     assert element.raw_data_prefix == BucketPath(
         bucket="bucket",
-        key="raw_data/data-product/some-table/",
+        key="raw_data/data_product/some_table/",
     )
 
     assert element.curated_data_prefix == BucketPath(
         bucket="bucket",
-        key="curated_data/database_name=data-product/table_name=some-table/",
+        key="curated_data/database_name=data_product/table_name=some_table/",
     )
 
 


### PR DESCRIPTION
Athena doesn't support any other special characters: https://docs.aws.amazon.com/athena/latest/ug/tables-databases-columns-names.html#ate-table-database-and-column-names-special-characters