### PR TITLE
:sparkles: Support file extension preservation in python base 

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.3.0] - 2023-10-09
+
+### Changed
+
+- Updated `element.raw_data_path` to accept the `file_extension` string type
+  input parameter used to pass to `element.extraction_instance`
+- Updated `element.extraction_instance` to accept the `file_extension`
+  string type input parameter used to build a filepath
+  with the file extension
+- Updated `test_infer_schema_from_csv()` to define the `file_extension`
+  string type variable required to pass
+  to `data_product_element.raw_data_path()`
+- Updated `test_data_product_element_raw_data_path()` to define the
+  `file_extension`string type variable required to pass
+  to `element.raw_data_path()`
+- Updated `test_data_product_element_raw_data_path()`
+  call to `element.raw_data_path()` now uses key word arguments
+- Updated `test_extraction_config()`to define the `file_extension`
+  string type variable required to pass to `element.extraction_instance()`
+  to generate the file path
+
 ## [3.2.0] - 2023-10-05
 
 ### Added

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "3.2.0",
+  "version": "3.3.0",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -273,16 +273,18 @@ class DataProductElement:
         """
         return QueryTable(database=self.data_product.name, name=self.name)
 
-    def raw_data_path(self, timestamp: datetime, uuid_value: UUID) -> BucketPath:
+    def raw_data_path(
+        self, timestamp: datetime, uuid_value: UUID, file_extension: str
+    ) -> BucketPath:
         """
         Path to the raw data extracted at a particular timestamp.
         E.g. raw_data/my-data-product/some-element/load_timestamp=
-             20230101T000000Z/3d95ff89-b063-484d-b510-53742d0a6a64
+             20230101T000000Z/3d95ff89-b063-484d-b510-53742d0a6a64.csv
         """
-        return self.extraction_instance(timestamp, uuid_value).path
+        return self.extraction_instance(timestamp, uuid_value, file_extension).path
 
     def extraction_instance(
-        self, timestamp: datetime, uuid_value: UUID
+        self, timestamp: datetime, uuid_value: UUID, file_extension: str
     ) -> RawDataExtraction:
         """
         Instance of the data extraction identified by uuid_value and timestamp.
@@ -294,7 +296,7 @@ class DataProductElement:
             key=os.path.join(
                 self.raw_data_prefix.key,
                 f"load_timestamp={amz_date}",
-                str(uuid_value),
+                f"{str(uuid_value)}{file_extension}",
             ),
         )
 

--- a/containers/daap-python-base/tests/unit/data_platform_paths_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_paths_test.py
@@ -150,6 +150,7 @@ def test_data_product_config_get_element():
 def test_data_product_element_raw_data_path():
     uuid_value = uuid.uuid4()
     timestamp = datetime(2023, 9, 5, 16, 53)
+    file_extension = ".csv"
 
     with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
         config = DataProductConfig(
@@ -161,11 +162,13 @@ def test_data_product_element_raw_data_path():
         )
         element = config.element("some-table")
 
-        path = element.raw_data_path(timestamp=timestamp, uuid_value=uuid_value)
+        path = element.raw_data_path(
+            timestamp=timestamp, uuid_value=uuid_value, file_extension=file_extension
+        )
 
         assert path == BucketPath(
             bucket="raw",
-            key=f"raw/my-database/v1.0/some-table/load_timestamp=20230905T165300Z/{uuid_value}",
+            key=f"raw/my-database/v1.0/some-table/load_timestamp=20230905T165300Z/{uuid_value}{file_extension}",
         )
 
 
@@ -190,6 +193,7 @@ def test_data_product_config_metadata_path():
 def test_extraction_config():
     uuid_value = uuid.uuid4()
     timestamp = datetime(2023, 9, 5, 16, 53)
+    file_extension = ".csv"
 
     with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
         config = DataProductConfig(
@@ -203,13 +207,13 @@ def test_extraction_config():
         element = config.element("some-table")
 
         extraction = element.extraction_instance(
-            uuid_value=uuid_value, timestamp=timestamp
+            uuid_value=uuid_value, timestamp=timestamp, file_extension=file_extension
         )
 
         assert extraction.timestamp == timestamp
         assert extraction.path == BucketPath(
             bucket="raw",
-            key=f"raw/my-database/v1.0/some-table/load_timestamp=20230905T165300Z/{uuid_value}",
+            key=f"raw/my-database/v1.0/some-table/load_timestamp=20230905T165300Z/{uuid_value}{file_extension}",
         )
 
 

--- a/containers/daap-python-base/tests/unit/infer_glue_schema_test.py
+++ b/containers/daap-python-base/tests/unit/infer_glue_schema_test.py
@@ -49,7 +49,11 @@ def test_csv_sample(test_input, expected, sample_size_in_bytes, logger):
 
 def test_infer_schema_from_csv(region_name, s3_client, logger, data_product_element):
     uuid_value = uuid4()
-    path = data_product_element.raw_data_path(datetime(2023, 1, 1), uuid_value)
+    timestamp = datetime(2023, 1, 1)
+    file_extension = ".csv"
+    path = data_product_element.raw_data_path(
+        timestamp=timestamp, uuid_value=uuid_value, file_extension=file_extension
+    )
 
     s3_client.create_bucket(
         Bucket=os.environ["RAW_DATA_BUCKET"],


### PR DESCRIPTION
I have separated out the changes to preserve file extensions into two pr's, this is for the required python base changes.

