### PR TITLE
❤️ Import and manage Auth0 tenants

### DIFF
--- a/terraform/auth0/ministryofjustice-data-platform-development/auth0-tenant.tf
+++ b/terraform/auth0/ministryofjustice-data-platform-development/auth0-tenant.tf
@@ -1,0 +1,15 @@
+/*
+  As per the documentation for this resource (https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant)
+    > Creating tenants through the Management API is not currently supported.
+    > Therefore, this resource can only manage an existing tenant created through the Auth0 dashboard.
+  I (@jacobwoffenden) have imported this using the suggested mechanism from https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant#import
+    > terraform import auth0_tenant.this <UUID>
+*/
+
+resource "auth0_tenant" "this" {
+  friendly_name         = "Ministry of Justice Data Platform Development"
+  idle_session_lifetime = 72
+  session_lifetime      = 168
+  support_email         = "data-platform-tech@digital.justice.gov.uk"
+  support_url           = "https://github.com/ministryofjustice/data-platform-support/issues/new/choose"
+}

--- a/terraform/auth0/ministryofjustice-data-platform/auth0-tenant.tf
+++ b/terraform/auth0/ministryofjustice-data-platform/auth0-tenant.tf
@@ -1,0 +1,15 @@
+/*
+  As per the documentation for this resource (https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant)
+    > Creating tenants through the Management API is not currently supported.
+    > Therefore, this resource can only manage an existing tenant created through the Auth0 dashboard.
+  I (@jacobwoffenden) have imported this using the suggested mechanism from https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant#import
+    > terraform import auth0_tenant.this <UUID>
+*/
+
+resource "auth0_tenant" "this" {
+  friendly_name         = "Ministry of Justice Data Platform"
+  idle_session_lifetime = 72
+  session_lifetime      = 168
+  support_email         = "data-platform-tech@digital.justice.gov.uk"
+  support_url           = "https://github.com/ministryofjustice/data-platform-support/issues/new/choose"
+}


### PR DESCRIPTION
This pull request:

- Imports our new Auth0 tenants
- Sets some basic attributes on them

Notes:

As documented in the code

> Creating tenants through the Management API is not currently supported. Therefore, this resource can only manage an existing tenant created through the Auth0 dashboard.

([source](https://registry.terraform.io/providers/auth0/auth0/latest/docs/resources/tenant))


Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>