### PR TITLE
Return text/plain preview instead of application/json

### DIFF
--- a/containers/daap-preview-data/CHANGELOG.md
+++ b/containers/daap-preview-data/CHANGELOG.md
@@ -9,7 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- update Dockerfile COPY command fixing `LAMBDA_TASK_ROOT` typo
+## [2.0.0] - 2023-11-08
+
+### Changed
+
+- Return `text/plain` responses instead of `application/json`
+- Update Dockerfile COPY command fixing `LAMBDA_TASK_ROOT` typo
 
 ## [1.0.2] - 2023-11-06
 

--- a/containers/daap-preview-data/config.json
+++ b/containers/daap-preview-data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "daap-preview-data",
-    "version": "1.0.2",
+    "version": "2.0.0",
     "registry": "ecr",
     "ecr": {
         "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-preview-data/tests/unit/mock_test.py
+++ b/containers/daap-preview-data/tests/unit/mock_test.py
@@ -127,10 +127,10 @@ def test_query_athena_with_results(
 
     processed_results = result["body"]
 
-    expected_results = '"| Header1      | Header2      | Header2Longerone |\
-\\n| Row 1 Data 1 | Row 1 Data 2 | 20231023T144052Z |\
-\\n| Row 2 Data 1 | Row 2 Data 2 | 20231024T144052Z |\
-\\n| Row 3 Data 1 | Row 3 Data 2 | 20231025T144052Z |\\n"'
+    expected_results = "| Header1      | Header2      | Header2Longerone |\
+\n| Row 1 Data 1 | Row 1 Data 2 | 20231023T144052Z |\
+\n| Row 2 Data 1 | Row 2 Data 2 | 20231024T144052Z |\
+\n| Row 3 Data 1 | Row 3 Data 2 | 20231025T144052Z |\n"
 
     assert processed_results == expected_results
 
@@ -159,6 +159,6 @@ def test_query_athena_without_results(
 
     processed_results = result["body"]
 
-    expected_results = '"No data to display"'
+    expected_results = "No data to display"
 
     assert processed_results == expected_results


### PR DESCRIPTION
Currently, API gateway is returning the response as a JSON encoded string, e.g.

`"| col_0              | col_1               | col_2               | col_3               | extraction_timestamp |\n| 0.1915194503788923 | 0.3648859839013723  | 0.0598092227798519  | 0.2852509600245098  | 20231023T144052Z     |\n| 0.7853585837137692 | 0.3688240060019745  | 0.6748809435823302  | 0.19567517866589823 | 20231023T144052Z     |\n| 0.7799758081188035 | 0.9331401019825216  | 0.5946247799344488  | 0.38231745203150647 | 20231023T144052Z     |\n| 0.2725926052826416 | 0.6513781432265774  | 0.5333101629987506  | 0.05387368514623658 | 20231023T144052Z     |\n| 0.2764642551430967 | 0.3972025777261542  | 0.04332406269480349 | 0.45164840826085906 | 20231023T144052Z     |\n| 0.6221087710398319 | 0.6153961784334937  | 0.18428708381381365 | 0.624916705305911   | 20231023T144052Z     |\n| 0.4377277390071145 | 0.07538124164297655 | 0.04735527880151513 | 0.47809379567067456 | 20231023T144052Z     |\n| 0.8018721775350193 | 0.7887301429407455  | 0.5614330800633979  | 0.9820047415219545  | 20231023T144052Z     |\n| 0.9581393536837052 | 0.31683612216887125 | 0.329668445620915   | 0.12394270048696299 | 20231023T144052Z     |\n| 0.8759326347420947 | 0.5680986526260692  | 0.5029668331126184  | 0.1193808979262484  | 20231023T144052Z     |\n"`

(Note the enclosing quote characters and literal \n instead of line breaks).

We actually want this to be plain text, formatted so that it displays nicely on a console.

This means the lambda proxy needs to return a value like this to API gateway:

```javascript
{
  "body": "| col_0 ...",  /* not json encoded */
  "headers": {
    "content-type": "text/plain"
  }
}
```