### PR TITLE
🚑 Add `limit-severities-for-sarif` option to `aquasecurity/trivy-action`

### DIFF
--- a/.github/workflows/reusable-workflow-containers.yml
+++ b/.github/workflows/reusable-workflow-containers.yml
@@ -189,6 +189,7 @@ jobs:
           format: sarif
           output: trivy-results.sarif
           severity: CRITICAL
+          limit-severities-for-sarif: true
 
       - name: Upload SARIF
         if: always()


### PR DESCRIPTION
Correctly pass severity when using SARIF format

Resolves #2251

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>