### PR TITLE
🚚 Update GitHub team slugs for accessing Modernisation Platform

### DIFF
--- a/terraform/github/analytical-platform-teams.tf
+++ b/terraform/github/analytical-platform-teams.tf
@@ -36,123 +36,123 @@ locals {
 
   analytical_platform_modernisation_platform_teams = {
     /* Analytical Platform */
-    "analytical-platform-development-modernisation-platform-administrator" = {
-      name           = "analytical-platform-development-modernisation-platform-administrator"
-      description    = "Analytical Platform Development Modernisation Platform Administrator"
+    "analytical-platform-development-administrator" = {
+      name           = "analytical-platform-development-administrator"
+      description    = "Analytical Platform Development Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members
       ])
     },
-    "analytical-platform-production-modernisation-platform-administrator" = {
-      name           = "analytical-platform-production-modernisation-platform-administrator"
-      description    = "Analytical Platform Production Modernisation Platform Administrator"
+    "analytical-platform-production-administrator" = {
+      name           = "analytical-platform-production-administrator"
+      description    = "Analytical Platform Production Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members
       ])
     },
     /* Analytical Platform Data */
-    "analytical-platform-data-development-modernisation-platform-administrator" = {
-      name           = "analytical-platform-data-development-modernisation-platform-administrator"
-      description    = "Analytical Platform Data Development Modernisation Platform Administrator"
+    "analytical-platform-data-development-administrator" = {
+      name           = "analytical-platform-data-development-administrator"
+      description    = "Analytical Platform Data Development Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members
       ])
     },
-    "analytical-platform-data-development-modernisation-platform-data-engineer" = {
-      name           = "analytical-platform-data-development-modernisation-platform-data-engineer"
-      description    = "Analytical Platform Data Development Modernisation Platform Data Engineer"
+    "analytical-platform-data-development-data-engineer" = {
+      name           = "analytical-platform-data-development-data-engineer"
+      description    = "Analytical Platform Data Development Data Engineer"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_engineering_team_members
       ])
     },
-    "analytical-platform-data-production-modernisation-platform-administrator" = {
-      name           = "analytical-platform-data-production-modernisation-platform-administrator"
-      description    = "Analytical Platform Data Production Modernisation Platform Administrator"
+    "analytical-platform-data-production-administrator" = {
+      name           = "analytical-platform-data-production-administrator"
+      description    = "Analytical Platform Data Production Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members
       ])
     },
-    "analytical-platform-data-production-modernisation-platform-data-engineer" = {
-      name           = "analytical-platform-data-production-modernisation-platform-data-engineer"
-      description    = "Analytical Platform Data Production Modernisation Platform Data Engineer"
+    "analytical-platform-data-production-data-engineer" = {
+      name           = "analytical-platform-data-production-data-engineer"
+      description    = "Analytical Platform Data Production Data Engineer"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_engineering_team_members
       ])
     },
     /* Analytical Platform Data Engineering */
-    "analytical-platform-data-engineering-sandboxa-modernisation-platform-administrator" = {
-      name           = "analytical-platform-data-engineering-sandboxa-modernisation-platform-administrator"
-      description    = "Analytical Platform Data Engineering SandboxA Modernisation Platform Administrator"
+    "analytical-platform-data-engineering-sandboxa-administrator" = {
+      name           = "analytical-platform-data-engineering-sandboxa-administrator"
+      description    = "Analytical Platform Data Engineering SandboxA Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members,
         local.data_engineering_team_members
       ])
     },
-    "analytical-platform-data-engineering-sandboxa-modernisation-platform-data-engineer" = {
-      name           = "analytical-platform-data-engineering-sandboxa-modernisation-platform-data-engineer"
-      description    = "Analytical Platform Data Engineering SandboxA Modernisation Platform Data Engineer"
+    "analytical-platform-data-engineering-sandboxa-data-engineer" = {
+      name           = "analytical-platform-data-engineering-sandboxa-data-engineer"
+      description    = "Analytical Platform Data Engineering SandboxA Data Engineer"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_engineering_team_members
       ])
     },
-    "analytical-platform-data-engineering-sandboxa-modernisation-platform-developer" = {
-      name           = "analytical-platform-data-engineering-sandboxa-modernisation-platform-developer"
-      description    = "Analytical Platform Data Engineering SandboxA Modernisation Platform Developer"
+    "analytical-platform-data-engineering-sandboxa-developer" = {
+      name           = "analytical-platform-data-engineering-sandboxa-developer"
+      description    = "Analytical Platform Data Engineering SandboxA Developer"
       parent_team_id = module.analytical_platform_team.id
       members        = flatten([])
     },
-    "analytical-platform-data-engineering-production-modernisation-platform-administrator" = {
-      name           = "analytical-platform-data-engineering-production-modernisation-platform-administrator"
-      description    = "Analytical Platform Data Engineering Production Modernisation Platform Administrator"
+    "analytical-platform-data-engineering-production-administrator" = {
+      name           = "analytical-platform-data-engineering-production-administrator"
+      description    = "Analytical Platform Data Engineering Production Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members
       ])
     },
-    "analytical-platform-data-engineering-production-modernisation-platform-data-engineer" = {
-      name           = "analytical-platform-data-engineering-production-modernisation-platform-data-engineer"
-      description    = "Analytical Platform Data Engineering Production Modernisation Platform Data Engineer"
+    "analytical-platform-data-engineering-production-data-engineer" = {
+      name           = "analytical-platform-data-engineering-production-data-engineer"
+      description    = "Analytical Platform Data Engineering Production Data Engineer"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_engineering_team_members
       ])
     },
-    "analytical-platform-data-engineering-production-modernisation-platform-developer" = {
-      name           = "analytical-platform-data-engineering-production-modernisation-platform-developer"
-      description    = "Analytical Platform Data Engineering Production Modernisation Platform Developer"
+    "analytical-platform-data-engineering-production-developer" = {
+      name           = "analytical-platform-data-engineering-production-developer"
+      description    = "Analytical Platform Data Engineering Production Developer"
       parent_team_id = module.analytical_platform_team.id
       members        = flatten([])
     },
     /* Analytical Platform Landing */
-    "analytical-platform-landing-production-modernisation-platform-administrator" = {
-      name           = "analytical-platform-landing-production-modernisation-platform-administrator"
-      description    = "Analytical Platform Landing Development Modernisation Platform Administrator"
+    "analytical-platform-landing-production-administrator" = {
+      name           = "analytical-platform-landing-production-administrator"
+      description    = "Analytical Platform Landing Development Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members
       ])
     },
     /* Analytical Platform Management */
-    "analytical-platform-management-production-modernisation-platform-administrator" = {
-      name           = "analytical-platform-management-production-modernisation-platform-administrator"
-      description    = "Analytical Platform Management Development Modernisation Platform Administrator"
+    "analytical-platform-management-production-administrator" = {
+      name           = "analytical-platform-management-production-administrator"
+      description    = "Analytical Platform Management Development Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members
       ])
     },
     /* MI Platform */
-    "mi-platform-development-modernisation-platform-administrator" = {
-      name           = "mi-platform-development-modernisation-platform-administrator"
-      description    = "MI Platform Development Modernisation Platform Administrator"
+    "mi-platform-development-administrator" = {
+      name           = "mi-platform-development-administrator"
+      description    = "MI Platform Development Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members

--- a/terraform/github/data-platform-teams.tf
+++ b/terraform/github/data-platform-teams.tf
@@ -104,61 +104,61 @@ locals {
   }
 
   data_platform_modernisation_platform_teams = {
-    "data-platform-development-modernisation-platform-sandbox" = {
-      name           = "data-platform-development-modernisation-platform-sandbox"
-      description    = "Data Platform Development Modernisation Platform Sandbox"
+    "data-platform-development-sandbox" = {
+      name           = "data-platform-development-sandbox"
+      description    = "Data Platform Development Sandbox"
       parent_team_id = module.data_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members,
         local.data_platform_teams["data-platform-labs"].members
       ])
     },
-    "data-platform-preproduction-modernisation-platform-developer" = {
-      name           = "data-platform-preproduction-modernisation-platform-developer"
-      description    = "Data Platform PreProduction Modernisation Platform Developer"
+    "data-platform-preproduction-developer" = {
+      name           = "data-platform-preproduction-developer"
+      description    = "Data Platform PreProduction Developer"
       parent_team_id = module.data_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members,
         local.data_platform_teams["data-platform-labs"].members
       ])
     },
-    "data-platform-production-modernisation-platform-developer" = {
-      name           = "data-platform-production-modernisation-platform-developer"
-      description    = "Data Platform Production Modernisation Platform Developer"
+    "data-platform-production-developer" = {
+      name           = "data-platform-production-developer"
+      description    = "Data Platform Production Developer"
       parent_team_id = module.data_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members,
         local.data_platform_teams["data-platform-labs"].members
       ])
     },
-    "data-platform-test-modernisation-platform-developer" = {
-      name           = "data-platform-test-modernisation-platform-developer"
-      description    = "Data Platform Test Modernisation Platform Developer"
+    "data-platform-test-developer" = {
+      name           = "data-platform-test-developer"
+      description    = "Data Platform Test Developer"
       parent_team_id = module.data_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members,
         local.data_platform_teams["data-platform-labs"].members
       ])
     }
-    "data-platform-modernisation-platform-audit-and-security" = {
-      name           = "data-platform-modernisation-platform-audit-and-security"
-      description    = "Data Platform Modernisation Platform Audit and Security"
+    "data-platform-audit-and-security" = {
+      name           = "data-platform-audit-and-security"
+      description    = "Data Platform Audit and Security"
       parent_team_id = module.data_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-audit-and-security"].members
       ])
     },
-    "data-platform-apps-and-tools-development-modernisation-platform-sandbox" = {
-      name           = "data-platform-apps-and-tools-development-modernisation-platform-sandbox"
-      description    = "Data Platform Apps and Tools Development Modernisation Platform Sandbox"
+    "data-platform-apps-and-tools-development-sandbox" = {
+      name           = "data-platform-apps-and-tools-development-sandbox"
+      description    = "Data Platform Apps and Tools Development Sandbox"
       parent_team_id = module.data_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members
       ])
     },
-    "data-platform-apps-and-tools-production-modernisation-platform-developer" = {
-      name           = "data-platform-apps-and-tools-production-modernisation-platform-developer"
-      description    = "Data Platform Apps and Tools Production Modernisation Platform Developer"
+    "data-platform-apps-and-tools-production-developer" = {
+      name           = "data-platform-apps-and-tools-production-developer"
+      description    = "Data Platform Apps and Tools Production Developer"
       parent_team_id = module.data_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members


### PR DESCRIPTION
This pull request squashes the team names and removes `modernisation-platform`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>