### PR TITLE
Update to the latest base image in create metadata lambda

### DIFF
--- a/containers/daap-create-metadata/CHANGELOG.md
+++ b/containers/daap-create-metadata/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.7] 2023-10-10
+
+### Changed
+
+- Bump base image to 2.2.0
+
 ## [1.0.6] 2023-10-03
 
 ### Changed

--- a/containers/daap-create-metadata/Dockerfile
+++ b/containers/daap-create-metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:1.0.2
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:2.2.0
 
 ARG VERSION
 


### PR DESCRIPTION
This is required for the s3 bucket logging to work correctly.

Once this new version is published I should be able to retest https://github.com/ministryofjustice/modernisation-platform-environments/pull/3588