### PR TITLE
✨ Add Entra ID Auth0 connections

### DIFF
--- a/terraform/auth0/ministryofjustice-data-platform-development/auth0-connections.tf
+++ b/terraform/auth0/ministryofjustice-data-platform-development/auth0-connections.tf
@@ -1,0 +1,18 @@
+resource "auth0_connection" "justiceuk_data_platform_auth0_ministryofjustice_development" {
+  name         = "justiceuk-data-platform-auth0-ministryofjustice-development"
+  display_name = "Ministry of Justice"
+  strategy     = "waad"
+
+  show_as_button = true
+
+  options {
+    identity_api                           = "microsoft-identity-platform-v2.0"
+    domain                                 = "justiceuk.onmicrosoft.com"
+    tenant_domain                          = "justiceuk.onmicrosoft.com"
+    client_id                              = data.aws_secretsmanager_secret_version.entra_id_client_id.secret_string
+    client_secret                          = data.aws_secretsmanager_secret_version.entra_id_client_secret.secret_string
+    set_user_root_attributes               = "on_each_login"
+    should_trust_email_verified_connection = "always_set_emails_as_verified"
+    waad_protocol                          = "openid-connect"
+  }
+}

--- a/terraform/auth0/ministryofjustice-data-platform-development/data.tf
+++ b/terraform/auth0/ministryofjustice-data-platform-development/data.tf
@@ -25,3 +25,21 @@ data "aws_secretsmanager_secret_version" "auth0_client_secret" {
 
   secret_id = "auth0/ministryofjustice-data-platform-development/client-secret"
 }
+
+data "aws_secretsmanager_secret_version" "entra_id_tenant_id" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "auth0/ministryofjustice-data-platform-development/entra-id/tenant-id"
+}
+
+data "aws_secretsmanager_secret_version" "entra_id_client_id" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "auth0/ministryofjustice-data-platform-development/entra-id/client-id"
+}
+
+data "aws_secretsmanager_secret_version" "entra_id_client_secret" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "auth0/ministryofjustice-data-platform-development/entra-id/client-secret"
+}

--- a/terraform/auth0/ministryofjustice-data-platform-development/data.tf
+++ b/terraform/auth0/ministryofjustice-data-platform-development/data.tf
@@ -26,12 +26,6 @@ data "aws_secretsmanager_secret_version" "auth0_client_secret" {
   secret_id = "auth0/ministryofjustice-data-platform-development/client-secret"
 }
 
-data "aws_secretsmanager_secret_version" "entra_id_tenant_id" {
-  provider = aws.analytical-platform-management-production
-
-  secret_id = "auth0/ministryofjustice-data-platform-development/entra-id/tenant-id"
-}
-
 data "aws_secretsmanager_secret_version" "entra_id_client_id" {
   provider = aws.analytical-platform-management-production
 

--- a/terraform/auth0/ministryofjustice-data-platform/auth0-connections.tf
+++ b/terraform/auth0/ministryofjustice-data-platform/auth0-connections.tf
@@ -1,0 +1,18 @@
+resource "auth0_connection" "justiceuk_data_platform_auth0_ministryofjustice_production" {
+  name         = "justiceuk-data-platform-auth0-ministryofjustice-production"
+  display_name = "Ministry of Justice"
+  strategy     = "waad"
+
+  show_as_button = true
+
+  options {
+    identity_api                           = "microsoft-identity-platform-v2.0"
+    domain                                 = "justiceuk.onmicrosoft.com"
+    tenant_domain                          = "justiceuk.onmicrosoft.com"
+    client_id                              = data.aws_secretsmanager_secret_version.entra_id_client_id.secret_string
+    client_secret                          = data.aws_secretsmanager_secret_version.entra_id_client_secret.secret_string
+    set_user_root_attributes               = "on_each_login"
+    should_trust_email_verified_connection = "always_set_emails_as_verified"
+    waad_protocol                          = "openid-connect"
+  }
+}

--- a/terraform/auth0/ministryofjustice-data-platform/data.tf
+++ b/terraform/auth0/ministryofjustice-data-platform/data.tf
@@ -25,3 +25,21 @@ data "aws_secretsmanager_secret_version" "auth0_client_secret" {
 
   secret_id = "auth0/ministryofjustice-data-platform/client-secret"
 }
+
+data "aws_secretsmanager_secret_version" "entra_id_tenant_id" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "auth0/ministryofjustice-data-platform/entra-id/tenant-id"
+}
+
+data "aws_secretsmanager_secret_version" "entra_id_client_id" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "auth0/ministryofjustice-data-platform/entra-id/client-id"
+}
+
+data "aws_secretsmanager_secret_version" "entra_id_client_secret" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "auth0/ministryofjustice-data-platform/entra-id/client-secret"
+}

--- a/terraform/auth0/ministryofjustice-data-platform/data.tf
+++ b/terraform/auth0/ministryofjustice-data-platform/data.tf
@@ -26,12 +26,6 @@ data "aws_secretsmanager_secret_version" "auth0_client_secret" {
   secret_id = "auth0/ministryofjustice-data-platform/client-secret"
 }
 
-data "aws_secretsmanager_secret_version" "entra_id_tenant_id" {
-  provider = aws.analytical-platform-management-production
-
-  secret_id = "auth0/ministryofjustice-data-platform/entra-id/tenant-id"
-}
-
 data "aws_secretsmanager_secret_version" "entra_id_client_id" {
   provider = aws.analytical-platform-management-production
 


### PR DESCRIPTION
This pull request:

- Is part of #2231 
- Creates Entra ID enterprise connections in Auth0

Manual steps:

1. Created Azure App Registrations
- [development](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/8eba29f8-9305-4565-b31d-78cc0effbb38/isMSAApp~/false)
- [production](https://portal.azure.com/#view/Microsoft_AAD_RegisteredApps/ApplicationMenuBlade/~/Overview/appId/7e626e8c-4fac-433c-a809-26826ea7f651/isMSAApp~/false)

2. Created AWS Secrets Manager secrets in `analytical-platform-management-production`
- `auth0/${TENANT_NAME}/entra-id/tenant-id`
- `auth0/${TENANT_NAME}/entra-id/client-id`
- `auth0/${TENANT_NAME}/entra-id/client-secret`

3. Applied locally to validate

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>