### PR TITLE
📌 Patch containers

### DIFF
--- a/containers/alpine-base/CHANGELOG.md
+++ b/containers/alpine-base/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-11-07
+
+###
+
+- Bumped Alpine to 3.18.3
+
 ## [0.2.0] - 2023-08-08
 
 ###

--- a/containers/alpine-base/CHANGELOG.md
+++ b/containers/alpine-base/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ###
 
-- Bumped Alpine to 3.18.3
+- Bumped Alpine to 3.18.4
 
 ## [0.2.0] - 2023-08-08
 

--- a/containers/alpine-base/CHANGELOG.md
+++ b/containers/alpine-base/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2023-11-07
 
-###
+### Changed
 
 - Bumped Alpine to 3.18.4
 

--- a/containers/alpine-base/Dockerfile
+++ b/containers/alpine-base/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.18.3
+FROM docker.io/alpine:3.18.4
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Data Platform" \

--- a/containers/alpine-base/config.json
+++ b/containers/alpine-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "alpine-base",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "registry": "dockerhub"
 }

--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.1] 2023-11-07
+## [1.3.1] 2023-11-08
 
 ### Changed
 
+- Updated base image
+- Updated pip
 - Updated urllib3
 
 ## [1.3.0] 2023-11-02

--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.1] 2023-11-07
+
+### Changed
+
+- Updated urllib3
+
 ## [1.3.0] 2023-11-02
 
 ### Updated

--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- update Dockerfile COPY command fixing `LAMBDA_TASK_ROOT` typo
-
 ## [1.3.1] 2023-11-08
 
 ### Changed

--- a/containers/daap-athena-load/Dockerfile
+++ b/containers/daap-athena-load/Dockerfile
@@ -1,11 +1,12 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:3.2.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.0.0
+
 ARG VERSION
 
 ENV VERSION="${VERSION}"
 
 COPY src/var/task ${LAMDA_TASK_ROOT}
 
-RUN python -m pip install --no-cache-dir --upgrade pip==23.2.1 \
+RUN python -m pip install --no-cache-dir --upgrade pip==23.3.1 \
     && python -m pip install --no-cache-dir --requirement requirements.txt
 
 CMD ["athena_load_handler.handler"]

--- a/containers/daap-athena-load/config.json
+++ b/containers/daap-athena-load/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-athena-load",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-athena-load/src/var/task/requirements.txt
+++ b/containers/daap-athena-load/src/var/task/requirements.txt
@@ -16,5 +16,5 @@ PyYAML==6.0
 s3fs==0.4.2
 s3transfer==0.6.1
 six==1.16.0
-urllib3==1.26.17
+urllib3==1.26.18
 wrapt==1.15.0

--- a/containers/daap-landing-to-raw/CHANGELOG.md
+++ b/containers/daap-landing-to-raw/CHANGELOG.md
@@ -9,10 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [1.3.2] 2023-11-07
+## [1.3.1] 2023-11-08
 
 ### Changed
 
+- Updated base image
+- Updated pip
 - Updated urllib3
 
 ## [1.3.1]

--- a/containers/daap-landing-to-raw/CHANGELOG.md
+++ b/containers/daap-landing-to-raw/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] 2023-11-07
+
+### Changed
+
+- Updated urllib3
+
 ## [1.3.1]
 
 - Bugfix for embedded newline check.

--- a/containers/daap-landing-to-raw/CHANGELOG.md
+++ b/containers/daap-landing-to-raw/CHANGELOG.md
@@ -9,8 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- update Dockerfile COPY command fixing `LAMBDA_TASK_ROOT` typo
-
 ## [1.3.1] 2023-11-08
 
 ### Changed

--- a/containers/daap-landing-to-raw/Dockerfile
+++ b/containers/daap-landing-to-raw/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:5.1.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.0.0
 
 ARG VERSION
 
@@ -6,7 +6,7 @@ ENV VERSION="${VERSION}"
 
 COPY src/var/task ${LAMDA_TASK_ROOT}
 
-RUN python -m pip install --no-cache-dir --upgrade pip==23.2.1 \
+RUN python -m pip install --no-cache-dir --upgrade pip==23.3.1 \
     && python -m pip install --no-cache-dir --requirement requirements.txt
 
 CMD ["landing_to_raw.handler"]

--- a/containers/daap-landing-to-raw/config.json
+++ b/containers/daap-landing-to-raw/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-landing-to-raw",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-landing-to-raw/src/var/task/requirements.txt
+++ b/containers/daap-landing-to-raw/src/var/task/requirements.txt
@@ -12,4 +12,4 @@ referencing==0.30.2
 rpds-py==0.10.0
 s3transfer==0.6.2
 six==1.16.0
-urllib3==1.26.17
+urllib3==1.26.18

--- a/containers/kubectl/CHANGELOG.md
+++ b/containers/kubectl/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2023-11-07
+
+###
+
+- Bumped Alpine to 3.18.4
+
 ## [0.2.0] - 2023-08-08
 
 ###

--- a/containers/kubectl/CHANGELOG.md
+++ b/containers/kubectl/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.3.0] - 2023-11-07
 
-###
+### Changed
 
 - Bumped Alpine to 3.18.4
 

--- a/containers/kubectl/Dockerfile
+++ b/containers/kubectl/Dockerfile
@@ -1,4 +1,4 @@
-FROM docker.io/alpine:3.18.3
+FROM docker.io/alpine:3.18.4
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Data Platform" \
@@ -26,7 +26,7 @@ RUN addgroup \
     && mkdir --parents ${CONTAINER_HOME} \
     && chown --recursive ${CONTAINER_USER}:${CONTAINER_GROUP} ${CONTAINER_HOME} \
     && apk add --no-cache --virtual build \
-      curl==8.2.1-r0 \
+      curl==8.4.0-r0 \
     && curl --location "https://dl.k8s.io/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl" \
       --output /usr/local/bin/kubectl \
     && chmod +x /usr/local/bin/kubectl \

--- a/containers/kubectl/config.json
+++ b/containers/kubectl/config.json
@@ -1,5 +1,5 @@
 {
   "name": "kubectl",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "registry": "dockerhub"
 }


### PR DESCRIPTION
Bump Alpine to 3.18.4

Supersedes:

- #1729
- #1740
- #1962
- #1961

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>