### PR TITLE
Handle case where data product is missing

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [5.2.1] - 2023-10-26
+
+### Changed
+
+- `VersionCreator` should handle the case where the data product doesn't exist
+
 ## [5.2.0] - 2023-10-25
 
 Added new versioning module.

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "5.2.0",
+  "version": "5.2.1",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/versioning.py
+++ b/containers/daap-python-base/src/var/task/versioning.py
@@ -92,7 +92,7 @@ class VersionCreator:
             logger=self.logger,
             input_data=input_data,
         ).load()
-        if not metadata.valid:
+        if not metadata.valid or not metadata.exists:
             raise InvalidUpdate()
 
         state = metadata_update_type(metadata)

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -96,3 +96,12 @@ class TestVersionCreator:
 
         with pytest.raises(InvalidUpdate):
             version_creator.update_metadata(input_data)
+
+    def test_cannot_update_product_that_does_not_exist(self):
+        input_data = dict(**test_metadata)
+        input_data["description"] = "New description"
+
+        version_creator = VersionCreator("does_not_exist", logging.getLogger())
+
+        with pytest.raises(InvalidUpdate):
+            version_creator.update_metadata(input_data)


### PR DESCRIPTION
I noticed this was not properly handled in the update metadata lambda.