### PR TITLE
Bump base image version to 7.0.0 for anything that touches the data bucket

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] 2023-11-15
+
+- Updated base image to 7.0.0
+
 ## [1.4.0] 2023-11-13
 
 - Updated base image to 6.2.0

--- a/containers/daap-athena-load/Dockerfile
+++ b/containers/daap-athena-load/Dockerfile
@@ -1,5 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.2.0
-
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:7.0.0
 ARG VERSION
 
 ENV VERSION="${VERSION}"

--- a/containers/daap-athena-load/config.json
+++ b/containers/daap-athena-load/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-athena-load",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-delete-data-product/CHANGELOG.md
+++ b/containers/daap-delete-data-product/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0] 2023-11-15
+
+### Changed
+
+- Update base image to 7.0.0
+
 ## [1.2.0] 2023-11-14
 
 ### Removes

--- a/containers/daap-delete-data-product/Dockerfile
+++ b/containers/daap-delete-data-product/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.3.1
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:7.0.0
 
 ARG VERSION
 

--- a/containers/daap-delete-data-product/config.json
+++ b/containers/daap-delete-data-product/config.json
@@ -1,6 +1,6 @@
 {
     "name": "daap-delete-data-product",
-    "version": "1.2.0",
+    "version": "1.3.0",
     "registry": "ecr",
     "ecr": {
         "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-delete-table-for-data-product/CHANGELOG.md
+++ b/containers/daap-delete-table-for-data-product/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2023-11-15
+
+### Changed
+
+- update base image to 7.0.0
+
 ## [2.1.0] - 2023-11-13
 
 ### Changed
@@ -27,7 +33,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - Most of the work done previously has now been moved to
-    the `VersionCreator.update_metadata_remove_schemas` method
+  the `VersionCreator.update_metadata_remove_schemas` method
 - `get_all_versions` moved to base
 - `generate_all_element_version_prefixes` moved to base
 - `delete_all_element_version_data_files` moved to base

--- a/containers/daap-delete-table-for-data-product/Dockerfile
+++ b/containers/daap-delete-table-for-data-product/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.2.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:7.0.0
 
 ARG VERSION
 

--- a/containers/daap-delete-table-for-data-product/config.json
+++ b/containers/daap-delete-table-for-data-product/config.json
@@ -1,6 +1,6 @@
 {
     "name": "daap-delete-table-for-data-product",
-    "version": "2.1.0",
+    "version": "2.2.0",
     "registry": "ecr",
     "ecr": {
         "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-delete-table-for-data-product/tests/unit/conftest.py
+++ b/containers/daap-delete-table-for-data-product/tests/unit/conftest.py
@@ -135,7 +135,12 @@ def event(data_product_name, table_name):
 
 @pytest.fixture
 def data_product_versions():
-    return {"v1.0", "v1.1", "v1.2"}
+    return {"v1.0", "v1.1", "v1.2", "v2.0"}
+
+
+@pytest.fixture
+def data_product_major_versions():
+    return {"v1", "v2"}
 
 
 @pytest.fixture
@@ -194,9 +199,13 @@ def create_glue_table(create_glue_database, glue_client, data_product_name, tabl
 
 @pytest.fixture
 def create_raw_data(
-    s3_client, create_raw_bucket, data_product_name, table_name, data_product_versions
+    s3_client,
+    create_raw_bucket,
+    data_product_name,
+    table_name,
+    data_product_major_versions,
 ):
-    for version in data_product_versions:
+    for version in data_product_major_versions:
         for i in range(10):
             s3_client.put_object(
                 Bucket=os.getenv("RAW_DATA_BUCKET"),
@@ -211,9 +220,9 @@ def create_curated_data(
     create_curated_bucket,
     data_product_name,
     table_name,
-    data_product_versions,
+    data_product_major_versions,
 ):
-    for version in data_product_versions:
+    for version in data_product_major_versions:
         for i in range(10):
             s3_client.put_object(
                 Bucket=os.getenv("CURATED_DATA_BUCKET"),

--- a/containers/daap-delete-table-for-data-product/tests/unit/mock_test.py
+++ b/containers/daap-delete-table-for-data-product/tests/unit/mock_test.py
@@ -22,7 +22,7 @@ class TestHandler:
         assert response["statusCode"] == HTTPStatus.OK
         assert (
             json.loads(response["body"])["message"]
-            == "Successfully removed table 'table-name', data files and generated new matadata version 'v2.0'"
+            == "Successfully removed table 'table-name', data files and generated new matadata version 'v3.0'"
         )
 
     def test_metadata_fail(
@@ -71,10 +71,10 @@ class TestHandler:
         s3_client,
         data_product_name,
         table_name,
-        data_product_versions,
+        data_product_major_versions,
     ):
         bucket = os.getenv("RAW_DATA_BUCKET")
-        for version in data_product_versions:
+        for version in data_product_major_versions:
             prefix = f"raw/{data_product_name}/{version}/{table_name}/"
             response = s3_client.list_objects_v2(
                 Bucket=bucket,
@@ -85,7 +85,7 @@ class TestHandler:
         # Call the handler
         delete_table.handler(event=event, context=fake_context)
 
-        for version in data_product_versions:
+        for version in data_product_major_versions:
             prefix = f"raw/{data_product_name}/{version}/{table_name}/"
             response = s3_client.list_objects_v2(
                 Bucket=bucket,
@@ -105,11 +105,11 @@ class TestHandler:
         s3_client,
         data_product_name,
         table_name,
-        data_product_versions,
+        data_product_major_versions,
     ):
         bucket = os.getenv("CURATED_DATA_BUCKET")
 
-        for version in data_product_versions:
+        for version in data_product_major_versions:
             prefix = f"curated/{data_product_name}/{version}/{table_name}/"
             response = s3_client.list_objects_v2(
                 Bucket=bucket,
@@ -120,7 +120,7 @@ class TestHandler:
         # Call the handler
         delete_table.handler(event=event, context=fake_context)
 
-        for version in data_product_versions:
+        for version in data_product_major_versions:
             prefix = f"curated/{data_product_name}/{version}/{table_name}/"
             response = s3_client.list_objects_v2(
                 Bucket=bucket,
@@ -146,8 +146,8 @@ class TestHandler:
         response = delete_table.handler(event=event, context=fake_context)
         bucket = os.getenv("METADATA_BUCKET")
 
-        # Validate that v2.0 of schema.json doesnt exist
-        schema_prefix = f"{data_product_name}/v2.0/{table_name}/schema.json"
+        # Validate that v3.0 of schema.json doesnt exist
+        schema_prefix = f"{data_product_name}/v3.0/{table_name}/schema.json"
         response = s3_client.list_objects_v2(
             Bucket=bucket,
             Prefix=schema_prefix,

--- a/containers/daap-landing-to-raw/CHANGELOG.md
+++ b/containers/daap-landing-to-raw/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] 2023-11-15
+
+- Updated base image to 7.0.0
+
 ## [1.4.0] 2023-11-13
 
 ### Changed

--- a/containers/daap-landing-to-raw/Dockerfile
+++ b/containers/daap-landing-to-raw/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.2.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:7.0.0
 
 ARG VERSION
 

--- a/containers/daap-landing-to-raw/config.json
+++ b/containers/daap-landing-to-raw/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-landing-to-raw",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-presigned-url/CHANGELOG.md
+++ b/containers/daap-presigned-url/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.0] 2023-11-15
+
+### Changed
+
+- Update base image to 7.0.0
+
 ## [1.6.0] 2023-11-14
 
 ### Changed

--- a/containers/daap-presigned-url/Dockerfile
+++ b/containers/daap-presigned-url/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.2.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:7.0.0
 
 ARG VERSION
 

--- a/containers/daap-presigned-url/config.json
+++ b/containers/daap-presigned-url/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-presigned-url",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-presigned-url/tests/unit/mock_test.py
+++ b/containers/daap-presigned-url/tests/unit/mock_test.py
@@ -50,7 +50,7 @@ def test_success(s3_client, fake_context, region_name, monkeypatch):
     assert body["URL"]["url"] == "https://bucket.s3.amazonaws.com/"
     assert (
         body["URL"]["fields"]["key"]
-        == f"landing/database1/v1.0/table1/load_timestamp=20230101T000000Z/{a_uuid}{file_extension}"
+        == f"landing/database1/v1/table1/load_timestamp=20230101T000000Z/{a_uuid}{file_extension}"
     )
 
 

--- a/containers/daap-preview-data/CHANGELOG.md
+++ b/containers/daap-preview-data/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2023-11-15
+
+### Changed
+
+- Updated base image to 7.0.0
+
 ## [2.1.1] - 2023-11-15
 
 ### Changed

--- a/containers/daap-preview-data/Dockerfile
+++ b/containers/daap-preview-data/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.2.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:7.0.0
 
 ARG VERSION
 

--- a/containers/daap-preview-data/config.json
+++ b/containers/daap-preview-data/config.json
@@ -1,6 +1,6 @@
 {
     "name": "daap-preview-data",
-    "version": "2.1.1",
+    "version": "2.2.0",
     "registry": "ecr",
     "ecr": {
         "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-reload-data-product/CHANGELOG.md
+++ b/containers/daap-reload-data-product/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0]
+
+### Changed
+
+- update base image to 7.0.0
+
 ## [2.1.0]
 
 ### Changed

--- a/containers/daap-reload-data-product/Dockerfile
+++ b/containers/daap-reload-data-product/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.2.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:7.0.0
 
 ARG VERSION
 

--- a/containers/daap-reload-data-product/config.json
+++ b/containers/daap-reload-data-product/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-reload-data-product",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-reload-data-product/tests/unit/reload_data_product_test.py
+++ b/containers/daap-reload-data-product/tests/unit/reload_data_product_test.py
@@ -99,8 +99,8 @@ def test_get_data_product_pages(s3_client, raw_data_bucket, data_product):
     )
     assert len(pages) == 1
     assert {i["Key"] for i in pages[0]["Contents"]} == {
-        "raw/foo/v1.0/bar/abc",
-        "raw/foo/v1.0/bar/baz",
+        "raw/foo/v1/bar/abc",
+        "raw/foo/v1/bar/baz",
     }
 
 
@@ -163,13 +163,13 @@ def test_handler_invokes_lambda_for_each_raw_file(
     do_nothing_lambda_client.invoke.assert_any_call(
         FunctionName="athena_load_lambda",
         InvocationType="Event",
-        Payload=f'{{"detail":{{"bucket":{{"name":"{raw_data_bucket}"}}, "object":{{"key":"raw/foo/v1.0/bar/abc"}}}}}}',
+        Payload=f'{{"detail":{{"bucket":{{"name":"{raw_data_bucket}"}}, "object":{{"key":"raw/foo/v1/bar/abc"}}}}}}',
     )
 
     do_nothing_lambda_client.invoke.assert_any_call(
         FunctionName="athena_load_lambda",
         InvocationType="Event",
-        Payload=f'{{"detail":{{"bucket":{{"name":"{raw_data_bucket}"}}, "object":{{"key":"raw/foo/v1.0/bar/baz"}}}}}}',
+        Payload=f'{{"detail":{{"bucket":{{"name":"{raw_data_bucket}"}}, "object":{{"key":"raw/foo/v1/bar/baz"}}}}}}',
     )
 
 

--- a/containers/daap-resync-unprocessed-files/CHANGELOG.md
+++ b/containers/daap-resync-unprocessed-files/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.2.0] - 2023-11-15
+
+- update base image to 7.0.0
+
 ## [2.1.0] - 2023-11-13
 
 - update base image to 6.2.0

--- a/containers/daap-resync-unprocessed-files/Dockerfile
+++ b/containers/daap-resync-unprocessed-files/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:6.2.0
+FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:7.0.0
 
 ARG VERSION
 

--- a/containers/daap-resync-unprocessed-files/config.json
+++ b/containers/daap-resync-unprocessed-files/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-resync-unprocessed-files",
-  "version": "2.1.0",
+  "version": "2.2.0",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",

--- a/containers/daap-resync-unprocessed-files/tests/unit/resync_unprocessed_file_test.py
+++ b/containers/daap-resync-unprocessed-files/tests/unit/resync_unprocessed_file_test.py
@@ -64,8 +64,8 @@ def test_get_raw_data_unique_extraction_timestamps(
     )
     raw_table_timestamp = sorted(get_unique_load_timestamps(pages))
     assert {i for i in raw_table_timestamp} == {
-        "data_product/v1.0/table_name/load_timestamp=timestamp1",
-        "data_product/v1.0/table_name/load_timestamp=timestamp2",
+        "data_product/v1/table_name/load_timestamp=timestamp1",
+        "data_product/v1/table_name/load_timestamp=timestamp2",
     }
 
 
@@ -80,7 +80,7 @@ def test_get_curated_unique_extraction_timestamps(
 
     curated_table_timestamp = sorted(get_unique_load_timestamps(pages))
     assert {i for i in curated_table_timestamp} == {
-        "data_product/v1.0/table_name/load_timestamp=timestamp1"
+        "data_product/v1/table_name/load_timestamp=timestamp1"
     }
 
 
@@ -105,5 +105,5 @@ def test_get_resync_keys(s3_client, data_element, raw_data_bucket, curated_data_
     )
 
     assert {i for i in raw_keys_to_resync} == {
-        "raw/data_product/v1.0/table_name/" + "load_timestamp=timestamp2/file2.csv"
+        "raw/data_product/v1/table_name/" + "load_timestamp=timestamp2/file2.csv"
     }


### PR DESCRIPTION
This brings in the changes from https://github.com/ministryofjustice/data-platform/pull/2347 to remove the minor version from s3 paths in the data bucket.

After this, it would be a good idea to delete the existing glue databases and curated data, since we have had multiple breaking changes
- this rename of the s3 paths
- the previous rename of the database names

We can recreate them by running the resync lambda.