### PR TITLE
🧰 Pass through Github vars into dev container if they're set

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -16,6 +16,10 @@
     "./features/src/sast-tools": {},
     "./features/src/terraform-tools": {}
   },
+  "containerEnv": {
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
+    "GITHUB_USER": "${localEnv:GITHUB_USER}"
+  },
   "overrideFeatureInstallOrder": [
     "ghcr.io/devcontainers/features/common-utils",
     "./features/src/base"


### PR DESCRIPTION
This will map the host GITHUB vars into the dev container if they're set. They can be overwritten in the container if needed.