### PR TITLE
create-a-derived-table OIDC role

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -138,6 +138,17 @@ updates:
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
   - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform/baseline"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+  - package-ecosystem: "terraform"
     directory: "terraform/aws/analytical-platform-data-engineering-production/10ds"
     schedule:
       interval: "daily"
@@ -161,6 +172,28 @@ updates:
       - "ministryofjustice/data-platform-core-infra"
   - package-ecosystem: "terraform"
     directory: "terraform/aws/analytical-platform-data-production/artifact-repos"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-data-production/control-panel-message-broker"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-data-production/create-a-derived-table"
     schedule:
       interval: "daily"
       time: "09:00"
@@ -248,29 +281,18 @@ updates:
     reviewers:
       - "ministryofjustice/data-platform-core-infra"
   - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-production/cluster"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform/baseline"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/data-platform-core-infra"
-  - package-ecosystem: "terraform"
     directory: "terraform/aws/analytical-platform/oidc"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-core-infra"
+  - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-production/cluster"
     schedule:
       interval: "daily"
       time: "09:00"

--- a/.github/path-filter/terraform.yml
+++ b/.github/path-filter/terraform.yml
@@ -7,6 +7,7 @@ aws-analytical-platform-baseline: terraform/aws/analytical-platform/baseline/**
 aws-analytical-platform-data-engineering-production-10ds: terraform/aws/analytical-platform-data-engineering-production/10ds/**
 aws-analytical-platform-data-production-airflow: terraform/aws/analytical-platform-data-production/airflow/**
 aws-analytical-platform-data-production-artifact-repos: terraform/aws/analytical-platform-data-production/artifact-repos/**
+aws-analytical-platform-data-production-control-panel-message-broker: terraform/aws/analytical-platform-data-production/control-panel-message-broker/**
 aws-analytical-platform-data-production-create-a-derived-table: terraform/aws/analytical-platform-data-production/create-a-derived-table/**
 aws-analytical-platform-data-production-kops: terraform/aws/analytical-platform-data-production/kops/**
 aws-analytical-platform-data-production-rds-s3-exports: terraform/aws/analytical-platform-data-production/rds-s3-exports/**

--- a/.github/path-filter/terraform.yml
+++ b/.github/path-filter/terraform.yml
@@ -3,20 +3,20 @@
 # bash scripts/path-filter/configuration-generator.sh terraform
 
 application-migration: terraform/application-migration/**
+aws-analytical-platform-baseline: terraform/aws/analytical-platform/baseline/**
 aws-analytical-platform-data-engineering-production-10ds: terraform/aws/analytical-platform-data-engineering-production/10ds/**
 aws-analytical-platform-data-production-airflow: terraform/aws/analytical-platform-data-production/airflow/**
 aws-analytical-platform-data-production-artifact-repos: terraform/aws/analytical-platform-data-production/artifact-repos/**
+aws-analytical-platform-data-production-create-a-derived-table: terraform/aws/analytical-platform-data-production/create-a-derived-table/**
 aws-analytical-platform-data-production-kops: terraform/aws/analytical-platform-data-production/kops/**
-aws-analytical-platform-data-production-control-panel-message-broker: terraform/aws/analytical-platform-data-production/control-panel-message-broker/**
 aws-analytical-platform-data-production-rds-s3-exports: terraform/aws/analytical-platform-data-production/rds-s3-exports/**
 aws-analytical-platform-data-production-s3-glue-crawler: terraform/aws/analytical-platform-data-production/s3-glue-crawler/**
 aws-analytical-platform-development-cluster: terraform/aws/analytical-platform-development/cluster/**
 aws-analytical-platform-development-control-panel-message-broker: terraform/aws/analytical-platform-development/control-panel-message-broker/**
 aws-analytical-platform-development-open-metadata: terraform/aws/analytical-platform-development/open-metadata/**
 aws-analytical-platform-management-production-cluster: terraform/aws/analytical-platform-management-production/cluster/**
-aws-analytical-platform-production-cluster: terraform/aws/analytical-platform-production/cluster/**
-aws-analytical-platform-baseline: terraform/aws/analytical-platform/baseline/**
 aws-analytical-platform-oidc: terraform/aws/analytical-platform/oidc/**
+aws-analytical-platform-production-cluster: terraform/aws/analytical-platform-production/cluster/**
 github-application-migration: terraform/github/application-migration/**
 github-data-platform: terraform/github/data-platform/**
 pagerduty: terraform/pagerduty/**

--- a/terraform/aws/analytical-platform-data-production/control-panel-message-broker/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/control-panel-message-broker/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.11.0"
+  constraints = "5.11.0"
+  hashes = [
+    "h1:euyha7/tuEI2q8/KQP7fB3EGA4KydEB26b/I1SxJ8xI=",
+    "zh:2913af44f9b584f756e5548d5ddc5a251c6d68a7fcd7c41d1418a800a94ef113",
+    "zh:31d2bfa84608b74ff5896f41b09e5927d7c37d18875277a51dcd75a1fea3f909",
+    "zh:8538ff18e3b4822178e793f06764efdbb84c62227c1051af7d2409ab7be37bfc",
+    "zh:8a9295e623327613fc02a6994e73c61b9d0d195bf6fabdb31ee9fd0e6778f62b",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a65877248951eadf0d16a3260e85f6b178645da7f1897bc7bda6f12fdbec8e47",
+    "zh:a70772851e2c87cc1e10c35389718a544746adc4acbbed129243c0972c367fc6",
+    "zh:b10ca631318f8d1d9a2baa318139bc9e545e51efaf677afece173badce75b44c",
+    "zh:ca2a5698c33158549fa084ad601610eae94498cba445458391b507da22355402",
+    "zh:cdbfc4d64161561bfbcaee5d9b078077ed986131a1eab32ff30e71be09037eec",
+    "zh:ce499f93835bf3d28c13ba98a0a220ff541a827fb400fa931601a375b907b56d",
+    "zh:da6af610e66e96280a299071a698568b505c2456bb15c906304d6f39578c72e3",
+    "zh:e42714e085126c10d8f29664143f97d771b6cc6887d27cdf6c4007ab12af4646",
+    "zh:e86dd0c561c73512acba69f55041adfc04d0467f592f52337a7ac600fbc93680",
+    "zh:f5da95bbd44809534c6678e9b1ae0b390331a5619f2ae353c6b88e96ae855cc0",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.5.1"
+  constraints = "3.5.1"
+  hashes = [
+    "h1:6FVyQ/aG6tawPam6B+oFjgdidKd83uG9n7dOSQ66HBA=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.21.0"
+  constraints = ">= 4.0.0, ~> 5.0, 5.21.0"
+  hashes = [
+    "h1:N8sP6VZjHbtgmaCU6BKPox51UIypWXQRal7JMecEXQw=",
+    "zh:1ba1411e4f8c047950db94c236f146d4590790320c68320b4e56082d8746a507",
+    "zh:3185e4a34cfcad35dcf11439290a4bd0ad52d462eca2ab5d4940488a2db72833",
+    "zh:3c6b901f874b4d9a85301a653d0bd507b052992bd84fc81100f4e5f73b1adab7",
+    "zh:45d3fdbbc5804f295576b7155fdca527dedff17a014ed40c215af3bc60c329db",
+    "zh:47b64b453d2c373062e47a54f3df33335dc29bce6ddbbf2da9e7be768c560abe",
+    "zh:5cdf57ffd465288d9732d14ba13b377a8d389e0ba0ce3ac4773fd6fdfc09d6a1",
+    "zh:81ec4c662581a2446c78da7b27d7e0d5c2e4d50925294789ec13661817f4b5a4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ac248464fd4ce1f020c05f27e3182532a7d1af4b8185a4b4be8b906b30b0ca5a",
+    "zh:bbbedc6b6eaffcce0b31b397d607464f0c21c1b9406182163d504d3f392cc68d",
+    "zh:c2afc111f9503829ed055e2ae91d873670c57bd16acc1a3246ac3957f6998d4e",
+    "zh:cd3c8175b2152848113482da70e5b9c7cb4c951f2046fc0b832715300bd88b97",
+    "zh:cf89b0c09d426d489f9477209d4084e64ad1b598036284fa688b41de626b58e6",
+    "zh:d9d127637c3b9ff6e2d0a2c30f54bd48ab1de34f725a5df1a6a3d039b021e636",
+    "zh:dccca1090e4054d6558218406385fb0421ab4ac3b75e121641973be481a81f01",
+  ]
+}

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/data.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/data.tf
@@ -1,0 +1,9 @@
+data "aws_caller_identity" "session" {
+  provider = aws.session
+}
+
+data "aws_iam_session_context" "session" {
+  provider = aws.session
+
+  arn = data.aws_caller_identity.session.arn
+}

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
@@ -1,0 +1,63 @@
+data "aws_iam_policy_document" "create_a_derived_table" {
+  statement {
+    sid    = "BucketAccess"
+    effect = "Allow"
+    actions = [
+      "s3:List*",
+      "s3:GetObject*",
+      "s3:GetBucket*",
+      "s3:DeleteObject*",
+      "s3:PutObject*"
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-derived-tables/*",
+      "arn:aws:s3:::dbt-query-dump/*"
+    ]
+  }
+
+  statement {
+    sid    = "AthenaAccess"
+    effect = "Allow"
+    actions = [
+      "athena:List*",
+      "athena:Get*",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution"
+    ]
+    resources = [
+      "arn:aws:athena:*:${data.aws_caller_identity.session.account_id}:datacatalog/*"
+    ]
+  }
+
+  statement {
+    sid    = "GlueAccess"
+    effect = "Allow"
+    actions = [
+      "glue:GetDatabase*",
+      "glue:CreateDatabase",
+      "glue:DeleteDatabase",
+      "glue:CreateTable",
+      "glue:DeleteTable",
+      "glue:CreatePartition",
+      "glue:DeletePartition",
+      "glue:CreateSchema",
+      "glue:DeleteSchema"
+    ]
+    resources = [
+      "arn:aws:glue:*:${data.aws_caller_identity.session.account_id}:schema/*",
+      "arn:aws:glue:*:${data.aws_caller_identity.session.account_id}:database/*",
+      "arn:aws:glue:*:${data.aws_caller_identity.session.account_id}:table/*/*",
+    ]
+  }
+}
+
+module "create_a_derived_table_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.30.0"
+
+  name_prefix = "create-a-derived-table"
+
+  policy = data.aws_iam_policy_document.create_a_derived_table.json
+}

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
@@ -14,7 +14,6 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "arn:aws:s3:::dbt-query-dump/*"
     ]
   }
-
   statement {
     sid    = "AthenaAccess"
     effect = "Allow"
@@ -24,11 +23,8 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "athena:StartQueryExecution",
       "athena:StopQueryExecution"
     ]
-    resources = [
-      "arn:aws:athena:*:${data.aws_caller_identity.session.account_id}:datacatalog/*"
-    ]
+    resources = ["arn:aws:athena:*:${data.aws_caller_identity.session.account_id}:datacatalog/*"]
   }
-
   statement {
     sid    = "GlueAccess"
     effect = "Allow"

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
@@ -1,4 +1,5 @@
 module "create_a_derived_table_iam_role" {
+  #checkov:skip=CKV_AWS_358:Seems like a false positive?
   source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
 
   role_name            = "create-a-derived-table"

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
@@ -1,9 +1,10 @@
 module "create_a_derived_table_iam_role" {
-  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=9d9a2d23cf569348cbdb665c979fcbaed76bb2f4" # v3.1.0
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
 
-  role_name           = "create-a-derived-table"
-  github_repositories = ["moj-analytical-services/create-a-derived-table"]
-  policy_arns         = [module.create_a_derived_table_iam_policy.arn]
+  role_name            = "create-a-derived-table"
+  github_repositories  = ["moj-analytical-services/create-a-derived-table"]
+  policy_arns          = [module.create_a_derived_table_iam_policy.arn]
+  max_session_duration = 7200
 
   tags = var.tags
 }

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
@@ -1,5 +1,6 @@
 module "create_a_derived_table_iam_role" {
-  #checkov:skip=CKV_AWS_358:Seems like a false positive?
+  #checkov:skip=CKV_AWS_358:This appears to be a false positive, we are specifying the organisation name
+
   source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=62b8a16c73d8e4422cd81923e46948e8f4b5cf48" # v3.2.0
 
   role_name            = "create-a-derived-table"

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
@@ -1,0 +1,9 @@
+module "create_a_derived_table_iam_role" {
+  source = "github.com/ministryofjustice/modernisation-platform-github-oidc-role?ref=9d9a2d23cf569348cbdb665c979fcbaed76bb2f4" # v3.1.0
+
+  role_name           = "create-a-derived-table"
+  github_repositories = ["moj-analytical-services/create-a-derived-table"]
+  policy_arns         = [module.create_a_derived_table_iam_policy.arn]
+
+  tags = var.tags
+}

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/terraform.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "5.21.0" # e.g. 5.9.0 can be found at https://registry.terraform.io/providers/hashicorp/aws/latest
+      version = "5.21.0"
     }
   }
   required_version = "~> 1.5"

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/terraform.tf
@@ -1,0 +1,42 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-data-production/create-a-derived-table/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.21.0" # e.g. 5.9.0 can be found at https://registry.terraform.io/providers/hashicorp/aws/latest
+    }
+  }
+  required_version = "~> 1.5"
+}
+
+provider "aws" {
+  alias = "session"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/terraform.tfvars
@@ -1,0 +1,15 @@
+account_ids = {
+  analytical-platform-data-production       = "593291632749"
+  analytical-platform-management-production = "042130406152"
+}
+
+tags = {
+  business-unit          = "Platforms"
+  application            = "Data Platform"
+  component              = "create-a-derived-table"
+  environment            = "production"
+  is-production          = "true"
+  owner                  = "data-platform:data-platform-tech@digital.justice.gov.uk"
+  infrastructure-support = "data-platform:data-platform-tech@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/create-a-derived-table"
+}

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/variables.tf
@@ -1,0 +1,9 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}


### PR DESCRIPTION
This PR seeks to create an OIDC based role that we can use to deploy tables from Create-A-Derived-Table. 

To Do:

- [x] Add longer timeout on new role.
- [x] Figure out why things are being removed from the path filter.