### PR TITLE
Extend logger to avoid use of extra dictionaries

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [6.2.0] - 2023-11-10
+
+## Changed
+
+- DataPlatformLogger now automatically adds version info the log context
+- DataPlatformLogger now accepts a `table_name` argument
+- Added `add_data_product()` to DataPlatformLogger to complement `add_extras()`
+
 ## [6.1.1] - 2023-11-10
 
 ### Changed

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "6.1.1",
+  "version": "6.2.0",
   "registry": "ghcr"
 }


### PR DESCRIPTION
Ensure logging is more consistent by moving some of the logged values currently paased through the `extra` argument to inside the logging module.