### PR TITLE
✨ Deploy Sagemaker (development)

### DIFF
--- a/terraform/aws/analytical-platform-development/sagemaker/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-development/sagemaker/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.21.0"
+  constraints = ">= 5.0.0, 5.21.0"
+  hashes = [
+    "h1:P9kgQZyi06yrLsAGnlOGAe01sOKsRsLQZOL295U38KM=",
+    "zh:1ba1411e4f8c047950db94c236f146d4590790320c68320b4e56082d8746a507",
+    "zh:3185e4a34cfcad35dcf11439290a4bd0ad52d462eca2ab5d4940488a2db72833",
+    "zh:3c6b901f874b4d9a85301a653d0bd507b052992bd84fc81100f4e5f73b1adab7",
+    "zh:45d3fdbbc5804f295576b7155fdca527dedff17a014ed40c215af3bc60c329db",
+    "zh:47b64b453d2c373062e47a54f3df33335dc29bce6ddbbf2da9e7be768c560abe",
+    "zh:5cdf57ffd465288d9732d14ba13b377a8d389e0ba0ce3ac4773fd6fdfc09d6a1",
+    "zh:81ec4c662581a2446c78da7b27d7e0d5c2e4d50925294789ec13661817f4b5a4",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ac248464fd4ce1f020c05f27e3182532a7d1af4b8185a4b4be8b906b30b0ca5a",
+    "zh:bbbedc6b6eaffcce0b31b397d607464f0c21c1b9406182163d504d3f392cc68d",
+    "zh:c2afc111f9503829ed055e2ae91d873670c57bd16acc1a3246ac3957f6998d4e",
+    "zh:cd3c8175b2152848113482da70e5b9c7cb4c951f2046fc0b832715300bd88b97",
+    "zh:cf89b0c09d426d489f9477209d4084e64ad1b598036284fa688b41de626b58e6",
+    "zh:d9d127637c3b9ff6e2d0a2c30f54bd48ab1de34f725a5df1a6a3d039b021e636",
+    "zh:dccca1090e4054d6558218406385fb0421ab4ac3b75e121641973be481a81f01",
+  ]
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/data.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/data.tf
@@ -1,0 +1,9 @@
+data "aws_caller_identity" "session" {
+  provider = aws.session
+}
+
+data "aws_iam_session_context" "session" {
+  provider = aws.session
+
+  arn = data.aws_caller_identity.session.arn
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/data.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/data.tf
@@ -2,8 +2,8 @@ data "aws_caller_identity" "session" {
   provider = aws.session
 }
 
-data "aws_iam_session_context" "session" {
-  provider = aws.session
+# data "aws_iam_session_context" "session" {
+#   provider = aws.session
 
-  arn = data.aws_caller_identity.session.arn
-}
+#   arn = data.aws_caller_identity.session.arn
+# }

--- a/terraform/aws/analytical-platform-development/sagemaker/data.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/data.tf
@@ -1,9 +1,0 @@
-# data "aws_caller_identity" "session" {
-#   provider = aws.session
-# }
-
-# data "aws_iam_session_context" "session" {
-#   provider = aws.session
-
-#   arn = data.aws_caller_identity.session.arn
-# }

--- a/terraform/aws/analytical-platform-development/sagemaker/data.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/data.tf
@@ -1,6 +1,6 @@
-data "aws_caller_identity" "session" {
-  provider = aws.session
-}
+# data "aws_caller_identity" "session" {
+#   provider = aws.session
+# }
 
 # data "aws_iam_session_context" "session" {
 #   provider = aws.session

--- a/terraform/aws/analytical-platform-development/sagemaker/iam-roles.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/iam-roles.tf
@@ -1,0 +1,21 @@
+resource "aws_iam_role" "sagemaker_studio_execution_role" {
+  name = "sagemaker-studio-execution-role"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Action = "sts:AssumeRole",
+        Effect = "Allow",
+        Principal = {
+          Service = "sagemaker.amazonaws.com"
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "sagemaker_full_access_studio" {
+  role       = aws_iam_role.sagemaker_studio_execution_role.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/outputs.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/outputs.tf
@@ -1,4 +1,4 @@
-# output "sagemaker_studio_domain_url" {
-#   value       = aws_sagemaker_domain.studio_domain.url
-#   description = "The URL to access the SageMaker Studio domain"
-# }
+output "sagemaker_studio_domain_url" {
+  value       = aws_sagemaker_domain.studio_domain.url
+  description = "The URL to access the SageMaker Studio domain"
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/outputs.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/outputs.tf
@@ -1,4 +1,4 @@
-output "sagemaker_studio_domain_url" {
-  value       = aws_sagemaker_domain.studio_domain.url
-  description = "The URL to access the SageMaker Studio domain"
-}
+# output "sagemaker_studio_domain_url" {
+#   value       = aws_sagemaker_domain.studio_domain.url
+#   description = "The URL to access the SageMaker Studio domain"
+# }

--- a/terraform/aws/analytical-platform-development/sagemaker/outputs.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/outputs.tf
@@ -1,0 +1,4 @@
+output "sagemaker_studio_domain_url" {
+  value       = aws_sagemaker_domain.studio_domain.url
+  description = "The URL to access the SageMaker Studio domain"
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
@@ -2,9 +2,9 @@ resource "aws_sagemaker_domain" "studio_domain" {
   domain_name = var.domain_name
   auth_mode   = var.auth_mode
 
-  # default_space_settings {
-  #   execution_role = aws_iam_role.sagemaker_studio_execution_role.arn
-  # }
+  default_space_settings {
+    execution_role = aws_iam_role.sagemaker_studio_execution_role.arn
+  }
 
   default_user_settings {
     execution_role  = aws_iam_role.sagemaker_studio_execution_role.arn

--- a/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
@@ -1,13 +1,52 @@
 resource "aws_sagemaker_domain" "studio_domain" {
-  domain_name = "mvp-studio-domain"
-  auth_mode   = "IAM" # Using IAM for authentication
+  domain_name = var.domain_name
+  auth_mode   = var.auth_mode
 
-  app_network_access_type = "PublicInternetOnly"
+  # default_space_settings {
+  #   execution_role = aws_iam_role.sagemaker_studio_execution_role.arn
+  # }
 
   default_user_settings {
-    execution_role = aws_iam_role.sagemaker_studio_execution_role.arn
+    execution_role  = aws_iam_role.sagemaker_studio_execution_role.arn
+    security_groups = [module.vpc.default_security_group_id]
+    jupyter_server_app_settings {
+      lifecycle_config_arns = []
+
+      default_resource_spec {
+        instance_type       = "system"
+        sagemaker_image_arn = "arn:aws:sagemaker:eu-west-2:712779665605:image/jupyter-server-3"
+      }
+    }
+
+    sharing_settings {
+      notebook_output_option = "Allowed"
+      s3_output_path         = "s3://sagemaker-studio-on6mcpqk2ec/sharing"
+    }
   }
 
-  vpc_id     = "YOUR_VPC_ID"      # Replace with your VPC ID
-  subnet_ids = ["YOUR_SUBNET_ID"] # Replace with your Subnet ID(s)
+  # # app_network_access_type = "PublicInternetOnly"
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.public_subnets
+
+  # single_sign_on_managed_application_instance_id = "YOUR_SSO_APP_INSTANCE_ID"
 }
+
+import {
+  to = aws_sagemaker_domain.studio_domain
+  id = "d-7zzp0wnkxqkt"
+}
+
+# # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_user_profile
+
+# resource "aws_sagemaker_user_profile" "example" {
+#   domain_id                      = aws_sagemaker_domain.studio_domain.id
+#   user_profile_name              = "example"
+#   single_sign_on_user_value      = "SSO_User_Name"
+#   single_sign_on_user_identifier = "UserName"
+
+#   user_settings {
+#     execution_role = aws_iam_role.sagemaker_studio_execution_role.arn
+#   }
+
+#   tags = tag.local
+# }

--- a/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
@@ -35,18 +35,3 @@ import {
   to = aws_sagemaker_domain.studio_domain
   id = "d-7zzp0wnkxqkt"
 }
-
-# # https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sagemaker_user_profile
-
-# resource "aws_sagemaker_user_profile" "example" {
-#   domain_id                      = aws_sagemaker_domain.studio_domain.id
-#   user_profile_name              = "example"
-#   single_sign_on_user_value      = "SSO_User_Name"
-#   single_sign_on_user_identifier = "UserName"
-
-#   user_settings {
-#     execution_role = aws_iam_role.sagemaker_studio_execution_role.arn
-#   }
-
-#   tags = tag.local
-# }

--- a/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
@@ -1,0 +1,13 @@
+resource "aws_sagemaker_domain" "studio_domain" {
+  domain_name = "mvp-studio-domain"
+  auth_mode   = "IAM" # Using IAM for authentication
+
+  app_network_access_type = "PublicInternetOnly"
+
+  default_user_settings {
+    execution_role = aws_iam_role.sagemaker_studio_execution_role.arn
+  }
+
+  vpc_id     = "YOUR_VPC_ID"      # Replace with your VPC ID
+  subnet_ids = ["YOUR_SUBNET_ID"] # Replace with your Subnet ID(s)
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
@@ -30,8 +30,3 @@ resource "aws_sagemaker_domain" "studio_domain" {
 
   # single_sign_on_managed_application_instance_id = "YOUR_SSO_APP_INSTANCE_ID"
 }
-
-import {
-  to = aws_sagemaker_domain.studio_domain
-  id = "d-7zzp0wnkxqkt"
-}

--- a/terraform/aws/analytical-platform-development/sagemaker/terraform.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/terraform.tf
@@ -33,14 +33,3 @@ provider "aws" {
     tags = var.tags
   }
 }
-
-provider "aws" {
-  alias  = "analytical-platform-management-production"
-  region = "eu-west-1"
-  assume_role {
-    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
-  }
-  default_tags {
-    tags = var.tags
-  }
-}

--- a/terraform/aws/analytical-platform-development/sagemaker/terraform.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/terraform.tf
@@ -1,0 +1,46 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-development/sagemaker/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.21.0"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "3.5.1"
+    }
+  }
+  required_version = "~> 1.5"
+}
+
+provider "aws" {
+  alias = "session"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-development"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-1"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/terraform.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/terraform.tf
@@ -12,10 +12,6 @@ terraform {
       source  = "hashicorp/aws"
       version = "5.21.0"
     }
-    random = {
-      source  = "hashicorp/random"
-      version = "3.5.1"
-    }
   }
   required_version = "~> 1.5"
 }

--- a/terraform/aws/analytical-platform-development/sagemaker/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/sagemaker/terraform.tfvars
@@ -1,0 +1,15 @@
+account_ids = {
+  analytical-platform-development           = "525294151996"
+  analytical-platform-management-production = "042130406152"
+}
+
+tags = {
+  business-unit          = "Platforms"
+  application            = "Data Platform"
+  component              = "SageMaker"
+  environment            = "development"
+  is-production          = "false"
+  owner                  = "data-platform:data-platform-tech@digital.justice.gov.uk"
+  infrastructure-support = "data-platform:data-platform-tech@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/data-platform"
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/variables.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/variables.tf
@@ -1,0 +1,9 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/variables.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/variables.tf
@@ -6,7 +6,7 @@ variable "account_ids" {
 variable "auth_mode" {
   description = "The mode of authentication that members use to access the domain. Valid values are IAM and SSO"
   type        = string
-  default     = "SSO"
+  default     = "IAM"
 }
 
 variable "domain_name" {

--- a/terraform/aws/analytical-platform-development/sagemaker/variables.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/variables.tf
@@ -3,6 +3,18 @@ variable "account_ids" {
   description = "Map of account names to account IDs"
 }
 
+variable "auth_mode" {
+  description = "The mode of authentication that members use to access the domain. Valid values are IAM and SSO"
+  type        = string
+  default     = "SSO"
+}
+
+variable "domain_name" {
+  description = "Sagemaker Domain Name"
+  type        = string
+  default     = "mvp-studio-domain"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Map of tags to apply to resources"

--- a/terraform/aws/analytical-platform-development/sagemaker/vpc.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/vpc.tf
@@ -1,0 +1,23 @@
+#tfsec:ignore:aws-ec2-require-vpc-flow-logs-for-all-vpcs
+module "vpc" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+  #checkov:skip=CKV_AWS_356:Module managed policy
+  #checkov:skip=CKV_AWS_111:Module managed policy
+  #checkov:skip=CKV2_AWS_11:This is not production infrastructure
+  #checkov:skip=CKV2_AWS_12:This is not production infrastructure
+  #checkov:skip=CKV2_AWS_19:This is not production infrastructure
+
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "5.1.2"
+
+  name = "sagemaker"
+
+  cidr            = "10.124.0.0/16"
+  azs             = ["eu-west-2a", "eu-west-2b", "eu-west-2c"]
+  public_subnets  = ["10.124.10.0/24", "10.124.11.0/24", "10.124.12.0/24"]
+  private_subnets = ["10.124.0.0/24", "10.124.1.0/24", "10.124.2.0/24"]
+
+  enable_nat_gateway     = true
+  one_nat_gateway_per_az = false
+
+}


### PR DESCRIPTION
This PR Deploys an AWS SageMaker domain to the `analytical-platform-development` AWS account. 

Comprehensive detail is included in [this](https://github.com/ministryofjustice/data-platform/issues/1970) ticket.

To do: 
- [ ] ~Add a name to the EFS which is created~ Out of scope for MVP 
- [x] Define IAM roles as code 
- [x] Enable spaces with default execution role
- [x] `SSO` -> `IAM`

