### PR TITLE
🎡 Set Markdown as default for tech-docs

### DIFF
--- a/.devcontainer/features/src/base/devcontainer-feature.json
+++ b/.devcontainer/features/src/base/devcontainer-feature.json
@@ -3,5 +3,14 @@
   "version": "1.0.0",
   "name": "base",
   "description": "Dev Container Base",
-  "installsAfter": ["ghcr.io/devcontainers/features/common-utils"]
+  "installsAfter": ["ghcr.io/devcontainers/features/common-utils"],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "files.associations": {
+          "*.md.erb": "markdown"
+        }
+      }
+    }
+  }
 }


### PR DESCRIPTION
tech-docs use md.erb files, VS code defaults to Ruby, this changes it to use Markdown