### PR TITLE
Move functionality creating new versions of data product metadata & schemas

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,13 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [5.1.1] - 2023-10-25
+## [5.2.0] - 2023-10-25
+
+Added new versioning module.
 
 ### Added
 
 - Extracted `VersionCreator` from `DataProductMetadata`. This class operates
-  on both metadata and schemas.
+  on both metadata and schemas in the metadata bucket.
 - Moved `s3_copy_folder_to_new_folder` utility from `create_schema` lambda.
+- All schemas are preserved from the previous version when updating
+  metadata.
 
 ## [5.1.0] - 2023-10-24
 

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.1.1] - 2023-10-25
+
+### Added
+
+- Extracted `VersionCreator` from `DataProductMetadata`. This class operates
+  on both metadata and schemas.
+- Moved `s3_copy_folder_to_new_folder` utility from `create_schema` lambda.
+
 ## [5.1.0] - 2023-10-24
 
 ### Added

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "5.1.1",
+  "version": "5.2.0",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "5.1.0",
+  "version": "5.1.1",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_product_metadata.py
+++ b/containers/daap-python-base/src/var/task/data_product_metadata.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import json
 import traceback
 from copy import deepcopy
-from typing import Dict, NamedTuple
+from typing import Dict
 
 import boto3
 import botocore
@@ -49,29 +49,6 @@ glue_csv_table_input_template = {
         "Parameters": {"classification": "csv", "skip.header.line.count": "1"},
     },
 }
-
-
-class Version(NamedTuple):
-    """
-    Helper object for manipulating version strings.
-    """
-
-    major: int
-    minor: int
-
-    def __str__(self):
-        return f"v{self.major}.{self.minor}"
-
-    @staticmethod
-    def parse(version_str) -> Version:
-        major, minor = [int(i) for i in version_str.lstrip("v").split(".")]
-        return Version(major, minor)
-
-    def increment_major(self) -> Version:
-        return Version(self.major + 1, self.minor)
-
-    def increment_minor(self) -> Version:
-        return Version(self.major, self.minor + 1)
 
 
 def format_table_schema(glue_schema: dict) -> dict:
@@ -186,16 +163,6 @@ class BaseJsonSchema:
                 f"version 1 of {self.type.value} already exists for this data product"
             )
             return True
-
-    def generate_next_version_string(self, major: bool = False) -> str:
-        """
-        Generate the next version
-        """
-        current_version = Version.parse(self.version)
-        if major:
-            return str(current_version.increment_major())
-        else:
-            return str(current_version.increment_minor())
 
     def validate(
         self,

--- a/containers/daap-python-base/src/var/task/versioning.py
+++ b/containers/daap-python-base/src/var/task/versioning.py
@@ -106,8 +106,8 @@ class VersionCreator:
         self._copy_from_previous_version(
             latest_version=latest_version, new_version=new_version
         )
-        latest_version_key = self.data_product_config.metadata_path(new_version).key
-        metadata.write_json_to_s3(latest_version_key)
+        new_version_key = self.data_product_config.metadata_path(new_version).key
+        metadata.write_json_to_s3(new_version_key)
 
         return new_version
 

--- a/containers/daap-python-base/src/var/task/versioning.py
+++ b/containers/daap-python-base/src/var/task/versioning.py
@@ -1,0 +1,169 @@
+"""
+Functionality for creating major and minor version updates to a data product.
+"""
+from __future__ import annotations
+
+from enum import Enum
+from typing import NamedTuple
+
+import boto3
+from data_platform_logging import DataPlatformLogger, s3_security_opts
+from data_platform_paths import DataProductConfig
+from data_product_metadata import DataProductMetadata
+
+s3_client = boto3.client("s3")
+
+
+class Version(NamedTuple):
+    """
+    Helper object for manipulating version strings.
+    """
+
+    major: int
+    minor: int
+
+    def __str__(self):
+        return f"v{self.major}.{self.minor}"
+
+    @staticmethod
+    def parse(version_str) -> Version:
+        major, minor = [int(i) for i in version_str.lstrip("v").split(".")]
+        return Version(major, minor)
+
+    def increment_major(self) -> Version:
+        return Version(self.major + 1, self.minor)
+
+    def increment_minor(self) -> Version:
+        return Version(self.major, self.minor + 1)
+
+
+UPDATABLE_METADATA_FIELDS = {
+    "description",
+    "email",
+    "dataProductOwner",
+    "dataProductOwnerDisplayName",
+    "domain",
+    "status",
+    "dpiaRequired",
+    "retentionPeriod",
+    "dataProductMaintainer",
+    "dataProductMaintainerDisplayName",
+    "tags",
+}
+
+
+class UpdateType(Enum):
+    """
+    Whether a schema or data product update represents a major or minor update to the data product.
+
+    Minor updates are those which are backwards compatable, e.g. adding a new table.
+
+    Major updates are those which may require data consumers to update their code,
+    e.g. if tables or fields are removed.
+    """
+
+    Unchanged = 0
+    MinorUpdate = 1
+    MajorUpdate = 2
+    NotAllowed = 3
+
+
+class InvalidUpdate(Exception):
+    """
+    Exception thrown when an update cannot be applied to a data product or schema
+    """
+
+
+class VersionCreator:
+    """
+    Service to create new versions of a data product when metadata or schema are updated.
+    """
+
+    def __init__(self, data_product_name, logger: DataPlatformLogger):
+        self.data_product_config = DataProductConfig(name=data_product_name)
+        self.logger = logger
+
+    def update_metadata(self, input_data) -> str:
+        """
+        Create a new version with updated metadata.
+        """
+        metadata = DataProductMetadata(
+            data_product_name=self.data_product_config.name,
+            logger=self.logger,
+            input_data=input_data,
+        ).load()
+        if not metadata.valid:
+            raise InvalidUpdate()
+
+        state = metadata_update_type(metadata)
+        self.logger.info(f"Update type {state}")
+
+        if state != UpdateType.MinorUpdate:
+            raise InvalidUpdate(state)
+
+        latest_version = metadata.version
+        new_version = str(Version.parse(latest_version).increment_minor())
+        self._copy_from_previous_version(
+            latest_version=latest_version, new_version=new_version
+        )
+        latest_version_key = self.data_product_config.metadata_path(new_version).key
+        metadata.write_json_to_s3(latest_version_key)
+
+        return new_version
+
+    def _copy_from_previous_version(self, latest_version, new_version):
+        bucket, source_folder = self.data_product_config.metadata_path(
+            latest_version
+        ).parent
+
+        s3_copy_folder_to_new_folder(
+            bucket=bucket,
+            source_folder=source_folder,
+            latest_version=latest_version,
+            new_version=new_version,
+            logger=self.logger,
+        )
+
+
+def metadata_update_type(data_product_metadata) -> UpdateType:
+    """
+    Figure out whether changes to the metadata represent a valid update
+    """
+    if not data_product_metadata.exists or not data_product_metadata.valid:
+        return UpdateType.NotAllowed
+
+    changed_fields = data_product_metadata.changed_fields()
+    if not changed_fields:
+        return UpdateType.Unchanged
+    if changed_fields.difference(UPDATABLE_METADATA_FIELDS):
+        return UpdateType.NotAllowed
+    else:
+        return UpdateType.MinorUpdate
+
+
+def s3_copy_folder_to_new_folder(
+    bucket, source_folder, latest_version, new_version, logger
+):
+    """
+    Recurisvely copy a folder, replacing {latest_version} with {new_version}
+    """
+    paginator = s3_client.get_paginator("list_objects_v2")
+    page_iterator = paginator.paginate(
+        Bucket=bucket,
+        Prefix=source_folder,
+    )
+    keys_to_copy = []
+    try:
+        for page in page_iterator:
+            keys_to_copy += [item["Key"] for item in page["Contents"]]
+    except KeyError as e:
+        logger.error(f"metadata for folder is empty but shouldn't be: {e}")
+    for key in keys_to_copy:
+        copy_source = {"Bucket": bucket, "Key": key}
+        destination_key = key.replace(latest_version, new_version)
+        s3_client.copy(
+            CopySource=copy_source,
+            Bucket=bucket,
+            Key=destination_key,
+            ExtraArgs=s3_security_opts,
+        )

--- a/containers/daap-python-base/tests/unit/conftest.py
+++ b/containers/daap-python-base/tests/unit/conftest.py
@@ -93,7 +93,6 @@ def logger():
     return DataPlatformLogger()
 
 
-@pytest.fixture
 def load_v1_metadata_schema_to_mock_s3(s3_client):
     with urllib.request.urlopen(
         "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-environments/main/terraform/environments/data-platform/data-product-metadata-json-schema/v1.0.0/moj_data_product_metadata_spec.json"  # noqa E501
@@ -107,7 +106,6 @@ def load_v1_metadata_schema_to_mock_s3(s3_client):
     )
 
 
-@pytest.fixture
 def load_v1_schema_schema_to_mock_s3(s3_client):
     with urllib.request.urlopen(
         "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-environments/main/terraform/environments/data-platform/data-product-table-schema-json-schema/v1.0.0/moj_data_product_table_spec.json"  # noqa E501
@@ -129,5 +127,8 @@ def metadata_bucket(s3_client, region_name):
         Bucket=bucket_name,
         CreateBucketConfiguration={"LocationConstraint": region_name},
     )
+
+    load_v1_metadata_schema_to_mock_s3(s3_client)
+    load_v1_schema_schema_to_mock_s3(s3_client)
 
     return bucket_name

--- a/containers/daap-python-base/tests/unit/data_product_metadata_test.py
+++ b/containers/daap-python-base/tests/unit/data_product_metadata_test.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import os
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 from unittest.mock import patch
@@ -193,7 +192,7 @@ def test_get_specific_metadata_spec_path(spec_type, expected_out):
 
 class TestDataProductMetadata:
     @pytest.fixture(autouse=True)
-    def setup(self, metadata_bucket, load_v1_metadata_schema_to_mock_s3):
+    def setup(self, metadata_bucket):
         self.bucket_name = metadata_bucket
 
     def test_metadata_exist(self, s3_client):
@@ -272,12 +271,7 @@ class TestDataProductMetadata:
 
 class TestDataProductSchema:
     @pytest.fixture(autouse=True)
-    def setup(
-        self,
-        metadata_bucket,
-        load_v1_schema_schema_to_mock_s3,
-        load_v1_metadata_schema_to_mock_s3,
-    ):
+    def setup(self, metadata_bucket):
         self.bucket_name = metadata_bucket
 
     validation_schema_inputs = [(test_schema_pass, True), (test_schema_fail, False)]

--- a/containers/daap-python-base/tests/unit/data_product_metadata_test.py
+++ b/containers/daap-python-base/tests/unit/data_product_metadata_test.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import os
-import urllib.request
 from tempfile import NamedTemporaryFile
 from unittest import TestCase
 from unittest.mock import patch
@@ -12,8 +11,6 @@ from data_platform_paths import JsonSchemaName
 from data_product_metadata import (
     DataProductMetadata,
     DataProductSchema,
-    InvalidUpdate,
-    VersionCreator,
     format_table_schema,
 )
 
@@ -132,43 +129,6 @@ test_glue_table_input = {
 }
 
 
-def load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client):
-    with urllib.request.urlopen(
-        "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-environments/main/terraform/environments/data-platform/data-product-metadata-json-schema/v1.0.0/moj_data_product_metadata_spec.json"  # noqa E501
-    ) as url:
-        data = json.load(url)
-    json_data = json.dumps(data)
-    s3_client.put_object(
-        Body=json_data,
-        Bucket=bucket_name,
-        Key="data_product_metadata_spec/v1.0.0/moj_data_product_metadata_spec.json",
-    )
-
-
-def load_v1_schema_schema_to_mock_s3(bucket_name, s3_client):
-    with urllib.request.urlopen(
-        "https://raw.githubusercontent.com/ministryofjustice/modernisation-platform-environments/main/terraform/environments/data-platform/data-product-table-schema-json-schema/v1.0.0/moj_data_product_table_spec.json"  # noqa E501
-    ) as url:
-        data = json.load(url)
-    json_data = json.dumps(data)
-    s3_client.put_object(
-        Body=json_data,
-        Bucket=bucket_name,
-        Key="data_product_schema_spec/v1.0.0/moj_data_product_schema_spec.json",
-    )
-
-
-def setup_bucket(name, s3_client, region_name, monkeypatch):
-    bucket_name = name
-    monkeypatch.setenv("BUCKET_NAME", bucket_name)
-
-    # Emulate the data product being set up in the bucket
-    s3_client.create_bucket(
-        Bucket=bucket_name,
-        CreateBucketConfiguration={"LocationConstraint": region_name},
-    )
-
-
 def load_test_data_product_metadata(
     bucket_name, s3_client, metadata=test_metadata_pass
 ):
@@ -231,183 +191,158 @@ def test_get_specific_metadata_spec_path(spec_type, expected_out):
     assert path == expected_out
 
 
-def test_metadata_exist(s3_client, region_name, monkeypatch):
-    bucket_name = os.getenv("METADATA_BUCKET")
-    setup_bucket(bucket_name, s3_client, region_name, monkeypatch)
-    load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client)
-    # populate some folders & files to mock s3 bucket
-    file_text = json.dumps(test_metadata_pass)
-    with NamedTemporaryFile(delete=True, suffix=".json") as tmp:
-        with open(tmp.name, "w", encoding="UTF-8") as f:
-            f.write(file_text)
+class TestDataProductMetadata:
+    @pytest.fixture(autouse=True)
+    def setup(self, metadata_bucket, load_v1_metadata_schema_to_mock_s3):
+        self.bucket_name = metadata_bucket
 
-        s3_client.upload_file(tmp.name, bucket_name, "test_product/v1.0/metadata.json")
+    def test_metadata_exist(self, s3_client):
+        # populate some folders & files to mock s3 bucket
+        file_text = json.dumps(test_metadata_pass)
+        with NamedTemporaryFile(delete=True, suffix=".json") as tmp:
+            with open(tmp.name, "w", encoding="UTF-8") as f:
+                f.write(file_text)
 
-    with patch("data_platform_paths.s3", s3_client):
-        md = DataProductMetadata(
-            data_product_name=test_metadata_pass["name"],
-            logger=logging.getLogger(),
-            input_data=test_metadata_pass,
-        )
-        assert md.exists
+            s3_client.upload_file(
+                tmp.name, self.bucket_name, "test_product/v1.0/metadata.json"
+            )
 
+        with patch("data_platform_paths.s3", s3_client):
+            md = DataProductMetadata(
+                data_product_name=test_metadata_pass["name"],
+                logger=logging.getLogger(),
+                input_data=test_metadata_pass,
+            )
+            assert md.exists
 
-def test_metadata_does_not_exist(s3_client, region_name, monkeypatch):
-    bucket_name = os.getenv("METADATA_BUCKET")
-    setup_bucket(bucket_name, s3_client, region_name, monkeypatch)
-    load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client)
-    with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
-        md = DataProductMetadata(
-            test_metadata_pass["name"],
-            logging.getLogger(),
-            input_data=test_metadata_pass,
-        )
-        assert not md.exists
-
-
-validation_md_inputs = [(test_metadata_pass, True), (test_metadata_fail, False)]
-
-
-@pytest.mark.parametrize("test_metadata, expected_out", validation_md_inputs)
-def test_valid_metadata(
-    test_metadata, expected_out, s3_client, region_name, monkeypatch
-):
-    bucket_name = os.getenv("METADATA_BUCKET")
-    setup_bucket(bucket_name, s3_client, region_name, monkeypatch)
-    load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client)
-    with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
-        md = DataProductMetadata(
-            test_metadata["name"],
-            logging.getLogger(),
-            input_data=test_metadata,
-        )
-        assert md.valid == expected_out
-
-
-validation_schema_inputs = [(test_schema_pass, True), (test_schema_fail, False)]
-
-
-@pytest.mark.parametrize("test_schema, expected_out", validation_schema_inputs)
-def test_valid_schema(test_schema, expected_out, s3_client, region_name, monkeypatch):
-    bucket_name = os.getenv("METADATA_BUCKET")
-    setup_bucket(bucket_name, s3_client, region_name, monkeypatch)
-    load_v1_schema_schema_to_mock_s3(bucket_name, s3_client)
-    load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client)
-    load_test_data_product_metadata(bucket_name, s3_client)
-    with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
-        md = DataProductSchema(
-            data_product_name="test_product",
-            table_name="test_table",
-            logger=logging.getLogger(),
-            input_data=test_schema,
-        )
-        assert md.valid == expected_out
-
-
-def test_write_json_to_s3(s3_client, region_name, monkeypatch):
-    bucket_name = os.getenv("METADATA_BUCKET")
-    setup_bucket(bucket_name, s3_client, region_name, monkeypatch)
-    load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client)
-    with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
-        md = DataProductMetadata(
-            test_metadata_pass["name"],
-            logging.getLogger(),
-            input_data=test_metadata_pass,
-        )
-
-        md.write_json_to_s3("test_product/v1.0/metadata.json")
-
-    response = s3_client.get_object(
-        Bucket=bucket_name, Key="test_product/v1.0/metadata.json"
-    )
-    data = response.get("Body").read().decode("utf-8")
-    from_s3 = json.loads(data)
-
-    assert test_metadata_pass == from_s3
-
-
-@pytest.mark.parametrize(
-    "data_product_name, expected_output",
-    [("test_product", True), ("test_product2", False)],
-)
-def test_does_data_product_metadata_exist(
-    data_product_name, expected_output, s3_client, region_name, monkeypatch
-):
-    bucket_name = os.getenv("METADATA_BUCKET")
-    setup_bucket(bucket_name, s3_client, region_name, monkeypatch)
-    load_v1_schema_schema_to_mock_s3(bucket_name, s3_client)
-    load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client)
-    load_test_data_product_metadata(bucket_name, s3_client)
-
-    with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
-        schema = DataProductSchema(
-            data_product_name=data_product_name,
-            table_name="test_table",
-            logger=logging.getLogger(),
-            input_data=test_schema_pass,
-        )
-        assert schema.has_registered_data_product == expected_output
-
-
-def test_convert_schema_to_glue_table_input_csv(s3_client, region_name, monkeypatch):
-    bucket_name = os.getenv("METADATA_BUCKET")
-    setup_bucket(bucket_name, s3_client, region_name, monkeypatch)
-    load_v1_schema_schema_to_mock_s3(bucket_name, s3_client)
-    load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client)
-    load_test_data_product_metadata(bucket_name, s3_client)
-    with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
-        schema = DataProductSchema(
-            data_product_name="test_product",
-            table_name="test_table",
-            logger=logging.getLogger(),
-            input_data=test_schema_pass,
-        )
-
-        schema.convert_schema_to_glue_table_input_csv()
-
-        # assert schema.data == test_glue_table_input
-        TestCase().assertDictEqual(test_glue_table_input, schema.data)
-
-
-def test_load_json_schema_object(s3_client, region_name, monkeypatch):
-    bucket_name = os.getenv("METADATA_BUCKET")
-    setup_bucket(bucket_name, s3_client, region_name, monkeypatch)
-    load_test_data_product_metadata(bucket_name, s3_client)
-    load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client)
-    with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
-        loaded_metadata = (
-            DataProductMetadata(
+    def test_metadata_does_not_exist(self):
+        with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
+            md = DataProductMetadata(
                 test_metadata_pass["name"],
                 logging.getLogger(),
-                input_data=None,
+                input_data=test_metadata_pass,
             )
-            .load()
-            .latest_version_saved_data
+            assert not md.exists
+
+    validation_md_inputs = [(test_metadata_pass, True), (test_metadata_fail, False)]
+
+    @pytest.mark.parametrize("test_metadata, expected_out", validation_md_inputs)
+    def test_valid_metadata(self, test_metadata, expected_out):
+        with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
+            md = DataProductMetadata(
+                test_metadata["name"],
+                logging.getLogger(),
+                input_data=test_metadata,
+            )
+            assert md.valid == expected_out
+
+    def test_write_json_to_s3(self, s3_client):
+        with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
+            md = DataProductMetadata(
+                test_metadata_pass["name"],
+                logging.getLogger(),
+                input_data=test_metadata_pass,
+            )
+
+            md.write_json_to_s3("test_product/v1.0/metadata.json")
+
+        response = s3_client.get_object(
+            Bucket=self.bucket_name, Key="test_product/v1.0/metadata.json"
         )
+        data = response.get("Body").read().decode("utf-8")
+        from_s3 = json.loads(data)
 
-        assert loaded_metadata == test_metadata_pass
+        assert test_metadata_pass == from_s3
+
+    def test_load_json_schema_object(self, s3_client):
+        load_test_data_product_metadata(self.bucket_name, s3_client)
+        with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
+            loaded_metadata = (
+                DataProductMetadata(
+                    test_metadata_pass["name"],
+                    logging.getLogger(),
+                    input_data=None,
+                )
+                .load()
+                .latest_version_saved_data
+            )
+
+            assert loaded_metadata == test_metadata_pass
 
 
-@pytest.mark.parametrize(
-    "metadata, expected",
-    [(test_metadata_pass, False), (test_metadata_with_schemas, True)],
-)
-def test_schema_parent_metadata_has_registered_schemas(
-    metadata, expected, s3_client, region_name, monkeypatch
-):
-    bucket_name = os.getenv("METADATA_BUCKET")
-    setup_bucket(bucket_name, s3_client, region_name, monkeypatch)
-    load_test_data_product_metadata(bucket_name, s3_client, metadata)
-    load_v1_metadata_schema_to_mock_s3(bucket_name, s3_client)
-    load_v1_schema_schema_to_mock_s3(bucket_name, s3_client)
-    with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
-        schema = DataProductSchema(
-            data_product_name="test_product",
-            table_name="test_table",
-            logger=logging.getLogger(),
-            input_data=test_schema_pass,
-        )
-        assert schema.parent_product_has_registered_schema == expected
+class TestDataProductSchema:
+    @pytest.fixture(autouse=True)
+    def setup(
+        self,
+        metadata_bucket,
+        load_v1_schema_schema_to_mock_s3,
+        load_v1_metadata_schema_to_mock_s3,
+    ):
+        self.bucket_name = metadata_bucket
+
+    validation_schema_inputs = [(test_schema_pass, True), (test_schema_fail, False)]
+
+    @pytest.mark.parametrize("test_schema, expected_out", validation_schema_inputs)
+    def test_valid_schema(self, test_schema, expected_out, s3_client):
+        load_test_data_product_metadata(self.bucket_name, s3_client)
+        with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
+            md = DataProductSchema(
+                data_product_name="test_product",
+                table_name="test_table",
+                logger=logging.getLogger(),
+                input_data=test_schema,
+            )
+            assert md.valid == expected_out
+
+    @pytest.mark.parametrize(
+        "data_product_name, expected_output",
+        [("test_product", True), ("test_product2", False)],
+    )
+    def test_does_data_product_metadata_exist(
+        self, data_product_name, expected_output, s3_client
+    ):
+        load_test_data_product_metadata(self.bucket_name, s3_client)
+
+        with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
+            schema = DataProductSchema(
+                data_product_name=data_product_name,
+                table_name="test_table",
+                logger=logging.getLogger(),
+                input_data=test_schema_pass,
+            )
+            assert schema.has_registered_data_product == expected_output
+
+    def test_convert_schema_to_glue_table_input_csv(self, s3_client):
+        load_test_data_product_metadata(self.bucket_name, s3_client)
+        with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
+            schema = DataProductSchema(
+                data_product_name="test_product",
+                table_name="test_table",
+                logger=logging.getLogger(),
+                input_data=test_schema_pass,
+            )
+
+            schema.convert_schema_to_glue_table_input_csv()
+
+            # assert schema.data == test_glue_table_input
+            TestCase().assertDictEqual(test_glue_table_input, schema.data)
+
+    @pytest.mark.parametrize(
+        "metadata, expected",
+        [(test_metadata_pass, False), (test_metadata_with_schemas, True)],
+    )
+    def test_schema_parent_metadata_has_registered_schemas(
+        self, metadata, expected, s3_client
+    ):
+        load_test_data_product_metadata(self.bucket_name, s3_client, metadata)
+        with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
+            schema = DataProductSchema(
+                data_product_name="test_product",
+                table_name="test_table",
+                logger=logging.getLogger(),
+                input_data=test_schema_pass,
+            )
+            assert schema.parent_product_has_registered_schema == expected
 
 
 @pytest.mark.parametrize(
@@ -418,67 +353,3 @@ def test_format_table_schema(glue_schema, expected):
     out_schema = format_table_schema(glue_schema)
 
     assert out_schema == expected
-
-
-class TestVersionCreator:
-    @pytest.fixture(autouse=True)
-    def setup(self, s3_client, region_name, monkeypatch):
-        self.s3_client = s3_client
-        self.bucket_name = os.getenv("METADATA_BUCKET")
-        setup_bucket(self.bucket_name, s3_client, region_name, monkeypatch)
-        load_test_data_product_metadata(self.bucket_name, s3_client)
-        load_v1_metadata_schema_to_mock_s3(self.bucket_name, s3_client)
-        load_v1_schema_schema_to_mock_s3(self.bucket_name, self.s3_client)
-
-    def assert_has_keys(self, keys):
-        contents = self.s3_client.list_objects_v2(
-            Bucket=self.bucket_name, Prefix=f'{test_metadata_pass["name"]}/v1.1'
-        )["Contents"]
-        actual = {i["Key"] for i in contents}
-
-        assert actual == keys
-
-    def test_creates_minor_version(
-        self,
-    ):
-        input_data = dict(**test_metadata_pass)
-        input_data["description"] = "New description"
-
-        version_creator = VersionCreator(
-            test_metadata_pass["name"], logging.getLogger()
-        )
-
-        version = version_creator.update_metadata(input_data)
-
-        assert version == "v1.1"
-        self.assert_has_keys({"test_product/v1.1/metadata.json"})
-
-    def test_copies_schemas(self):
-        load_test_schema(self.bucket_name, self.s3_client)
-
-        input_data = dict(**test_metadata_pass)
-        input_data["description"] = "New description"
-
-        version_creator = VersionCreator(
-            test_metadata_pass["name"], logging.getLogger()
-        )
-
-        version_creator.update_metadata(input_data)
-
-        self.assert_has_keys(
-            {
-                "test_product/v1.1/metadata.json",
-                "test_product/v1.1/test_table/schema.json",
-            }
-        )
-
-    def test_cannot_update_name(self):
-        input_data = dict(**test_metadata_pass)
-        input_data["name"] = "new name"
-
-        version_creator = VersionCreator(
-            test_metadata_pass["name"], logging.getLogger()
-        )
-
-        with pytest.raises(InvalidUpdate):
-            version_creator.update_metadata(input_data)

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -1,0 +1,98 @@
+import json
+import logging
+
+import pytest
+from versioning import InvalidUpdate, VersionCreator
+
+test_metadata = {
+    "name": "test_product",
+    "description": "just testing the metadata json validation/registration",
+    "domain": "MoJ",
+    "dataProductOwner": "matthew.laverty@justice.gov.uk",
+    "dataProductOwnerDisplayName": "matt laverty",
+    "email": "matthew.laverty@justice.gov.uk",
+    "status": "draft",
+    "retentionPeriod": 3000,
+    "dpiaRequired": False,
+}
+
+test_schema = {
+    "tableDescription": "table has schema to pass test",
+    "columns": [
+        {
+            "name": "col_1",
+            "type": "bigint",
+            "description": "ABCDEFGHIJKLMNOPQRSTUVWXY",
+        },
+        {"name": "col_2", "type": "tinyint", "description": "ABCDEFGHIJKL"},
+        {
+            "name": "col_3",
+            "type": "int",
+            "description": "ABCDEFGHIJKLMNOPQRSTUVWX",
+        },
+        {"name": "col_4", "type": "smallint", "description": "ABCDEFGHIJKLMN"},
+    ],
+}
+
+
+class TestVersionCreator:
+    @pytest.fixture(autouse=True)
+    def setup(self, metadata_bucket, s3_client):
+        self.s3_client = s3_client
+        self.bucket_name = metadata_bucket
+        s3_client.put_object(
+            Body=json.dumps(test_metadata),
+            Bucket=self.bucket_name,
+            Key="test_product/v1.0/metadata.json",
+        )
+
+    def assert_has_keys(self, keys):
+        contents = self.s3_client.list_objects_v2(
+            Bucket=self.bucket_name, Prefix=f"{test_metadata['name']}/v1.1"
+        )["Contents"]
+        actual = {i["Key"] for i in contents}
+
+        assert actual == keys
+
+    def test_creates_minor_version(
+        self,
+    ):
+        input_data = dict(**test_metadata)
+        input_data["description"] = "New description"
+
+        version_creator = VersionCreator(test_metadata["name"], logging.getLogger())
+
+        version = version_creator.update_metadata(input_data)
+
+        assert version == "v1.1"
+        self.assert_has_keys({"test_product/v1.1/metadata.json"})
+
+    def test_copies_schemas(self, s3_client):
+        s3_client.put_object(
+            Body=json.dumps(test_schema),
+            Bucket=self.bucket_name,
+            Key="test_product/v1.0/test_table/schema.json",
+        )
+
+        input_data = dict(**test_metadata)
+        input_data["description"] = "New description"
+
+        version_creator = VersionCreator(test_metadata["name"], logging.getLogger())
+
+        version_creator.update_metadata(input_data)
+
+        self.assert_has_keys(
+            {
+                "test_product/v1.1/metadata.json",
+                "test_product/v1.1/test_table/schema.json",
+            }
+        )
+
+    def test_cannot_update_name(self):
+        input_data = dict(**test_metadata)
+        input_data["name"] = "new name"
+
+        version_creator = VersionCreator(test_metadata["name"], logging.getLogger())
+
+        with pytest.raises(InvalidUpdate):
+            version_creator.update_metadata(input_data)


### PR DESCRIPTION
This PR moves a bunch of versioning related code into a new module for use in the update data product endpoint (https://github.com/ministryofjustice/data-platform/issues/1657)

This is mostly moving functionality I added to the metadata module in https://github.com/ministryofjustice/data-platform/pull/2027. We can potentially build on this in https://github.com/ministryofjustice/data-platform/issues/1925.

This separates some class responsibilities:
- DataPlatformMetadata and DataPlatformSchema more focused on reading/writing these files and converting to glue format
- VersionCreator is responsible for determining what is a major/minor change, and updating the metadata bucket accordingly

I've also moved `s3_copy_folder_to_new_folder` from the create_schema lambda, and ensured that is called when updating metadata fields. This is required to preserve the schemas from the previous version.