### PR TITLE
Update python-data-platform-catalogue.yml

### DIFF
--- a/.github/workflows/python-data-platform-catalogue.yml
+++ b/.github/workflows/python-data-platform-catalogue.yml
@@ -15,6 +15,8 @@ jobs:
     defaults:
       run:
         working-directory: python-libraries/data-platform-catalogue
+    environment:
+      name: data-platform-catalogue
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION
Pass in an environment to see if this fixed the release

https://docs.pypi.org/trusted-publishers/troubleshooting/

> invalid-pending-publisher and invalid-publisher: the OIDC token itself is well-formed (and has a valid signature), but doesn't match any known (pending) OIDC publisher. This likely indicates a mismatch between the OIDC publisher specified in the user/project settings and the claims represented in the actual OIDC token. Check for typos! **If you're using GitHub Actions, check if the workflow is using the same environment as configured when the publisher was configured on PyPI.**