### PR TITLE
Add workflows for new data-platform-catalogue package

### DIFF
--- a/.github/workflows/python-data-platform-catalogue.yml
+++ b/.github/workflows/python-data-platform-catalogue.yml
@@ -1,28 +1,45 @@
-name: Release Data Platform Catalogue package on PyPi when tagged
+---
+name: Release Data Platform Catalogue Python library
+
 on:
   push:
     tags:
       - "python-library-data-platform-catalogue-v*.*.*"
+
+permissions: read-all
+
 jobs:
-  poetry-publish:
+  release:
+    name: Release
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python-libraries/data-platform-catalogue
     permissions:
-      # IMPORTANT: this permission is mandatory for trusted publishing
       id-token: write
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
+
       - name: Set up Python 3.10
-        uses: actions/setup-python@v2
+        id: setup_python
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: "3.10"
+
       - name: Install Poetry
+        id: install_poetry
         run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+          curl -sSL "https://install.python-poetry.org" | python3 -
+          echo "${HOME}/.poetry/bin" >>"${GITHUB_PATH}"
+
       - name: Build a distribution
-        run: poetry build
-        working-directory: python-libraries/data-platform-catalogue
+        id: build_distribution
+        run: |
+          poetry build
+
       - name: Publish package distributions to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@b7f401de30cb6434a1e19f805ff006643653240e # v1.8.10
         with:
           packages-dir: python-libraries/data-platform-catalogue/dist

--- a/.github/workflows/python-data-platform-catalogue.yml
+++ b/.github/workflows/python-data-platform-catalogue.yml
@@ -1,0 +1,28 @@
+name: Release Data Platform Catalogue package on PyPi when tagged
+on:
+  push:
+    tags:
+      - "python-library-data-platform-catalogue-v*.*.*"
+jobs:
+  poetry-publish:
+    runs-on: ubuntu-latest
+    permissions:
+      # IMPORTANT: this permission is mandatory for trusted publishing
+      id-token: write
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v2
+        with:
+          python-version: "3.10"
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+      - name: Build a distribution
+        run: poetry build
+        working-directory: python-libraries/data-platform-catalogue
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: python-libraries/data-platform-catalogue/dist

--- a/.github/workflows/test-data-platform-catalogue.yml
+++ b/.github/workflows/test-data-platform-catalogue.yml
@@ -1,0 +1,48 @@
+name: Test Data Platform Catalogue package
+
+on: # yamllint disable-line rule:truthy
+  pull_request:
+    branches:
+      - main
+    paths:
+      - python-libraries/data-platform-catalogue/**
+  push:
+    branches:
+      - main
+    paths:
+      - python-libraries/data-platform-catalogue/**
+
+jobs:
+  run_tests:
+    name: Run tests
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      max-parallel: 4
+      matrix:
+        python-version:
+          - "3.10"
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Install Poetry
+        run: |
+          curl -sSL https://install.python-poetry.org | python3 -
+          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: poetry
+          cache-dependency-path: python-libraries/data-platform-catalogue/poetry.lock
+
+      - name: Install the project
+        run: |
+          poetry install
+        working-directory: python-libraries/data-platform-catalogue
+
+      - name: Run tests
+        run: |
+          poetry run pytest
+        working-directory: python-libraries/data-platform-catalogue

--- a/.github/workflows/test-data-platform-catalogue.yml
+++ b/.github/workflows/test-data-platform-catalogue.yml
@@ -1,4 +1,4 @@
-name: Test Data Platform Catalogue package
+name: Test Data Platform Catalogue Python library
 
 on: # yamllint disable-line rule:truthy
   pull_request:
@@ -12,10 +12,15 @@ on: # yamllint disable-line rule:truthy
     paths:
       - python-libraries/data-platform-catalogue/**
 
+permissions: read-all
+
 jobs:
-  run_tests:
+  run-tests:
     name: Run tests
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: python-libraries/data-platform-catalogue
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -23,26 +28,30 @@ jobs:
         python-version:
           - "3.10"
     steps:
-      - uses: actions/checkout@v3
-
-      - name: Install Poetry
-        run: |
-          curl -sSL https://install.python-poetry.org | python3 -
-          echo "$HOME/.poetry/bin" >> $GITHUB_PATH
+      - name: Checkout
+        id: checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
 
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v4
+        id: setup_python
+        uses: actions/setup-python@65d7f2d534ac1bc67fcd62888c5f4f3d2cb2b236 # v4.7.1
         with:
           python-version: ${{ matrix.python-version }}
           cache: poetry
           cache-dependency-path: python-libraries/data-platform-catalogue/poetry.lock
 
-      - name: Install the project
+      - name: Install Poetry
+        id: install_poetry
+        run: |
+          curl -sSL "https://install.python-poetry.org" | python3 -
+          echo "${HOME}/.poetry/bin" >>"${GITHUB_PATH}"
+
+      - name: Poetry install
+        id: poetry_install
         run: |
           poetry install
-        working-directory: python-libraries/data-platform-catalogue
 
       - name: Run tests
+        id: run_tests
         run: |
           poetry run pytest
-        working-directory: python-libraries/data-platform-catalogue


### PR DESCRIPTION
Branched from https://github.com/ministryofjustice/data-platform/pull/1960

This adds some as yet untested github workflows for the new library:

- Run unit tests when PRs change the library
- Build and publish the library when tagged with a tag like `catalogue-v1.0.0` (added a prefix for disambiguation because this is in the monorepo atm)

@jacobwoffenden has set up our repo as a trusted publisher for PyPi, which means we don't need to pass any tokens. https://docs.pypi.org/trusted-publishers/using-a-publisher/