### PR TITLE
Modify catalogue client to accept full metadata objects and hide internal exceptions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,4 @@
 /containers/daap-* @ministryofjustice/data-platform-labs
 /scripts/simulated-data-producer/ @ministryofjustice/data-platform-labs
 /terraform/ @ministryofjustice/data-platform-core-infra
+/python-libraries/data-platform-catalogue/ @ministryofjustice/data-platform-labs

--- a/python-libraries/data-platform-catalogue/README.md
+++ b/python-libraries/data-platform-catalogue/README.md
@@ -25,7 +25,10 @@ pip install ministryofjustice-data-platform-catalogue
 ## Example usage
 
 ```python
-from data_platform_catalogue import CatalogueClient
+from data_platform_catalogue import (
+  CatalogueClient, CatalogueMetadata,
+  DataProductMetadata, TableMetadata
+)
 
 client = CatalogueClient(
     jwt_token="***",
@@ -34,13 +37,32 @@ client = CatalogueClient(
 
 assert client.is_healthy()
 
-service_fqn = client.create_or_update_database_service(name="data_platform")
-database_fqn = client.create_or_update_database(name="all_data_products", service_fqn=service_fqn)
-schema_fqn = client.create_or_update_database(name="my_data_product", database_fqn=database_fqn)
 
-table_fqn = client.create_or_update_table(
-    name="my_table",
-    schema_fqn=schema_fqn,
-    column_types={"foo": "string", "bar": "int"}
+catalogue = CatalogueMetadata(
+  name = "data_platform",
+  description = "All data products hosted on the data platform",
 )
+
+data_product = DataProductMetadata(
+    name = "my_data_product",
+    description = "bla bla",
+    version = "v1.0.0",
+    owner = "7804c127-d677-4900-82f9-83517e51bb94",
+    email = "justice@justice.gov.uk",
+    retention_period_in_days = 365,
+    domain = "legal-aid",
+    dpia_required = False
+)
+
+table = TableMetadata(
+  name = "my_table",
+  description = "bla bla",
+  column_types = {"foo": "string", "bar": "int"},
+  retention_period_in_days = 365
+)
+
+service_fqn = client.create_or_update_database_service(name="data_platform")
+database_fqn = client.create_or_update_database(metadata=catalogue, service_fqn=service_fqn)
+schema_fqn = client.create_or_update_schema(metadata=data_product, database_fqn=database_fqn)
+table_fqn = client.create_or_update_table(metadata=table, schema_fqn=schema_fqn)
 ```

--- a/python-libraries/data-platform-catalogue/README.md
+++ b/python-libraries/data-platform-catalogue/README.md
@@ -27,7 +27,8 @@ pip install ministryofjustice-data-platform-catalogue
 ```python
 from data_platform_catalogue import (
   CatalogueClient, CatalogueMetadata,
-  DataProductMetadata, TableMetadata
+  DataProductMetadata, TableMetadata,
+  CatalogueError
 )
 
 client = CatalogueClient(
@@ -61,8 +62,11 @@ table = TableMetadata(
   retention_period_in_days = 365
 )
 
-service_fqn = client.create_or_update_database_service(name="data_platform")
-database_fqn = client.create_or_update_database(metadata=catalogue, service_fqn=service_fqn)
-schema_fqn = client.create_or_update_schema(metadata=data_product, database_fqn=database_fqn)
-table_fqn = client.create_or_update_table(metadata=table, schema_fqn=schema_fqn)
+try:
+  service_fqn = client.create_or_update_database_service(name="data_platform")
+  database_fqn = client.create_or_update_database(metadata=catalogue, service_fqn=service_fqn)
+  schema_fqn = client.create_or_update_schema(metadata=data_product, database_fqn=database_fqn)
+  table_fqn = client.create_or_update_table(metadata=table, schema_fqn=schema_fqn)
+except CatalogueError:
+  print("oh no")
 ```

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
@@ -1,4 +1,8 @@
-from .client import CatalogueClient  # noqa: F401
+from .client import (
+    CatalogueClient,
+    CatalogueError,
+    ReferencedEntityMissing,
+)  # noqa: F401
 from .entities import (
     CatalogueMetadata,
     DataProductMetadata,

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
@@ -1,1 +1,6 @@
 from .client import CatalogueClient  # noqa: F401
+from .entities import (
+    CatalogueMetadata,
+    DataProductMetadata,
+    TableMetadata,
+)  # noqa: F401

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
@@ -1,10 +1,5 @@
-from .client import (
-    CatalogueClient,
-    CatalogueError,
-    ReferencedEntityMissing,
-)  # noqa: F401
-from .entities import (
-    CatalogueMetadata,
-    DataProductMetadata,
-    TableMetadata,
-)  # noqa: F401
+from .client import CatalogueClient  # noqa: F401
+from .client import CatalogueError, ReferencedEntityMissing  # noqa: F401
+from .entities import CatalogueMetadata  # noqa: F401
+from .entities import DataProductMetadata  # noqa: F401
+from .entities import TableMetadata  # noqa: F401

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client.py
@@ -1,7 +1,7 @@
 import json
 import logging
-
 from http import HTTPStatus
+
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
@@ -26,7 +26,7 @@ from metadata.generated.schema.type.tagLabel import (
     TagLabel,
     TagSource,
 )
-from metadata.ingestion.ometa.ometa_api import OpenMetadata, APIError
+from metadata.ingestion.ometa.ometa_api import APIError, OpenMetadata
 
 from .entities import CatalogueMetadata, DataProductMetadata, TableMetadata
 

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
@@ -1,0 +1,30 @@
+from dataclasses import dataclass, field
+
+
+@dataclass
+class CatalogueMetadata:
+    name: str
+    description: str
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class DataProductMetadata:
+    name: str
+    description: str
+    version: str
+    owner: str
+    email: str
+    retention_period_in_days: int
+    domain: str
+    dpia_required: bool
+    tags: list[str] = field(default_factory=list)
+
+
+@dataclass
+class TableMetadata:
+    name: str
+    description: str
+    column_types: dict[str, str]
+    retention_period_in_days: int
+    tags: list[str] = field(default_factory=list)

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.1.0"
+version = "0.1.1"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"

--- a/python-libraries/data-platform-catalogue/tests/test_client.py
+++ b/python-libraries/data-platform-catalogue/tests/test_client.py
@@ -1,5 +1,10 @@
 import pytest
 from data_platform_catalogue.client import CatalogueClient
+from data_platform_catalogue.entities import (
+    CatalogueMetadata,
+    DataProductMetadata,
+    TableMetadata,
+)
 
 
 class TestCatalogueClient:
@@ -58,6 +63,36 @@ class TestCatalogueClient:
         }
 
     @pytest.fixture
+    def catalogue(self):
+        return CatalogueMetadata(
+            name="data_platform",
+            description="All data products hosted on the data platform",
+        )
+
+    @pytest.fixture
+    def data_product(self):
+        return DataProductMetadata(
+            name="my_data_product",
+            description="bla bla",
+            version="v1.0.0",
+            owner="2e1fa91a-c607-49e4-9be2-6f072ebe27c7",
+            email="justice@justice.gov.uk",
+            retention_period_in_days=365,
+            domain="legal-aid",
+            dpia_required=False,
+            tags=["test"],
+        )
+
+    @pytest.fixture
+    def table(self):
+        return TableMetadata(
+            name="my_table",
+            description="bla bla",
+            column_types={"foo": "string", "bar": "int"},
+            retention_period_in_days=365,
+        )
+
+    @pytest.fixture
     def client(self, requests_mock):
         requests_mock.get(
             "http://example.com/api/v1/system/version",
@@ -82,20 +117,20 @@ class TestCatalogueClient:
         }
         assert fqn == "some-service"
 
-    def test_create_database(self, client, requests_mock):
+    def test_create_database(self, client, requests_mock, catalogue):
         requests_mock.put(
             "http://example.com/api/v1/databases",
             json=self.mock_database_response("some-db"),
         )
 
         fqn = client.create_or_update_database(
-            name="data-product", service_fqn="data-platform"
+            metadata=catalogue, service_fqn="data-platform"
         )
         assert requests_mock.last_request.json() == {
-            "name": "data-product",
+            "name": "data_platform",
             "displayName": None,
-            "description": None,
-            "tags": None,
+            "description": "All data products hosted on the data platform",
+            "tags": [],
             "owner": None,
             "service": "data-platform",
             "default": False,
@@ -105,41 +140,59 @@ class TestCatalogueClient:
         }
         assert fqn == "some-db"
 
-    def test_create_schema(self, client, requests_mock):
+    def test_create_schema(self, client, requests_mock, data_product):
         requests_mock.put(
             "http://example.com/api/v1/databaseSchemas",
             json=self.mock_schema_response("some-schema"),
         )
 
-        fqn = client.create_or_update_schema(name="schema", database_fqn="data-product")
+        fqn = client.create_or_update_schema(
+            metadata=data_product, database_fqn="data-product"
+        )
         assert requests_mock.last_request.json() == {
-            "name": "schema",
+            "name": "my_data_product",
             "displayName": None,
-            "description": None,
-            "owner": None,
+            "description": "bla bla",
+            "owner": {
+                "deleted": None,
+                "description": None,
+                "displayName": None,
+                "fullyQualifiedName": None,
+                "href": None,
+                "id": "2e1fa91a-c607-49e4-9be2-6f072ebe27c7",
+                "name": None,
+                "type": "user",
+            },
             "database": "data-product",
-            "tags": None,
-            "retentionPeriod": None,
+            "tags": [
+                {
+                    "description": None,
+                    "href": None,
+                    "labelType": "Automated",
+                    "source": "Classification",
+                    "state": "Confirmed",
+                    "tagFQN": "test",
+                }
+            ],
+            "retentionPeriod": "P365D",
             "extension": None,
             "sourceUrl": None,
         }
         assert fqn == "some-schema"
 
-    def test_create_table(self, client, requests_mock):
+    def test_create_table(self, client, requests_mock, table):
         requests_mock.put(
             "http://example.com/api/v1/tables",
             json=self.mock_table_response("some-table"),
         )
 
         fqn = client.create_or_update_table(
-            name="table",
-            schema_fqn="data-platform.data-product.schema",
-            column_types={"foo": "string", "bar": "int"},
+            metadata=table, schema_fqn="data-platform.data-product.schema"
         )
         assert requests_mock.last_request.json() == {
-            "name": "table",
+            "name": "my_table",
             "displayName": None,
-            "description": None,
+            "description": "bla bla",
             "tableType": None,
             "columns": [
                 {
@@ -186,9 +239,9 @@ class TestCatalogueClient:
             "tableProfilerConfig": None,
             "owner": None,
             "databaseSchema": "data-platform.data-product.schema",
-            "tags": None,
+            "tags": [],
             "viewDefinition": None,
-            "retentionPeriod": None,
+            "retentionPeriod": "P365D",
             "extension": None,
             "sourceUrl": None,
             "fileFormat": None,

--- a/python-libraries/data-platform-catalogue/tests/test_client.py
+++ b/python-libraries/data-platform-catalogue/tests/test_client.py
@@ -1,5 +1,5 @@
 import pytest
-from data_platform_catalogue.client import CatalogueClient
+from data_platform_catalogue.client import CatalogueClient, ReferencedEntityMissing
 from data_platform_catalogue.entities import (
     CatalogueMetadata,
     DataProductMetadata,
@@ -247,3 +247,15 @@ class TestCatalogueClient:
             "fileFormat": None,
         }
         assert fqn == "some-table"
+
+    def test_404_handling(self, client, requests_mock, table):
+        requests_mock.put(
+            "http://example.com/api/v1/tables",
+            status_code=404,
+            json={"code": "something", "message": "something"},
+        )
+
+        with pytest.raises(ReferencedEntityMissing):
+            client.create_or_update_table(
+                metadata=table, schema_fqn="data-platform.data-product.schema"
+            )


### PR DESCRIPTION
Previously, the client was creating minimal Tables and Schemas in OpenMetadata with just a name.

However, we should be passing through any metadata that we capture when creating a data product or table.
See JSON schemas: https://github.com/ministryofjustice/modernisation-platform-environments/tree/main/terraform/environments/data-platform

This change forces the user of this library to pass through the following metadata:

- name, description for database/schema/table
- retention period at schema/table level
- version, owner, email, dpi_required, domain at schema level

We can also accept optional tags at any level. These are expected to correspond to classifications in OpenMetadata. By default we have tags for PII sensitivity and "tier". https://catalogue.apps-tools.development.data-platform.service.justice.gov.uk/tags/

**Note**: Email, dpia_required, domain, versions are not yet passed through to the catalogue. These may require use of custom attributes. We can only do these at the table level at the moment, but 1.2.0 will add support at other levels.

Tags and owner are assumed to reference things that already exist in OpenMetadata - if not, we raise an error.