### PR TITLE
DP-1657 Add update metadata function to base image

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## Changed
+
+- Moved `format_error_response` into data_platform_api_responses
+- `format_response_json` now accepts a dict `body` argument instead of
+  a json encoded `json_body` string
+
 ## [4.0.1] - 2023-10-18
 
 ### Added

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,11 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [4.1.0] - 2023-10-23
+
+## Added
+
+- `DataProductMetadata.create_new_version` method
+
 ## Changed
 
 - Moved `format_error_response` into data_platform_api_responses
 - `format_response_json` now accepts a dict `body` argument instead of
   a json encoded `json_body` string
+- The `.write_json_to_s3` method of `DataProductMetadata`
+  and `DataProductSchema` no longer requires a path.
 
 ## [4.0.1] - 2023-10-18
 

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.1.0] - 2023-10-23
+## [5.0.0] - 2023-10-23
 
 ## Added
 

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "4.1.0",
+  "version": "5.0.0",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_platform_api_responses.py
+++ b/containers/daap-python-base/src/var/task/data_platform_api_responses.py
@@ -1,39 +1,87 @@
 import json
+import os
+from http import HTTPStatus
+from warnings import warn
+
+from data_platform_logging import DataPlatformLogger
+
+logger = DataPlatformLogger(
+    extra={
+        "image_version": os.getenv("VERSION", "unknown"),
+        "base_image_version": os.getenv("BASE_VERSION", "unknown"),
+    }
+)
 
 
-def format_response_json(status_code, json_body) -> dict:
+def format_response_json(status_code: HTTPStatus, body: dict) -> dict:
+    """
+    Generate a JSON response to return to API Gateway
+    """
     formatted_response_json = {
         "statusCode": status_code,
         "headers": {"Content-Type": "application/json"},
-        "body": json_body,
+        "body": json.dumps(body),
     }
 
     return formatted_response_json
 
 
+def format_error_response(response_code: HTTPStatus, event: dict, message: str) -> dict:
+    """
+    Generate a response to return to API Gateway that contains a formatted
+    error.
+    """
+    response_body = {"error": {"message": message}}
+    response = {
+        "statusCode": response_code,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps(response_body),
+    }
+
+    logger.error(f"code: {response_code}, error message: {message}, input: {event}")
+
+    return response
+
+
 def response_status_400(error) -> dict:
-    response_body = json.dumps({"error": {"message": error}})
-    formatted_response = format_response_json(400, response_body)
+    warn(
+        "replace `response_status_400(...)` with `format_error_response(HTTPStatus.BAD_REQUEST, ...)`",
+        DeprecationWarning,
+    )
+    response_body = {"error": {"message": error}}
+    formatted_response = format_response_json(HTTPStatus.BAD_REQUEST, response_body)
 
     return formatted_response
 
 
 def response_status_403(error) -> dict:
-    response_body = json.dumps({"error": {"message": error}})
-    formatted_response = format_response_json(403, response_body)
+    warn(
+        "replace `response_status_403(...)` with `format_error_response(HTTPStatus.FORBIDDEN, ...)`",
+        DeprecationWarning,
+    )
+    response_body = {"error": {"message": error}}
+    formatted_response = format_response_json(HTTPStatus.FORBIDDEN, response_body)
 
     return formatted_response
 
 
 def response_status_404(error) -> dict:
-    response_body = json.dumps({"error": {"message": error}})
-    formatted_response = format_response_json(404, response_body)
+    warn(
+        "replace `response_status_404(...)` with `format_error_response(HTTPStatus.NOT_FOUND, ...)`",
+        DeprecationWarning,
+    )
+    response_body = {"error": {"message": error}}
+    formatted_response = format_response_json(HTTPStatus.NOT_FOUND, response_body)
 
     return formatted_response
 
 
 def response_status_200(message) -> dict:
-    response_body = json.dumps({"message": message})
-    formatted_response = format_response_json(200, response_body)
+    warn(
+        "replace `response_status_200(...)` with `format_response_json(HTTPStatus.OK, ...)`",
+        DeprecationWarning,
+    )
+    response_body = {"message": message}
+    formatted_response = format_response_json(HTTPStatus.OK, response_body)
 
     return formatted_response

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -98,7 +98,20 @@ def get_data_product_specification_path(
 
 
 class BaseJsonSchema:
-    """base class for operations on json type metadata and schema for data products"""
+    """
+    Base class for operations on json type metadata and schema for data products.
+
+    Parameters:
+    - bucket_path should be the path to the latest version, or 1.0.0 if no version exists
+    - input_data is optional data to be validated and written
+
+    Attributes:
+    - exists: does *any* version of this schema exist?
+    - valid: is the input_data valid?
+    - version: the version string corresponding to the `bucket_path`
+    - write_bucket / latest_version_key: the bucket and key components of `bucket_path`, respectively
+    - latest_version_saved_data: the metadata stored at `bucket_path`
+    """
 
     def __init__(
         self,
@@ -118,6 +131,7 @@ class BaseJsonSchema:
         self.exists = self._check_a_version_exists()
         self.write_bucket = bucket_path.bucket
         self.latest_version_key = bucket_path.key
+        self.latest_version_saved_data = None
         self.version = bucket_path.key.split("/")[1]
         if input_data is not None:
             self.validate(input_data)

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -456,7 +456,7 @@ class DataProductMetadata(BaseJsonSchema):
             input_data=input_data,
         )
 
-    def create_new_version(self) -> DataProductMetadata | None:
+    def create_new_version(self) -> DataProductMetadata:
         """
         Create a new version of the data product
         """

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -150,15 +150,15 @@ class BaseJsonSchema:
     Base class for operations on json type metadata and schema for data products.
 
     Parameters:
-    - bucket_path should be the path to the latest version, or 1.0.0 if no version exists
+    - latest_version_path should be the path to the latest version, or 1.0.0 if no version exists
     - input_data is optional data to be validated and written
 
     Attributes:
     - exists: does *any* version of this schema exist?
     - valid: is the input_data valid?
-    - version: the version string corresponding to the `bucket_path`
-    - write_bucket / latest_version_key: the bucket and key components of `bucket_path`, respectively
-    - latest_version_saved_data: the metadata stored at `bucket_path`
+    - version: the version string corresponding to the `latest_version_path`
+    - write_bucket / latest_version_key: the bucket and key components of `latest_version_path`, respectively
+    - latest_version_saved_data: the metadata stored at `latest_version_path`
     """
 
     def __init__(
@@ -166,7 +166,7 @@ class BaseJsonSchema:
         data_product_name: str,
         logger: DataPlatformLogger,
         json_type: JsonSchemaName,
-        bucket_path: BucketPath,
+        latest_version_path: BucketPath,
         input_data: dict | None,
         table_name: str | None = None,
     ):
@@ -177,10 +177,10 @@ class BaseJsonSchema:
         self.valid = False
         self.type = json_type
         self.exists = self._check_a_version_exists()
-        self.write_bucket = bucket_path.bucket
-        self.latest_version_key = bucket_path.key
+        self.write_bucket = latest_version_path.bucket
+        self.latest_version_key = latest_version_path.key
         self.latest_version_saved_data = None
-        self.version = bucket_path.key.split("/")[1]
+        self.version = latest_version_path.key.split("/")[1]
         if input_data is not None:
             self.validate(input_data)
 
@@ -320,13 +320,15 @@ class DataProductSchema(BaseJsonSchema):
         input_data: dict | None,
     ):
         # returns path of latest schema or v1 if it doesn't exist
-        bucket_path = DataProductConfig(name=data_product_name).schema_path(table_name)
+        latest_version_path = DataProductConfig(name=data_product_name).schema_path(
+            table_name
+        )
 
         super().__init__(
             data_product_name=data_product_name,
             logger=logger,
             json_type=JsonSchemaName("schema"),
-            bucket_path=bucket_path,
+            latest_version_path=latest_version_path,
             input_data=input_data,
             table_name=table_name,
         )
@@ -442,17 +444,14 @@ class DataProductMetadata(BaseJsonSchema):
         data_product_name: str,
         logger: DataPlatformLogger,
         input_data: dict | None,
-        version: str | None = None,
     ):
-        bucket_path = DataProductConfig(data_product_name).metadata_path(
-            version=version
-        )
+        latest_version_path = DataProductConfig(data_product_name).metadata_path()
 
         super().__init__(
             json_type=JsonSchemaName("metadata"),
             data_product_name=data_product_name,
             logger=logger,
-            bucket_path=bucket_path,
+            latest_version_path=latest_version_path,
             input_data=input_data,
         )
 

--- a/containers/daap-python-base/tests/unit/conftest.py
+++ b/containers/daap-python-base/tests/unit/conftest.py
@@ -10,9 +10,6 @@ from moto import mock_s3
 
 sys.path.append(join(dirname(__file__), "../", "../", "src", "var", "task"))
 
-from data_platform_logging import DataPlatformLogger  # noqa E402
-from data_platform_paths import DataProductElement  # noqa E402
-
 os.environ["AWS_ACCESS_KEY_ID"] = "testing"
 os.environ["AWS_SECRET_ACCESS_KEY"] = "testing"
 os.environ["AWS_SECURITY_TOKEN"] = "testing"
@@ -21,6 +18,9 @@ os.environ["AWS_LAMBDA_FUNCTION_NAME"] = "test_lambda"
 os.environ["BUCKET_NAME"] = "bucket"
 os.putenv("TZ", "Europe/London")
 time.tzset()
+
+from data_platform_logging import DataPlatformLogger  # noqa E402
+from data_platform_paths import DataProductElement  # noqa E402
 
 
 @pytest.fixture

--- a/containers/daap-python-base/tests/unit/data_platform_api_responses_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_api_responses_test.py
@@ -5,13 +5,25 @@ import data_platform_api_responses
 
 def test_format_response_json():
     formatted_response_json = data_platform_api_responses.format_response_json(
-        111, json.dumps({"test": "test"})
+        111, {"test": "test"}
     )
 
     assert formatted_response_json == {
         "statusCode": 111,
         "headers": {"Content-Type": "application/json"},
         "body": json.dumps({"test": "test"}),
+    }
+
+
+def test_format_error_response():
+    formatted_response_json = data_platform_api_responses.format_error_response(
+        111, {"foo": "bar"}, "message"
+    )
+
+    assert formatted_response_json == {
+        "statusCode": 111,
+        "headers": {"Content-Type": "application/json"},
+        "body": json.dumps({"error": {"message": "message"}}),
     }
 
 

--- a/containers/daap-python-base/tests/unit/data_product_metadata_test.py
+++ b/containers/daap-python-base/tests/unit/data_product_metadata_test.py
@@ -12,6 +12,7 @@ from data_platform_paths import JsonSchemaName
 from data_product_metadata import (
     DataProductMetadata,
     DataProductSchema,
+    InvalidUpdate,
     format_table_schema,
 )
 
@@ -445,6 +446,5 @@ class TestDataProductUpload:
             input_data=input_data,
         )
 
-        new_metadata = loaded_metadata.create_new_version()
-
-        assert new_metadata is None
+        with pytest.raises(InvalidUpdate):
+            loaded_metadata.create_new_version()

--- a/containers/daap-python-base/tests/unit/data_product_metadata_test.py
+++ b/containers/daap-python-base/tests/unit/data_product_metadata_test.py
@@ -435,9 +435,9 @@ class TestDataProductUpload:
 
         assert new_metadata.load().latest_version_saved_data == input_data
 
-    def test_major_update_not_allowed_yet(self):
+    def test_cannot_update_name(self):
         input_data = dict(**test_metadata_pass)
-        input_data["retentionPeriod"] = 100
+        input_data["name"] = "new name"
 
         loaded_metadata = DataProductMetadata(
             test_metadata_pass["name"],


### PR DESCRIPTION
This PR is preparation for adding an "update metadata" endpoint.

I've added some functionality to the metadata class to detect whether an update is minor or not; and if it is minor, to create a new minor version (we'll deal with major updates later).

This is implemented at the DataProductMetadata level rather than in the base class, since the schema update case is more complicated and until we start working on that, I'm not sure what we'll be able to reuse from this implementation.

I've also moved the `format_error_response` function into the base since I saw we were creating this in a few different places. For consistency, I made format_response_json also do the `json.dumps` which is a breaking change but very easy to update.