### PR TITLE
[DP-2064] Tie data to a major version, instead of a minor version

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [7.0.0] - 2023-11-14
 
-## Changed
+### Changed
 
 - Data paths now contain only the major version. A minor version change implies
   the schemas are all backwards compatable with existing data.

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.0.0] - 2023-11-14
+
+## Changed
+
+- Data paths now contain only the major version. A minor version change implies
+  the schemas are all backwards compatable with existing data.
+
 ## [6.3.1] - 2023-11-14
 
 ### Changed

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "6.3.1",
+  "version": "7.0.0",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -235,11 +235,12 @@ def generate_all_element_version_prefixes(
     """Generates element prefixes for all data product versions"""
 
     data_product_versions = get_all_versions(data_product_name)
+    major_versions = {version.split(".")[0] for version in data_product_versions}
     element_prefixes = []
 
-    for version in data_product_versions:
+    for major_version in major_versions:
         element_prefixes.append(
-            f"{path_prefix}/{data_product_name}/{version}/{table_name}/"
+            f"{path_prefix}/{data_product_name}/{major_version}/{table_name}/"
         )
 
     return element_prefixes

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -257,7 +257,7 @@ class DataProductElement:
 
     @property
     def database_name(self) -> str:
-        latest_major_version = self.data_product.latest_version.split(".")[0]
+        latest_major_version = self.data_product.latest_major_version
         return self.data_product.name + "_" + latest_major_version
 
     @staticmethod
@@ -269,7 +269,7 @@ class DataProductElement:
     def landing_data_prefix(self):
         """
         The path to the raw data in s3 up to and including the element name,
-        e.g. landing/{data-product}/{version}/{some_element}
+        e.g. landing/{data-product}/{major-version}/{some_element}
         """
         return BucketPath(
             bucket=self.data_product.landing_zone_bucket,
@@ -281,7 +281,7 @@ class DataProductElement:
     def raw_data_prefix(self):
         """
         The path to the raw data in s3 up to and including the element name,
-        e.g. raw/{data-product}/{version}/{some_element}
+        e.g. raw/{data-product}/{major-version}/{some_element}
         """
         return BucketPath(
             bucket=self.data_product.raw_data_bucket,
@@ -292,7 +292,7 @@ class DataProductElement:
     def curated_data_prefix(self):
         """
         The path to the curated data in s3 up to and including the element name,
-        e.g. curated/{data-product}/{version}/{some-element}/
+        e.g. curated/{data-product}/{major-version}/{some-element}/
         """
         return BucketPath(
             bucket=self.data_product.curated_data_bucket,
@@ -392,38 +392,39 @@ class DataProductConfig:
 
     def __post_init__(self):
         self.latest_version = get_latest_version(self.name)
+        self.latest_major_version = self.latest_version.split(".")[0]
 
     @property
     def raw_data_prefix(self):
         """
         The path to the raw data in s3 excluding the element name,
-        e.g. raw/my-data-product/version/
+        e.g. raw/my-data-product/major-version/
         """
         return BucketPath(
             bucket=self.raw_data_bucket,
-            key=os.path.join("raw", self.name, self.latest_version) + "/",
+            key=os.path.join("raw", self.name, self.latest_major_version) + "/",
         )
 
     @property
     def landing_data_prefix(self):
         """
         The path to the landing data in s3 excluding the element name,
-        e.g. landing/my-data-product/version/
+        e.g. landing/my-data-product/major-version/
         """
         return BucketPath(
             bucket=self.landing_zone_bucket,
-            key=os.path.join("landing", self.name, self.latest_version) + "/",
+            key=os.path.join("landing", self.name, self.latest_major_version) + "/",
         )
 
     @property
     def curated_data_prefix(self):
         """
         The path to the curated data in s3 excluding the element name,
-        e.g. curated/my-data-product/version/
+        e.g. curated/my-data-product/major-version/
         """
         return BucketPath(
             bucket=self.curated_data_bucket,
-            key=os.path.join("curated", self.name, self.latest_version) + "/",
+            key=os.path.join("curated", self.name, self.latest_major_version) + "/",
         )
 
     def element(self, name):

--- a/containers/daap-python-base/tests/unit/conftest.py
+++ b/containers/daap-python-base/tests/unit/conftest.py
@@ -209,7 +209,12 @@ def table_name():
 
 @pytest.fixture
 def data_product_versions():
-    return {"v1.0", "v1.1", "v1.2"}
+    return {"v1.0", "v1.1", "v1.2", "v2.0"}
+
+
+@pytest.fixture
+def data_product_major_versions():
+    return {"v1", "v2"}
 
 
 @pytest.fixture
@@ -219,9 +224,9 @@ def create_raw_and_curated_data(
     create_curated_bucket,
     data_product_name,
     table_name,
-    data_product_versions,
+    data_product_major_versions,
 ):
-    for version in data_product_versions:
+    for version in data_product_major_versions:
         for i in range(10):
             s3_client.put_object(
                 Bucket=os.getenv("CURATED_DATA_BUCKET"),

--- a/containers/daap-python-base/tests/unit/data_platform_paths_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_paths_test.py
@@ -103,17 +103,17 @@ def test_data_product_element_config():
 
         assert element.landing_data_prefix == BucketPath(
             bucket="landing",
-            key="landing/data_product/v1.0/some_table/",
+            key="landing/data_product/v1/some_table/",
         )
 
         assert element.raw_data_prefix == BucketPath(
             bucket="raw",
-            key="raw/data_product/v1.0/some_table/",
+            key="raw/data_product/v1/some_table/",
         )
 
         assert element.curated_data_prefix == BucketPath(
             bucket="curated",
-            key="curated/data_product/v1.0/some_table/",
+            key="curated/data_product/v1/some_table/",
         )
 
 
@@ -128,14 +128,14 @@ def test_data_product_config_path_prefixes():
         )
 
         assert config.raw_data_prefix == BucketPath(
-            bucket="raw", key="raw/my-database/v1.0/"
+            bucket="raw", key="raw/my-database/v1/"
         )
         assert config.curated_data_prefix == BucketPath(
-            bucket="curated", key="curated/my-database/v1.0/"
+            bucket="curated", key="curated/my-database/v1/"
         )
 
         assert config.landing_data_prefix == BucketPath(
-            bucket="landing", key="landing/my-database/v1.0/"
+            bucket="landing", key="landing/my-database/v1/"
         )
 
 
@@ -174,7 +174,7 @@ def test_data_product_element_raw_data_path():
 
         assert path == BucketPath(
             bucket="raw",
-            key=f"raw/my-database/v1.0/some-table/load_timestamp=20230905T165300Z/{uuid_value}{file_extension}",
+            key=f"raw/my-database/v1/some-table/load_timestamp=20230905T165300Z/{uuid_value}{file_extension}",
         )
 
 
@@ -199,7 +199,7 @@ def test_data_product_element_landing_data_path():
 
         assert path == BucketPath(
             bucket="landing",
-            key=f"landing/my-database/v1.0/some-table/load_timestamp=20230905T165300Z/{uuid_value}{file_extension}",
+            key=f"landing/my-database/v1/some-table/load_timestamp=20230905T165300Z/{uuid_value}{file_extension}",
         )
 
 
@@ -244,7 +244,7 @@ def test_extraction_config():
         assert extraction.timestamp == timestamp
         assert extraction.path == BucketPath(
             bucket="raw",
-            key=f"raw/my-database/v1.0/some-table/load_timestamp=20230905T165300Z/{uuid_value}{file_extension}",
+            key=f"raw/my-database/v1/some-table/load_timestamp=20230905T165300Z/{uuid_value}{file_extension}",
         )
 
 
@@ -254,7 +254,7 @@ def test_extraction_config_parse_from_raw_uri(monkeypatch):
     monkeypatch.setenv("LANDING_ZONE_BUCKET", "bucket4")
 
     raw_data_uri = (
-        "s3://bucket1/raw/database-name/v1.0/table-name/load_timestamp=20230905T162700Z/"
+        "s3://bucket1/raw/database-name/v1/table-name/load_timestamp=20230905T162700Z/"
         + "7cf8e644-06af-47ce-8f5f-b53c22a35f2e"
     )
 
@@ -264,7 +264,7 @@ def test_extraction_config_parse_from_raw_uri(monkeypatch):
         assert config.path == BucketPath(
             bucket="bucket1",
             key=(
-                "raw/database-name/v1.0/table-name/load_timestamp=20230905T162700Z/"
+                "raw/database-name/v1/table-name/load_timestamp=20230905T162700Z/"
                 + "7cf8e644-06af-47ce-8f5f-b53c22a35f2e"
             ),
         )

--- a/containers/daap-python-base/tests/unit/data_platform_paths_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_paths_test.py
@@ -87,7 +87,7 @@ def test_data_product_config_specification_prefix():
     )
 
 
-def test_data_product_element_config(monkeypatch):
+def test_data_product_element_config():
     with patch("data_platform_paths.get_latest_version", lambda _: "v1.0"):
         element = DataProductElement.load("some_table", "data_product")
 

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -457,13 +457,13 @@ class TestUpdateMetadataRemoveSchema:
         create_raw_and_curated_data,
         data_product_name,
         glue_client,
-        data_product_versions,
+        data_product_major_versions,
     ):
         version_creator = VersionCreator(data_product_name, logging.getLogger())
         schema_list = ["schema0"]
         with patch("glue_utils.glue_client", glue_client):
             # Validate we have the required number of files
-            for version in data_product_versions:
+            for version in data_product_major_versions:
                 curated_prefix = f"curated/{data_product_name}/{version}/schema0/"
                 response = s3_client.list_objects_v2(
                     Bucket=os.getenv("CURATED_DATA_BUCKET"),
@@ -482,7 +482,7 @@ class TestUpdateMetadataRemoveSchema:
             version_creator.update_metadata_remove_schemas(schema_list=schema_list)
 
             # Validate files are deleted
-            for version in data_product_versions:
+            for version in data_product_major_versions:
                 curated_prefix = f"curated/{data_product_name}/{version}/schema0/"
                 response = s3_client.list_objects_v2(
                     Bucket=os.getenv("CURATED_DATA_BUCKET"),
@@ -511,7 +511,7 @@ class TestUpdateMetadataRemoveSchema:
         with patch("glue_utils.glue_client", glue_client):
             # Call the handler
             version_creator.update_metadata_remove_schemas(schema_list=schema_list)
-            schema_prefix = f"{data_product_name}/v2.0/{schema_list[0]}/schema.json"
+            schema_prefix = f"{data_product_name}/v3.0/{schema_list[0]}/schema.json"
             response = s3_client.list_objects_v2(
                 Bucket=self.bucket_name,
                 Prefix=schema_prefix,
@@ -584,23 +584,23 @@ class TestRemoveAllVersions:
             Bucket=self.bucket_name,
             Prefix=prefix,
         )
-        assert response.get("KeyCount") == 12
+        assert response.get("KeyCount") == 16
 
-        # Assert we have the correct number of metadata files to begin with
+        # Assert we have the correct number of raw files to begin with
         prefix = f"raw/{data_product_name}/"
         response = s3_client.list_objects_v2(
             Bucket=os.getenv("RAW_DATA_BUCKET"),
             Prefix=prefix,
         )
-        assert response.get("KeyCount") == 30
+        assert response.get("KeyCount") == 20
 
-        # Assert we have the correct number of metadata files to begin with
+        # Assert we have the correct number of curated files to begin with
         prefix = f"curated/{data_product_name}/"
         response = s3_client.list_objects_v2(
             Bucket=os.getenv("CURATED_DATA_BUCKET"),
             Prefix=prefix,
         )
-        assert response.get("KeyCount") == 30
+        assert response.get("KeyCount") == 20
 
         #######################################################################
         version_creator = VersionCreator(data_product_name, logging.getLogger())


### PR DESCRIPTION
https://github.com/ministryofjustice/data-catalogue/issues/85

## Description
All data paths now contain the major version `/v1/` or `/v2/` rather than the full version `/v1.0/` or `/v2.1/`

## Consequences
- It is no longer possible to derive a full data product version from a file path. The version is the last minor version corresponding to the major version in the path.
- Data uploaded in an earlier minor version is still accessible via the athena table after a minor update. E.g. my_data_product_v1.some_table queries all data uploaded to v1.0, v1.1, v1.2 etc
- When columns have been added in a minor version, data from historical parquet files will be treated as NULL in the athena table ([source: stack overflow](https://stackoverflow.com/questions/67280896/add-columns-to-aws-athena-paquet-tables/67333744#67333744))

## Todo
- [x] Review landing-to-raw, presigned-url, athena-load - see if this breaks any assumptions
- [x] TBC: What happens when we add columns? In this case we will have historic parquet files without the column stored in the same location. Will this break athena, or set the columns to null?