### PR TITLE
Update load handler to latest base image

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.2.3] 2023-10-18
+
+### Changed
+
+- Base image to daap-python-base:3.2.0
+
 ## [1.2.2] 2023-10-11
 
 ### Changed

--- a/containers/daap-athena-load/Dockerfile
+++ b/containers/daap-athena-load/Dockerfile
@@ -1,5 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:2.2.0
-
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:3.2.0
 ARG VERSION
 
 ENV VERSION="${VERSION}"

--- a/containers/daap-athena-load/config.json
+++ b/containers/daap-athena-load/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-athena-load",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-athena-load/src/var/task/create_curated_athena_table.py
+++ b/containers/daap-athena-load/src/var/task/create_curated_athena_table.py
@@ -316,7 +316,7 @@ def does_partition_file_exist(
             " doesn't exist and will be created"
         )
 
-    ts_exists = any(f"extraction_timestamp={timestamp}" in i["Key"] for i in response)
-    logger.info(f"extraction_timestamp={timestamp} exists = {ts_exists}")
+    ts_exists = any(f"load_timestamp={timestamp}" in i["Key"] for i in response)
+    logger.info(f"load_timestamp={timestamp} exists = {ts_exists}")
 
     return ts_exists

--- a/containers/daap-athena-load/tests/unit/athena_load_handler_test.py
+++ b/containers/daap-athena-load/tests/unit/athena_load_handler_test.py
@@ -1,6 +1,7 @@
 from unittest.mock import MagicMock
 
 import athena_load_handler
+from data_platform_paths import get_metadata_bucket
 from infer_glue_schema import InferredMetadata
 from moto import mock_sts
 
@@ -13,7 +14,10 @@ def test_handler_does_not_error(
     Test the handler doesn't error when passed valid input
     """
     bucket_name = "bucket"
-    key = "raw_data/data_product/table/extraction_timestamp=20230101T000000Z/file.csv"
+    key = "raw/data_product/table/load_timestamp=20230101T000000Z/file.csv"
+
+    s3_client.create_bucket(Bucket=get_metadata_bucket())
+    mocker.patch("data_platform_paths.s3", s3_client)
 
     # Patch all the helper methods to do nothing
     mocker.patch(

--- a/containers/daap-athena-load/tests/unit/conftest.py
+++ b/containers/daap-athena-load/tests/unit/conftest.py
@@ -22,7 +22,7 @@ os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
 os.environ["AWS_SECURITY_TOKEN"] = "testing"
 os.environ["AWS_SESSION_TOKEN"] = "testing"
 os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-os.environ["BUCKET_NAME"] = "test"
+os.environ["BUCKET_NAME"] = "bucket"
 
 
 @dataclass
@@ -71,9 +71,21 @@ def athena_client():
         yield client
 
 
+@pytest.fixture(autouse=True)
+def data_bucket(s3_client):
+    os.environ["RAW_DATA_BUCKET"] = "data"
+    os.environ["CURATED_DATA_BUCKET"] = "data"
+    s3_client.create_bucket(Bucket="data")
+
+
+@pytest.fixture(autouse=True)
+def metadata_bucket(s3_client):
+    os.environ["METADATA_BUCKET"] = "meta"
+    s3_client.create_bucket(Bucket="meta")
+
+
 @pytest.fixture
-def data_product_element(monkeypatch):
-    monkeypatch.setenv("BUCKET_NAME", "bucket")
+def data_product_element():
     return DataProductElement.load(element_name="foo", data_product_name="bar")
 
 

--- a/containers/daap-athena-load/tests/unit/conftest.py
+++ b/containers/daap-athena-load/tests/unit/conftest.py
@@ -7,6 +7,13 @@ import boto3
 import pytest
 from moto import mock_athena, mock_glue, mock_s3
 
+os.environ["AWS_ACCESS_KEY_ID"] = "testing"
+os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
+os.environ["AWS_SECURITY_TOKEN"] = "testing"
+os.environ["AWS_SESSION_TOKEN"] = "testing"
+os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
+os.environ["BUCKET_NAME"] = "bucket"
+
 sys.path.append(join(dirname(__file__), "../", "../", "src", "var", "task"))
 sys.path.append(
     join(
@@ -16,13 +23,6 @@ sys.path.append(
 
 from data_platform_logging import DataPlatformLogger  # noqa E402
 from data_platform_paths import DataProductElement  # noqa E402
-
-os.environ["AWS_ACCESS_KEY_ID"] = "testing"
-os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
-os.environ["AWS_SECURITY_TOKEN"] = "testing"
-os.environ["AWS_SESSION_TOKEN"] = "testing"
-os.environ["AWS_DEFAULT_REGION"] = "us-east-1"
-os.environ["BUCKET_NAME"] = "bucket"
 
 
 @dataclass

--- a/containers/daap-athena-load/tests/unit/create_curated_athena_table_test.py
+++ b/containers/daap-athena-load/tests/unit/create_curated_athena_table_test.py
@@ -13,8 +13,7 @@ from data_platform_paths import BucketPath, QueryTable
 
 class TestCreateCuratedAthenaTable:
     @pytest.fixture(autouse=True)
-    def setup(self, s3_client, athena_client):
-        s3_client.create_bucket(Bucket="bucket")
+    def setup(self, athena_client):
         athena_client.create_work_group(Name="data_product_workgroup")
 
     @pytest.fixture
@@ -80,9 +79,9 @@ class TestCreateCuratedAthenaTable:
             DatabaseName=data_product_element.curated_data_table.database,
         )
         s3_client.put_object(
-            Bucket="bucket",
+            Bucket="data",
             Key=data_product_element.curated_data_prefix.key
-            + "extraction_timestamp=20230101T000000Z/partition.parquet",
+            + "load_timestamp=20230101T000000Z/partition.parquet",
             Body="",
         )
 
@@ -100,7 +99,7 @@ class TestCreateCuratedAthenaTable:
         function_kwargs,
     ):
         s3_client.put_object(
-            Bucket="bucket",
+            Bucket="data",
             Key=data_product_element.curated_data_prefix.key + "partition.parquet",
             Body="",
         )
@@ -174,14 +173,14 @@ class TestCuratedDataQueryBuilder:
 
 class TestDoesPartitionFileExist:
     def test_returns_true(self, s3_client, logger):
-        s3_client.create_bucket(Bucket="bucket")
+        s3_client.create_bucket(Bucket="test")
         s3_client.put_object(
-            Key="curated_data/db/table_name/foo.parquet", Body="", Bucket="bucket"
+            Key="curated_data/db/table_name/foo.parquet", Body="", Bucket="test"
         )
 
         assert not does_partition_file_exist(
             curated_data_prefix=BucketPath(
-                "bucket", "curated_data/database=db/table=table_name/"
+                "test", "curated_data/database=db/table=table_name/"
             ),
             timestamp="20230101T0000Z",
             logger=logger,
@@ -189,11 +188,11 @@ class TestDoesPartitionFileExist:
         )
 
     def test_returns_false(self, s3_client, logger):
-        s3_client.create_bucket(Bucket="bucket")
+        s3_client.create_bucket(Bucket="test")
 
         assert not does_partition_file_exist(
             curated_data_prefix=BucketPath(
-                "bucket", "curated_data/database=db/table=table_name/"
+                "test", "curated_data/database=db/table=table_name/"
             ),
             timestamp="20230101T0000Z",
             logger=logger,


### PR DESCRIPTION
This updates the load handler to pick up the latest base image that has Murdo's changes to the path conventions.

Tested locally and it seems to work with the new bucket structure.

```
curl "http://localhost:9000/2015-03-31/functions/function/invocations" -d '{"detail": {"bucket": {"name": "data-development20231011135451999500000005"}, "object": {"key": "raw/example_prison_data_product/v1.0/testing/load_timestamp=20231012T105202Z/16c81cf4-cec7-4a2d-a8b2-6768fb4d5b2b.csv"}}}'
```