### PR TITLE
Dpl 1875 refactor create metadata for new base image

### DIFF
--- a/containers/daap-create-metadata/CHANGELOG.md
+++ b/containers/daap-create-metadata/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] 2023-10-13
+
+### Changed
+
+- Bump base image to 4.0.0. This includes refactoring of the handler
+  to use the new `DataProductMetadata` methods in data_product_metadata.
+
 ## [1.0.7] 2023-10-11
 
 ### Changed

--- a/containers/daap-create-metadata/Dockerfile
+++ b/containers/daap-create-metadata/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:2.2.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:4.0.0
 
 ARG VERSION
 

--- a/containers/daap-create-metadata/config.json
+++ b/containers/daap-create-metadata/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-create-metadata",
-  "version": "1.0.7",
+  "version": "2.0.0",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-create-metadata/tests/unit/create_metadata_test.py
+++ b/containers/daap-create-metadata/tests/unit/create_metadata_test.py
@@ -28,18 +28,19 @@ def test_existing_metadata_definition_fail(fake_event, fake_context):
 
 def test_metadata_creation_pass(fake_event, fake_context):
     with patch("create_metadata.DataProductMetadata") as mock_metadata:
-        mock_metadata.return_value.metadata_exists = False
-        mock_metadata.return_value.valid_metadata = True
+        mock_metadata.return_value.exists = False
+        mock_metadata.return_value.valid = True
+        with patch("create_metadata.DataProductConfig") as mock_key:
+            mock_key.return_value.metadata_path.key = "somekey"
+            response = create_metadata.handler(event=fake_event, context=fake_context)
 
-        response = create_metadata.handler(event=fake_event, context=fake_context)
-
-        assert response["statusCode"] == HTTPStatus.CREATED
+            assert response["statusCode"] == HTTPStatus.CREATED
 
 
 def test_metadata_validation_fail(fake_event, fake_context):
     with patch("create_metadata.DataProductMetadata") as mock_metadata:
-        mock_metadata.return_value.metadata_exists = False
-        mock_metadata.return_value.valid_metadata = False
+        mock_metadata.return_value.exists = False
+        mock_metadata.return_value.valid = False
         mock_metadata.return_value.error_traceback = "testing"
 
         response = create_metadata.handler(event=fake_event, context=fake_context)
@@ -54,8 +55,8 @@ def test_metadata_validation_fail(fake_event, fake_context):
 @pytest.mark.parametrize("method", [HTTPMethod.GET, HTTPMethod.PUT, HTTPMethod.DELETE])
 def test_http_method_fail(fake_event, fake_context, method):
     with patch("create_metadata.DataProductMetadata") as mock_metadata:
-        mock_metadata.return_value.metadata_exists = False
-        mock_metadata.return_value.valid_metadata = True
+        mock_metadata.return_value.exists = False
+        mock_metadata.return_value.valid = True
 
         response = create_metadata.handler(event=fake_event, context=fake_context)
 


### PR DESCRIPTION
bump base image in `daap-create-metadata` and refactor handler and tests to work with new `DataProductMetadata` class