### PR TITLE
Validate schema name

### DIFF
--- a/containers/daap-create-schema/CHANGELOG.md
+++ b/containers/daap-create-schema/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.2]
+
+### Changed
+
+- Added missing validation for table name.
+
 ## [1.0.1]
 
 ### Changed

--- a/containers/daap-create-schema/Dockerfile
+++ b/containers/daap-create-schema/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:4.0.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:5.2.0
 
 ARG VERSION
 

--- a/containers/daap-create-schema/config.json
+++ b/containers/daap-create-schema/config.json
@@ -1,6 +1,6 @@
 {
     "name": "daap-create-schema",
-    "version": "1.0.1",
+    "version": "1.0.2",
     "registry": "ecr",
     "ecr": {
       "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",


### PR DESCRIPTION
https://github.com/ministryofjustice/data-catalogue/issues/94

Check schema name against a regex so that it is valid for use with athena.

If invalid, return 400.

This commit also updates the lambda to use the latest response helpers.