### PR TITLE
🔥 Remove Analytical Platform Team

### DIFF
--- a/.github/workflows/platform-pagerduty-rota-to-slack.yml
+++ b/.github/workflows/platform-pagerduty-rota-to-slack.yml
@@ -20,8 +20,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - pagerduty-schedule-id: P2IZGH3 # Analytical Platform
-            slack-channel: C04M8224WCV # data-platform-apps-and-tools
           - pagerduty-schedule-id: POE95CC # Data Platform
             slack-channel: C04M8224WCV # data-platform-apps-and-tools
     steps:

--- a/terraform/pagerduty/business-services.tf
+++ b/terraform/pagerduty/business-services.tf
@@ -1,24 +1,6 @@
 locals {
   business_services = [
     {
-      name             = "Analytical Platform"
-      description      = "To support data-driven decision-making by developing the best environment for high quality use of data"
-      point_of_contact = "#ask-analytical-platform"
-      team             = module.teams["Analytical Platform"].id
-      supporting_services = [
-        {
-          name = "Cloud Platform"
-          id   = data.pagerduty_business_service.cloud_platform.id
-          type = data.pagerduty_business_service.cloud_platform.type
-        },
-        {
-          name = "Modernisation Platform"
-          id   = data.pagerduty_business_service.modernisation_platform.id
-          type = data.pagerduty_business_service.modernisation_platform.type
-        }
-      ]
-    },
-    {
       name             = "Data Platform"
       description      = "Connecting the right people, systems, and data to improve justice outcomes"
       point_of_contact = "#ask-data-platform"

--- a/terraform/pagerduty/escalation-policies.tf
+++ b/terraform/pagerduty/escalation-policies.tf
@@ -1,23 +1,6 @@
 locals {
   escalation_policies = [
     {
-      name        = "Analytical Platform"
-      description = "Escalation policy for the Analytical Platform team"
-      team        = module.teams["Analytical Platform"].id
-      num_loops   = 2
-      rules = [
-        {
-          escalation_delay_in_minutes = 15
-          targets = [
-            {
-              type = "schedule_reference"
-              id   = module.schedules["Analytical Platform"].id
-            }
-          ]
-        }
-      ]
-    },
-    {
       name        = "Data Platform"
       description = "Escalation policy for the Data Platform team"
       team        = module.teams["Data Platform"].id

--- a/terraform/pagerduty/modules/service/technical/main.tf
+++ b/terraform/pagerduty/modules/service/technical/main.tf
@@ -78,6 +78,8 @@ resource "pagerduty_service_integration" "cloudwatch" {
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_cloudwatch_integration_key" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   count = var.enable_cloudwatch_integration ? 1 : 0
 
   name       = "${local.secretsmanager_prefix}/cloudwatch"
@@ -109,6 +111,8 @@ resource "pagerduty_service_integration" "cloudtrail" {
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_cloudtrail_integration_key" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   count = var.enable_cloudtrail_integration ? 1 : 0
 
   name       = "${local.secretsmanager_prefix}/cloudtrail"
@@ -140,6 +144,8 @@ resource "pagerduty_service_integration" "guardduty" {
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_guardduty_integration_key" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   count = var.enable_guardduty_integration ? 1 : 0
 
   name       = "${local.secretsmanager_prefix}/guardduty"
@@ -170,6 +176,8 @@ resource "pagerduty_service_integration" "health_dashboard" {
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_health_dashboard_integration_key" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   count = var.enable_health_dashboard_integration ? 1 : 0
 
   name       = "${local.secretsmanager_prefix}/health-dashboard"
@@ -201,6 +209,8 @@ resource "pagerduty_service_integration" "security_hub" {
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_security_hub_integration_key" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   count = var.enable_security_hub_integration ? 1 : 0
 
   name       = "${local.secretsmanager_prefix}/security-hub"
@@ -233,6 +243,8 @@ resource "pagerduty_service_integration" "email" {
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_email_integration_key" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   count = var.enable_email_integration ? 1 : 0
 
   name       = "${local.secretsmanager_prefix}/email"
@@ -263,6 +275,8 @@ resource "pagerduty_service_integration" "airflow" {
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_airflow_integration_key" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   count = var.enable_airflow_integration ? 1 : 0
 
   name       = "${local.secretsmanager_prefix}/airflow"
@@ -294,6 +308,8 @@ resource "pagerduty_service_integration" "alert_manager" {
 }
 
 resource "aws_secretsmanager_secret" "pagerduty_alert_manager_integration_key" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   count = var.enable_alert_manager_integration ? 1 : 0
 
   name       = "${local.secretsmanager_prefix}/alert-manager"

--- a/terraform/pagerduty/schedules.tf
+++ b/terraform/pagerduty/schedules.tf
@@ -1,60 +1,6 @@
 locals {
   schedules = [
     {
-      name = "Analytical Platform"
-      team = module.teams["Analytical Platform"].id
-      layers = [
-        {
-          name                         = "Daily Support Rota"
-          start                        = "2023-03-27T09:00:00Z"
-          rotation_virtual_start       = "2023-03-28T09:00:00+01:00"
-          rotation_turn_length_seconds = 86400
-          users = [
-            module.users["julia.lawrence@digital.justice.gov.uk"].id,
-            module.users["richard.baguley@digital.justice.gov.uk"].id,
-            module.users["thomas.webber@digital.justice.gov.uk"].id,
-            module.users["brian.ellwood@digital.justice.gov.uk"].id,
-            module.users["michael.collins@digital.justice.gov.uk"].id,
-            module.users["yikang.mao@justice.gov.uk"].id,
-            module.users["gary.henderson@digital.justice.gov.uk"].id,
-            module.users["mitch.dawson@digital.justice.gov.uk"].id
-          ]
-          restrictions = [
-            {
-              type              = "weekly_restriction"
-              start_day_of_week = 1
-              start_time_of_day = "09:00:00"
-              duration_seconds  = 28800
-            },
-            {
-              type              = "weekly_restriction"
-              start_day_of_week = 2
-              start_time_of_day = "09:00:00"
-              duration_seconds  = 28800
-            },
-            {
-              type              = "weekly_restriction"
-              start_day_of_week = 3
-              start_time_of_day = "09:00:00"
-              duration_seconds  = 28800
-            },
-            {
-              type              = "weekly_restriction"
-              start_day_of_week = 4
-              start_time_of_day = "09:00:00"
-              duration_seconds  = 28800
-            },
-            {
-              type              = "weekly_restriction"
-              start_day_of_week = 5
-              start_time_of_day = "09:00:00"
-              duration_seconds  = 28800
-            }
-          ]
-        }
-      ]
-    },
-    {
       name = "Data Platform"
       team = module.teams["Data Platform"].id
       layers = [
@@ -65,9 +11,16 @@ locals {
           rotation_turn_length_seconds = 86400
           users = [
             module.users["jacob.woffenden@digital.justice.gov.uk"].id,
-            module.users["emma.terry@digital.justice.gov.uk"].id,
             module.users["julia.lawrence@digital.justice.gov.uk"].id,
             module.users["richard.baguley@digital.justice.gov.uk"].id,
+            module.users["emma.terry@digital.justice.gov.uk"].id,
+            module.users["brian.ellwood@digital.justice.gov.uk"].id,
+            module.users["michael.collins@digital.justice.gov.uk"].id,
+            module.users["yikang.mao@justice.gov.uk"].id,
+            module.users["gary.henderson@digital.justice.gov.uk"].id,
+            module.users["alex.vilela@digital.justice.gov.uk"].id,
+            module.users["jacob.hamblin-pyke@digital.justice.gov.uk"].id,
+            module.users["murad.ali@digital.justice.gov.uk"].id
           ]
           restrictions = [
             {

--- a/terraform/pagerduty/teams.tf
+++ b/terraform/pagerduty/teams.tf
@@ -1,22 +1,6 @@
 locals {
   teams = [
     {
-      name = "Analytical Platform"
-      managers = [
-        module.users["jacob.woffenden@digital.justice.gov.uk"].id,
-        module.users["julia.lawrence@digital.justice.gov.uk"].id,
-        module.users["richard.baguley@digital.justice.gov.uk"].id
-      ]
-      responders = [
-        module.users["thomas.webber@digital.justice.gov.uk"].id,
-        module.users["brian.ellwood@digital.justice.gov.uk"].id,
-        module.users["michael.collins@digital.justice.gov.uk"].id,
-        module.users["yikang.mao@justice.gov.uk"].id,
-        module.users["gary.henderson@digital.justice.gov.uk"].id,
-        module.users["mitch.dawson@digital.justice.gov.uk"].id
-      ]
-    },
-    {
       name = "Data Platform"
       managers = [
         module.users["jacob.woffenden@digital.justice.gov.uk"].id,
@@ -24,7 +8,14 @@ locals {
         module.users["richard.baguley@digital.justice.gov.uk"].id
       ]
       responders = [
-        module.users["emma.terry@digital.justice.gov.uk"].id
+        module.users["emma.terry@digital.justice.gov.uk"].id,
+        module.users["brian.ellwood@digital.justice.gov.uk"].id,
+        module.users["michael.collins@digital.justice.gov.uk"].id,
+        module.users["yikang.mao@justice.gov.uk"].id,
+        module.users["gary.henderson@digital.justice.gov.uk"].id,
+        module.users["alex.vilela@digital.justice.gov.uk"].id,
+        module.users["jacob.hamblin-pyke@digital.justice.gov.uk"].id,
+        module.users["murad.ali@digital.justice.gov.uk"].id
       ]
     }
   ]

--- a/terraform/pagerduty/technical-services.tf
+++ b/terraform/pagerduty/technical-services.tf
@@ -3,7 +3,7 @@ locals {
     {
       name              = "Analytical Platform"
       description       = "Generic alerts for the Analytical Platform"
-      escalation_policy = module.escalation_policies["Analytical Platform"].id
+      escalation_policy = module.escalation_policies["Data Platform"].id
       auto_pause_notifications_parameters = [
         {
           enabled = true

--- a/terraform/pagerduty/users.tf
+++ b/terraform/pagerduty/users.tf
@@ -17,10 +17,6 @@ locals {
       email = "richard.baguley@digital.justice.gov.uk"
     },
     {
-      name  = "Tom Webber"
-      email = "thomas.webber@digital.justice.gov.uk"
-    },
-    {
       name  = "Brian Ellwood"
       email = "brian.ellwood@digital.justice.gov.uk"
     },
@@ -37,8 +33,16 @@ locals {
       email = "gary.henderson@digital.justice.gov.uk"
     },
     {
-      name  = "Mitch Dawson"
-      email = "mitch.dawson@digital.justice.gov.uk"
+      name  = "Alex Vilela"
+      email = "alex.vilela@digital.justice.gov.uk"
+    },
+    {
+      name  = "Jacob Hamblin-Pyke"
+      email = "jacob.hamblin-pyke@digital.justice.gov.uk"
+    },
+    {
+      name  = "Murad Ali"
+      email = "murad.ali@digital.justice.gov.uk"
     }
   ]
 }


### PR DESCRIPTION
Resolves #1885

- Removes team members that are no longer with us 😢 
- Adds team members that have joined us 🎉 
- Consolidates Analytical Platform into Data Platform #OneTeamOneDream
- Updates GitHub automation to reflect team changes ♻️ 
- Addresses static analysis output for technical-service module 🛂

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>