### PR TITLE
Skip duplicate actions

### DIFF
--- a/.github/workflows/test-daap.yml
+++ b/.github/workflows/test-daap.yml
@@ -8,6 +8,8 @@ on: # yamllint disable-line rule:truthy
     paths:
       - containers/daap-*/**
   push:
+    branches:
+      - main
     paths:
       - containers/daap-*/**
 


### PR DESCRIPTION
Currently this workflow triggers twice, once for PR, once for push.

We can avoid this by restricting the `push` trigger to the main branch. This matches the `containers.yaml` workflow.