### PR TITLE
✨ Add Data Platform Control Panel Development Auth0 client

### DIFF
--- a/terraform/auth0/ministryofjustice-data-platform-development/auth0-clients.tf
+++ b/terraform/auth0/ministryofjustice-data-platform-development/auth0-clients.tf
@@ -1,0 +1,9 @@
+resource "auth0_client" "data_platform_control_panel" {
+  name     = "data-platform-control-panel"
+  app_type = "regular_web"
+}
+
+resource "auth0_connection_client" "data_platform_control_panel_entra_id" {
+  client_id     = auth0_client.data_platform_control_panel.id
+  connection_id = auth0_connection.justiceuk_data_platform_auth0_ministryofjustice_development.id
+}


### PR DESCRIPTION
This pull request:

- Is part of #2231 
- Creates skeleton Auth0 client for Data Platform Control Panel Development
- Links said Auth0 client to our Entra ID integration

Notes:

- Uses https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/client
- Uses https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/connection_client

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>