### PR TITLE
✨ Add `ONBUILD` to DaaP Python Base

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.0.0] - 2023-11-07
+
+### Changed
+
+- Adds `ONBUILD` for downstream images
+
 ## [5.4.0] - 2023-11-02
 
 ### Updated

--- a/containers/daap-python-base/Dockerfile
+++ b/containers/daap-python-base/Dockerfile
@@ -4,7 +4,11 @@ ARG VERSION
 
 ENV BASE_VERSION="${VERSION}"
 
-COPY src/var/task ${LAMDA_TASK_ROOT}
+COPY src/var/task ${LAMBDA_TASK_ROOT}
 
-RUN python -m pip install --no-cache-dir --upgrade pip==23.2.1 \
+RUN python -m pip install --no-cache-dir --upgrade pip==23.3.1 \
     && python -m pip install --no-cache-dir --requirement requirements.txt
+
+ONBUILD RUN yum update --assumeyes \
+            && yum clean all \
+            && rm -rf /var/cache/yum

--- a/containers/daap-python-base/Dockerfile
+++ b/containers/daap-python-base/Dockerfile
@@ -6,13 +6,13 @@ ENV BASE_VERSION="${VERSION}"
 
 COPY src/var/task ${LAMBDA_TASK_ROOT}
 
-RUN yum update --assumeyes \
+RUN yum update --security --assumeyes \
     && yum clean all \
     && rm -rf /var/cache/yum
 
 RUN python -m pip install --no-cache-dir --upgrade pip==23.3.1 \
     && python -m pip install --no-cache-dir --requirement requirements.txt
 
-ONBUILD RUN yum update --assumeyes \
+ONBUILD RUN yum update --security --assumeyes \
             && yum clean all \
             && rm -rf /var/cache/yum

--- a/containers/daap-python-base/Dockerfile
+++ b/containers/daap-python-base/Dockerfile
@@ -6,6 +6,10 @@ ENV BASE_VERSION="${VERSION}"
 
 COPY src/var/task ${LAMBDA_TASK_ROOT}
 
+RUN yum update --assumeyes \
+    && yum clean all \
+    && rm -rf /var/cache/yum
+
 RUN python -m pip install --no-cache-dir --upgrade pip==23.3.1 \
     && python -m pip install --no-cache-dir --requirement requirements.txt
 

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "5.4.0",
+  "version": "6.0.0",
   "registry": "ghcr"
 }


### PR DESCRIPTION
This pull request:

- Adds an [`ONBUILD`](https://docs.docker.com/engine/reference/builder/#onbuild) instruction so child images run a `yum update --security` before proceeding, this will pull in any patches for system packages
- Fixes a typo in `LAMBDA_TASK_ROOT`
- Bumps pip to `23.3.1`