### PR TITLE
Dropping Cal's permissions

### DIFF
--- a/terraform/github/analytical-platform-teams.tf
+++ b/terraform/github/analytical-platform-teams.tf
@@ -14,7 +14,6 @@ locals {
         "julialawrence",     # Julia Lawrence
         "bagg3rs",           # Richard Baguley
         "jacobwoffenden",    # Jacob Woffenden
-        "calumabarnett",     # Calum Barnett
         "SimonsMOJ",         # Simon Heron
         "mshodge",           # Michael Hodges
         "YvanMOJdigital",    # Yvan Smith


### PR DESCRIPTION
Calum is now part of another team and doesn't need anything above data engineering levels of access. 