### PR TITLE
Update paths since name of package has been renamed

### DIFF
--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -5,9 +5,10 @@ description = "Library to integrate the MoJ data platform with the catalogue com
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"
 readme = "README.md"
+packages = [{ include = "data_platform_catalogue" }]
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.10.0"
 openmetadata-ingestion = "^1.1.7.0"
 
 # 1.5.4 doesn't install for some reason. Either way it will be removed from the next release of the ingestion package.


### PR DESCRIPTION
This is needed for poetry to be able to build the package, following this rename https://github.com/ministryofjustice/data-platform/pull/2011