### PR TITLE
Detect and reject early unprocessable CSV formats

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Updated log level from error to info when table is first created
+
 ## [1.2.3] 2023-10-18
 
 ### Changed

--- a/containers/daap-athena-load/src/var/task/create_curated_athena_table.py
+++ b/containers/daap-athena-load/src/var/task/create_curated_athena_table.py
@@ -311,7 +311,7 @@ def does_partition_file_exist(
         for page in page_iterator:
             response += page["Contents"]
     except KeyError as e:
-        logger.error(
+        logger.info(
             f"No {e} key found at data product curated path – the database"
             " doesn't exist and will be created"
         )

--- a/containers/daap-landing-to-raw/CHANGELOG.md
+++ b/containers/daap-landing-to-raw/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0]
+
+### Changes
+
+- Reject CSVs with embedded newlines. We are currently unable to process these
+  CSVs, so the ingestion fails in the athena load step. This changes ensures
+  that we handle the failure gracefully until we implement a solution (e.g.
+  preprocessing the data).
+
 ## [1.2.0]
 
 - Delete file from landing after copying it to raw

--- a/containers/daap-landing-to-raw/config.json
+++ b/containers/daap-landing-to-raw/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-landing-to-raw",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-landing-to-raw/src/var/task/landing_to_raw.py
+++ b/containers/daap-landing-to-raw/src/var/task/landing_to_raw.py
@@ -6,7 +6,7 @@ from data_platform_logging import DataPlatformLogger, s3_security_opts
 from data_platform_paths import BucketPath, RawDataExtraction, get_raw_data_bucket
 from dataengineeringutils3.s3 import read_json_from_s3
 from infer_glue_schema import infer_glue_schema_from_raw_csv
-from validation import DataInvalid, validate_data_against_schema
+from validation import DataInvalid, validate_csv_format, validate_data_against_schema
 
 s3 = boto3.client("s3")
 
@@ -22,6 +22,12 @@ def extract_columns_from_schema(schema: dict) -> dict[str, str]:
         }
     except KeyError:
         raise ValueError(f"Invalid schema: {schema}")
+
+
+def validate_format(bucket_name: str, file_key: str, logger: DataPlatformLogger):
+    obj = boto3.resource("s3").Object(bucket_name, file_key)
+    bytes_stream = obj.get()["Body"]
+    validate_csv_format(bytes_stream, logger)
 
 
 def handler(event, context):
@@ -66,10 +72,14 @@ def handler(event, context):
         inferred_columns = extract_columns_from_schema(inferred_schema)
 
         try:
+            logger.info("Validating schema")
             validate_data_against_schema(
                 inferred_columns=inferred_columns,
                 registered_schema_columns=registered_schema_columns,
             )
+            logger.info("Checking for unprocessable CSV rows")
+            validate_format(bucket_name=bucket_name, file_key=file_key, logger=logger)
+            logger.info("Continuing with ingestion")
         except DataInvalid:
             logger.error(f"{file_key} invalid; moving to fail location", exc_info=True)
             s3.copy(


### PR DESCRIPTION
## Purpose
This is a workaround for https://github.com/ministryofjustice/data-platform/issues/2148

The athena load step cannot process certain kinds of CSVs due to limitations in the OpenCSVSerde used by Athena.

Specifically, this does not support embedded line breaks in CSV files, even though this is valid CSV, and can be produced by a postgres CSV export.

See
https://docs.aws.amazon.com/athena/latest/ug/csv-serde.html https://repost.aws/questions/QUwL_lVp85TPe-i3VP6jcU_A/athena-not-able-to-read-multi-line-text-in-csv-fields

## Description
This commit detects this happening, and fails the ingestion so the problem will be visible to data owners. We can detect the issue via pyarrow's csv parser.

I found the `newlines_in_values` option rejects csvs where the value is unquoted and spans multiple lines. But it still allows through quoted values with newlines in, so I had to check this with a filter.

Long term we would rather preprocess the whole dataset to filter out these newlines, but we don't think this would be a quick fix, and a resource-constrained lambda may be not be the best place for this (we request only 512mb of memory for our lambdas).

## Performance notes
I'm using [pyarrow's open_csv method](https://arrow.apache.org/docs/python/generated/pyarrow.csv.open_csv.html#pyarrow.csv.open_csv) which reads the file in chunks rather than reading the whole CSV into memory, so this will work with 5gb datasets.

I did some experimenting with iterating through all the chunks, but I'm not confident this will not time out with large files so I left it out. We already use a 1.5mb sample of the dataset for the schema validation so it should be good enough for this too.