### PR TITLE
Switch to structured logging with Structlog

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.1.0] - 2023-11-08
+
+### Changed
+
+- DataPlatformLogger now outputs JSON in the stdout logs, so that all the extra
+  data attached to a log record is preserved, and can be parsed and filtered
+  in CloudWatch.
+- The JSON written to S3 is unchanged.
+
 ## [6.0.0] - 2023-11-07
 
 ### Changed
@@ -20,7 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Updated
 
 - Data Product `database_name` property added;
-  includes suffix of major version string e.g. "_v1"
+  includes suffix of major version string e.g. "\_v1"
 - remove csv-specific values from template glue metadata
 
 ## [5.3.1] - 2023-10-26

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "6.0.0",
+  "version": "6.1.0",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_platform_logging.py
+++ b/containers/daap-python-base/src/var/task/data_platform_logging.py
@@ -1,13 +1,11 @@
-import inspect
 import json
 import logging
 import os
-import sys
 import time
-from datetime import datetime
 from typing import List
 
 import boto3
+import structlog
 from botocore.exceptions import ClientError
 from data_platform_paths import data_product_log_bucket_and_key
 
@@ -27,23 +25,6 @@ logging_levels = {
     "WARNING": logging.WARNING,
     "ERROR": logging.ERROR,
 }
-
-
-def _make_log_dict(level: str, msg: str, extra: dict, func: str) -> dict:
-    """
-    creates a dict with all the standard logging items plus a key
-    and value for any of the extra information passed to the logger
-    class.
-    """
-    msg_dict = {}
-    msg_dict["level"] = level
-    msg_dict["date_time"] = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-    msg_dict["message"] = msg
-    msg_dict["function_name"] = func
-
-    for k, v in extra.items():
-        msg_dict[k] = v
-    return msg_dict
 
 
 class DataPlatformLogger:
@@ -83,42 +64,39 @@ class DataPlatformLogger:
 
         for k, v in extra.items():
             self.extra[k] = v
+
         self.log_list_dict: List[dict] = []
         self.format = format
-        self.logger = logging.getLogger()
+        structlog.configure(
+            wrapper_class=structlog.make_filtering_bound_logger(logging_levels[level]),
+            processors=[
+                structlog.processors.EventRenamer(to="message"),
+                structlog.processors.TimeStamper(
+                    fmt="%Y-%m-%d %H:%M:%S", key="date_time"
+                ),
+                structlog.processors.add_log_level,
+                structlog.processors.dict_tracebacks,
+                structlog.processors.CallsiteParameterAdder(
+                    parameters={structlog.processors.CallsiteParameter.FUNC_NAME},
+                    additional_ignores=["data_platform_logging"],
+                ),
+                self.write_log_dict_to_s3_json,
+                structlog.processors.JSONRenderer(),
+            ],
+        )
+        self.logger = structlog.get_logger(**self.extra)
 
         self.log_bucket_path = data_product_log_bucket_and_key(
             lambda_name=self.extra["lambda_name"], data_product_name=data_product_name
         )
 
-        # if used in a lambda function we remove the preloaded handlers
-        for h in self.logger.handlers:
-            self.logger.removeHandler(h)
-
-        handler = logging.StreamHandler(sys.stdout)
-
-        handler.setFormatter(logging.Formatter(format, datefmt="%Y-%m-%d %H:%M:%S"))
-        self.logger.addHandler(handler)
-        self.logger.setLevel(logging_levels[level])
-
-    def add_extras(self, other_extras: dict, format=None):
+    def add_extras(self, other_extras: dict):
         """
         This method can be used to add additional information to a logger
         object after it has been instantiated.
-
-        If given a format the new information will be added to the log
-        line in the standard output too. Other wise the extra information
-        will be collected in log_list_dict and can be written out as a json.
         """
-        for k, v in other_extras.items():
-            self.extra[k] = v
-        if format is not None:
-            self.logger.removeHandler(self.logger.handlers[0])
-            handler = logging.StreamHandler(sys.stdout)
-
-            handler.setFormatter(logging.Formatter(format, datefmt="%Y-%m-%d %H:%M:%S"))
-            self.logger.addHandler(handler)
-
+        self.extra.update(other_extras)
+        self.logger = self.logger.bind(**other_extras)
         return self
 
     def debug(self, msg: str, *args, **kwargs):
@@ -129,9 +107,7 @@ class DataPlatformLogger:
         Also adds the displays log info plus everything contained in extra.
 
         """
-        log_dict = _make_log_dict("debug", msg, self.extra, inspect.stack()[1].function)
-        self._write_log_dict_to_s3_json(log_dict)
-        self.logger.debug(msg, *args, extra=self.extra, **kwargs)
+        self.logger.debug(msg, *args, **kwargs)
 
     def info(self, msg: str, *args, **kwargs):
         """
@@ -141,9 +117,7 @@ class DataPlatformLogger:
         Also adds the displays log info plus everything contained in extra.
 
         """
-        log_dict = _make_log_dict("info", msg, self.extra, inspect.stack()[1].function)
-        self._write_log_dict_to_s3_json(log_dict)
-        self.logger.info(msg, *args, extra=self.extra, **kwargs)
+        self.logger.info(msg, *args, **kwargs)
 
     def warning(self, msg: str, *args, **kwargs):
         """
@@ -153,11 +127,7 @@ class DataPlatformLogger:
         Also adds the displays log info plus everything contained in extra.
 
         """
-        log_dict = _make_log_dict(
-            "warning", msg, self.extra, inspect.stack()[1].function
-        )
-        self._write_log_dict_to_s3_json(log_dict)
-        self.logger.warning(msg, *args, extra=self.extra, **kwargs)
+        self.logger.warning(msg, *args, **kwargs)
 
     def error(self, msg: str, *args, **kwargs):
         """
@@ -167,17 +137,14 @@ class DataPlatformLogger:
         Also adds the displays log info plus everything contained in extra.
 
         """
-        log_dict = _make_log_dict("error", msg, self.extra, inspect.stack()[1].function)
-        self._write_log_dict_to_s3_json(log_dict)
-        self.logger.error(msg, *args, extra=self.extra, **kwargs)
+        self.logger.error(msg, *args, **kwargs)
 
-    def _write_log_dict_to_s3_json(
-        self, log_line: dict, additional_args: dict = s3_security_opts
-    ) -> None:
+    def write_log_dict_to_s3_json(self, _logger, _method_name, event_dict) -> dict:
         """
         writes the list of log dicts to s3 as a json file in the correct
         format for an athena table
         """
+        event_dict["function_name"] = event_dict.pop("func_name")
         s3_client = boto3.client("s3")
 
         try:
@@ -191,17 +158,18 @@ class DataPlatformLogger:
                 # if an unexpected error we want to exit the method
                 # to avoid creating a log file with 1 line of last log
                 # but not raise an error, disrupting the application
-                print(e)
-                return None
+                return event_dict
         else:
             data = response.get("Body").read().decode("utf-8")
             jlines = data
 
-        jlines += json.dumps(log_line) + "\n"
+        jlines += json.dumps(event_dict) + "\n"
 
         s3_client.put_object(
             Body=jlines,
             Bucket=self.log_bucket_path.bucket,
             Key=self.log_bucket_path.key,
-            **additional_args
+            **s3_security_opts
         )
+
+        return event_dict

--- a/containers/daap-python-base/src/var/task/requirements.txt
+++ b/containers/daap-python-base/src/var/task/requirements.txt
@@ -13,3 +13,4 @@ rpds-py==0.10.0
 s3transfer==0.6.2
 six==1.16.0
 urllib3==1.26.18
+structlog==23.2.0

--- a/containers/daap-python-base/tests/unit/data_platform_logging_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_logging_test.py
@@ -51,7 +51,12 @@ def test_stdout_info_log(extra_input, s3_client, region_name, capsys, monkeypatc
 
     test_logger.info("test info message")
     captured = capsys.readouterr()
-    assert "INFO     | 2023-01-01 00:00:00 | test info message\n" == captured.out
+    event_info = json.loads(captured.out)
+
+    assert event_info["message"] == "test info message"
+    assert event_info["date_time"] == "2023-01-01 00:00:00"
+    assert event_info["level"] == "info"
+    assert set(extra_input.items()).issubset(set(event_info.items()))
 
 
 @freeze_time("2023-01-01")
@@ -62,7 +67,11 @@ def test_stdout_warning_log(s3_client, region_name, capsys, monkeypatch):
     test_logger = DataPlatformLogger()
     test_logger.warning("test warning message")
     captured = capsys.readouterr()
-    assert "WARNING  | 2023-01-01 00:00:00 | test warning message\n" == captured.out
+    event_info = json.loads(captured.out)
+
+    assert event_info["message"] == "test warning message"
+    assert event_info["date_time"] == "2023-01-01 00:00:00"
+    assert event_info["level"] == "warning"
 
 
 @freeze_time("2023-01-01")
@@ -75,7 +84,11 @@ def test_stdout_debug_log(s3_client, region_name, capsys, monkeypatch):
     captured = capsys.readouterr()
     all_outputs = captured.out.split("\n")
     last_out = all_outputs[-2]
-    assert "DEBUG    | 2023-01-01 00:00:00 | test debug message" == last_out
+    event_info = json.loads(last_out)
+
+    assert event_info["message"] == "test debug message"
+    assert event_info["date_time"] == "2023-01-01 00:00:00"
+    assert event_info["level"] == "debug"
 
 
 @freeze_time("2023-01-01")
@@ -86,7 +99,11 @@ def test_stdout_error_log(s3_client, region_name, capsys, monkeypatch):
     test_logger = DataPlatformLogger()
     test_logger.error("test error message")
     captured = capsys.readouterr()
-    assert "ERROR    | 2023-01-01 00:00:00 | test error message\n" == captured.out
+    event_info = json.loads(captured.out)
+
+    assert event_info["message"] == "test error message"
+    assert event_info["date_time"] == "2023-01-01 00:00:00"
+    assert event_info["level"] == "error"
 
 
 @pytest.mark.parametrize("extra_input", extra_inputs)


### PR DESCRIPTION
## Problem
Our lambdas log in a plain text format, and only send the full JSON to s3. This means that cloudwatch doesn't have the extra fields like `data_product_name`, so we can't filter very easily or count events for specific data products/tables.

For https://github.com/ministryofjustice/data-platform/issues/2034 I am investigating surfacing these logs in Grafana, so would like to send the full structured data to cloudwatch.

Note that it is possible to query the data in S3 via Athena, instead of visualising the data in cloudwatch but we don't have this configured yet, and I'm not sure if it adds additional cost.

**I also noticed that the process of writing logs to s3 may lose events**, because there is no way to append lines to objects in s3, so we're actually reading the whole file for the current (date, data product, lambda) combination, appending in python, and then writing back to s3. This assumes that the same lambda will never be called concurrently for the same data product, but this is not going to be the case when uploading multiple tables for the same product.

## Description
I've added [structlog](https://www.structlog.org/en/stable/index.html) as a drop in replacement for logging. This library was recommended in the lambda docs: https://docs.aws.amazon.com/lambda/latest/operatorguide/parse-logs.html

I've configured it to output logs as JSON instead of unstructured stdout. This means we now send the same structured data to cloudwatch as well as s3.

## Notes
- We could configure this differently in development - the library ships with a formatter that pretty prints the structured data. But for now I wanted to keep it simple.
- I've intentionally not made any changes to the s3 logging (except to wire it up to structlog's processor chain)