### PR TITLE
Ensure raw athena table is deleted on error

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Refactor infer_glue_schema
 - Remove unused argument from create_raw_athena_table
 - Ensure raw athena tables are deleted if there is an exception
+- Bump base image version
 
 ## [1.1.4] 2023-09-21
 

--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Refactor infer_glue_schema
 - Remove unused argument from create_raw_athena_table
+- Ensure raw athena tables are deleted if there is an exception
 
 ## [1.1.4] 2023-09-21
 

--- a/containers/daap-athena-load/Dockerfile
+++ b/containers/daap-athena-load/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:2.0.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:2.0.3
 
 ARG VERSION
 

--- a/containers/daap-athena-load/src/var/task/athena_load_handler.py
+++ b/containers/daap-athena-load/src/var/task/athena_load_handler.py
@@ -2,7 +2,7 @@ import os
 
 import boto3
 from create_curated_athena_table import create_curated_athena_table
-from create_raw_athena_table import create_raw_athena_table
+from create_raw_athena_table import temporary_raw_athena_table
 from data_platform_logging import DataPlatformLogger
 from data_platform_paths import QueryTable, RawDataExtraction
 from infer_glue_schema import infer_glue_schema_from_raw_csv
@@ -47,27 +47,24 @@ def handler(
     logger.info(f"{extraction.timestamp=} {data_product_element.curated_data_table=}")
 
     # Create a table of all string-type columns, to load raw data into
-    create_raw_athena_table(
-        metadata_glue=inferred_metadata.metadata_str,
+    with temporary_raw_athena_table(
+        metadata=inferred_metadata,
         logger=logger,
         glue_client=glue_client,
-    )
-
-    # Load the raw string data into the raw tables
-    # Create a curated table with proper datatypes if it doesn't exist
-    # Create a curated parquet file from the raw file
-    # Add a timestamp and insert raw data to the curated table, casting to type
-    create_curated_athena_table(
-        data_product_element=data_product_element,
-        raw_data_table=QueryTable(database=temp_database_name, name=temp_table_name),
-        extraction_timestamp=extraction.timestamp.strftime("%Y%m%dT%H%M%SZ"),
-        metadata=inferred_metadata.metadata,
-        logger=logger,
-        glue_client=glue_client,
-        s3_client=s3_client,
-        athena_client=athena_client,
-    )
-
-    # Delete the raw string tables, which are just used as an intermediary
-    glue_client.delete_table(DatabaseName=temp_database_name, Name=temp_table_name)
-    logger.info(f"removed raw table data_products_raw.{temp_table_name}")
+    ):
+        # Load the raw string data into the raw tables
+        # Create a curated table with proper datatypes if it doesn't exist
+        # Create a curated parquet file from the raw file
+        # Add a timestamp and insert raw data to the curated table, casting to type
+        create_curated_athena_table(
+            data_product_element=data_product_element,
+            raw_data_table=QueryTable(
+                database=temp_database_name, name=temp_table_name
+            ),
+            extraction_timestamp=extraction.timestamp.strftime("%Y%m%dT%H%M%SZ"),
+            metadata=inferred_metadata.metadata,
+            logger=logger,
+            glue_client=glue_client,
+            s3_client=s3_client,
+            athena_client=athena_client,
+        )

--- a/containers/daap-athena-load/src/var/task/create_raw_athena_table.py
+++ b/containers/daap-athena-load/src/var/task/create_raw_athena_table.py
@@ -1,24 +1,28 @@
+from contextlib import contextmanager
+from typing import Generator
+
 from botocore.exceptions import ClientError
 from data_platform_logging import DataPlatformLogger
+from infer_glue_schema import InferredMetadata
 
 
 def create_raw_athena_table(
-    metadata_glue: dict, logger: DataPlatformLogger, glue_client
+    metadata: InferredMetadata, logger: DataPlatformLogger, glue_client
 ) -> None:
     """
     Creates an empty athena table from the raw file pushed by
     a data producer for raw data.
     """
-    database_name = metadata_glue["DatabaseName"]
+    database_name = metadata.database_name
     create_glue_database(glue_client, database_name, logger)
 
     # Create raw data table, recreating it if necessary
-    table_name = metadata_glue["TableInput"]["Name"]
+    table_name = metadata.table_name
     try:
         glue_client.delete_table(DatabaseName=database_name, Name=table_name)
     except ClientError:
         pass
-    glue_client.create_table(**metadata_glue)
+    glue_client.create_table(**metadata.metadata_str)
     logger.info(f"created table {database_name}.{table_name}")
 
 
@@ -38,3 +42,27 @@ def create_glue_database(glue_client, database_name, logger):
         else:
             logger.error("Unexpected error: %s" % e)
             raise
+
+
+def delete_raw_athena_table(
+    metadata: InferredMetadata, logger: DataPlatformLogger, glue_client
+):
+    glue_client.delete_table(
+        DatabaseName=metadata.database_name, Name=metadata.table_name
+    )
+    logger.info(f"removed raw table {metadata.database_name}.{metadata.table_name}")
+
+
+@contextmanager
+def temporary_raw_athena_table(
+    metadata: InferredMetadata, logger: DataPlatformLogger, glue_client
+) -> Generator[None, None, None]:
+    try:
+        create_raw_athena_table(
+            metadata=metadata, logger=logger, glue_client=glue_client
+        )
+        yield
+    finally:
+        delete_raw_athena_table(
+            metadata=metadata, logger=logger, glue_client=glue_client
+        )

--- a/containers/daap-athena-load/tests/unit/athena_load_handler_test.py
+++ b/containers/daap-athena-load/tests/unit/athena_load_handler_test.py
@@ -20,7 +20,7 @@ def test_handler_does_not_error(
         "athena_load_handler.create_curated_athena_table",
         autospec=True,
     )
-    mocker.patch("athena_load_handler.create_raw_athena_table", autospec=True)
+    mocker.patch("athena_load_handler.temporary_raw_athena_table", autospec=True)
     mock_infer_schema = mocker.patch(
         "athena_load_handler.infer_glue_schema_from_raw_csv", autospec=True
     )

--- a/containers/daap-athena-load/tests/unit/create_raw_athena_table_test.py
+++ b/containers/daap-athena-load/tests/unit/create_raw_athena_table_test.py
@@ -1,17 +1,20 @@
-from unittest.mock import create_autospec
-
 import create_raw_athena_table
-from data_platform_logging import DataPlatformLogger
+import pytest
+from botocore.exceptions import ClientError
+from infer_glue_schema import InferredMetadata
 
 
-def test_create_raw_athena_table(glue_client):
-    logger = create_autospec(DataPlatformLogger)
-
+def test_create_raw_athena_table(glue_client, logger):
     create_raw_athena_table.create_raw_athena_table(
-        metadata_glue={
-            "TableInput": {"Name": "table"},
-            "DatabaseName": "data_products_raw",
-        },
+        metadata=InferredMetadata(
+            {
+                "TableInput": {
+                    "Name": "table",
+                    "StorageDescriptor": {"Columns": []},
+                },
+                "DatabaseName": "data_products_raw",
+            }
+        ),
         logger=logger,
         glue_client=glue_client,
     )
@@ -20,22 +23,48 @@ def test_create_raw_athena_table(glue_client):
     assert table["Table"]["VersionId"] == "1"
 
 
-def test_create_raw_athena_table_recreates_the_db(glue_client):
-    logger = create_autospec(DataPlatformLogger)
-
+def test_create_raw_athena_table_recreates_the_db(glue_client, logger):
     glue_client.create_database(DatabaseInput={"Name": "data_products_raw"})
     glue_client.create_table(
         TableInput={"Name": "table"}, DatabaseName="data_products_raw"
     )
 
     create_raw_athena_table.create_raw_athena_table(
-        metadata_glue={
-            "TableInput": {"Name": "table"},
-            "DatabaseName": "data_products_raw",
-        },
+        metadata=InferredMetadata(
+            {
+                "TableInput": {
+                    "Name": "table",
+                    "StorageDescriptor": {"Columns": []},
+                },
+                "DatabaseName": "data_products_raw",
+            }
+        ),
         logger=logger,
         glue_client=glue_client,
     )
 
     table = glue_client.get_table(Name="table", DatabaseName="data_products_raw")
     assert table["Table"]["VersionId"] == "1"
+
+
+def test_context_manager_creates_and_deletes_table(glue_client, logger):
+    with create_raw_athena_table.temporary_raw_athena_table(
+        metadata=InferredMetadata(
+            {
+                "TableInput": {
+                    "Name": "temporary",
+                    "StorageDescriptor": {"Columns": []},
+                },
+                "DatabaseName": "data_products_raw",
+            }
+        ),
+        logger=logger,
+        glue_client=glue_client,
+    ):
+        table = glue_client.get_table(
+            Name="temporary", DatabaseName="data_products_raw"
+        )
+        assert table["Table"]["VersionId"] == "1"
+
+    with pytest.raises(ClientError):
+        glue_client.get_table(Name="temporary", DatabaseName="data_products_raw")


### PR DESCRIPTION
Since we now use a unique name for this table, we should be careful to always delete it, otherwise we will have resources accumulate in AWS.

(Part of #1310)