### PR TITLE
add kms alias

### DIFF
--- a/terraform/aws/analytical-platform/baseline/modules/cost-explorer-anomaly-monitor/main.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/cost-explorer-anomaly-monitor/main.tf
@@ -32,7 +32,7 @@ resource "aws_kms_key" "ce_anomaly_monitor" {
 }
 
 resource "aws_kms_alias" "ce_anomaly_monitor" {
-  name          = "alias/cost-anomaly-key"
+  name          = "alias/cost-explorer-anomaly-monitor"
   target_key_id = aws_kms_key.ce_anomaly_monitor.key_id
 }
 

--- a/terraform/aws/analytical-platform/baseline/modules/cost-explorer-anomaly-monitor/main.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/cost-explorer-anomaly-monitor/main.tf
@@ -31,6 +31,11 @@ resource "aws_kms_key" "ce_anomaly_monitor" {
   enable_key_rotation = true
 }
 
+resource "aws_kms_alias" "ce_anomaly_monitor" {
+  name          = "alias/cost-anomaly-key"
+  target_key_id = aws_kms_key.ce_anomaly_monitor.key_id
+}
+
 resource "aws_kms_key_policy" "ce_anomaly_monitor" {
   provider = aws.target
 

--- a/terraform/aws/analytical-platform/baseline/modules/guardduty/main.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/guardduty/main.tf
@@ -45,7 +45,7 @@ resource "aws_kms_key" "guardduty_findings" {
 }
 
 resource "aws_kms_alias" "guardduty_findings" {
-  name          = "alias/guard-duty-key"
+  name          = "alias/guardduty-findings"
   target_key_id = aws_kms_key.guardduty_findings.key_id
 }
 

--- a/terraform/aws/analytical-platform/baseline/modules/guardduty/main.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/guardduty/main.tf
@@ -44,6 +44,11 @@ resource "aws_kms_key" "guardduty_findings" {
   enable_key_rotation = true
 }
 
+resource "aws_kms_alias" "guardduty_findings" {
+  name          = "alias/guard-duty-key"
+  target_key_id = aws_kms_key.guardduty_findings.key_id
+}
+
 resource "aws_kms_key_policy" "guardduty_findings" {
   provider = aws.target
 


### PR DESCRIPTION
This pr adds aliases to the kms keys for guardduty and cost anomaly ready to be reinstated by previous accidental deletion due to `aws-nuke`