### PR TITLE
🛂 Adds `ap-rshiny-notesbook` to ECR trust

### DIFF
--- a/terraform/aws/analytical-platform/oidc/oidc-providers.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-providers.tf
@@ -152,7 +152,7 @@ module "analytical_platform_data_production_github_oidc_provider" {
 
   role_name              = "github-actions-ecr-oidc-dummy"
   additional_permissions = data.aws_iam_policy_document.analytical_platform_data_production_github_oidc_provider.json
-  github_repositories    = [format("ministryofjustice/%s:*", "data-platform-dummy-repo")]
+  github_repositories    = [format("ministryofjustice/%s:*", "data-platform-dummy-repo", "ap-rshiny-notesbook")]
 
   tags_prefix = "data-platform"
   tags_common = var.tags

--- a/terraform/aws/analytical-platform/oidc/oidc-providers.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-providers.tf
@@ -152,7 +152,10 @@ module "analytical_platform_data_production_github_oidc_provider" {
 
   role_name              = "github-actions-ecr-oidc-dummy"
   additional_permissions = data.aws_iam_policy_document.analytical_platform_data_production_github_oidc_provider.json
-  github_repositories    = [format("ministryofjustice/%s:*", "data-platform-dummy-repo", "ap-rshiny-notesbook")]
+  github_repositories = [
+    "ministryofjustice/data-platform-dummy-repo:*",
+    "ministryofjustice/ap-rshiny-notesbook:*"
+  ]
 
   tags_prefix = "data-platform"
   tags_common = var.tags


### PR DESCRIPTION
Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>