### PR TITLE
:technologist: Add user dotfile functionality

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,5 +31,14 @@
     { "source": "ministryofjustice-data-platform-devcontainer-workspace", "target": "/home/vscode/workspace", "type": "volume" },
     { "source": "ministryofjustice-data-platform-devcontainer-commandhistory", "target": "/home/vscode/.commandhistory", "type": "volume" }
   ],
-  "workspaceFolder": "/home/vscode/workspace"
+  "workspaceFolder": "/home/vscode/workspace",
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "dotfiles.repository": "https://github.com/${localEnv:GITHUB_USER}/dotfiles",
+        "dotfiles.targetPath": "~/dotfiles",
+        "dotfiles.installCommand": "setup.sh"
+      }
+    }
+  }
 }


### PR DESCRIPTION
This change adds a feature* which will enable remote dotfiles from a users GitHub profile to be loaded into the devcontainer. 

In short this allows users to use the devcontainer whilst simultaneously using the aliases that they already know/love. 

To use this feature simply create a repo called `dotfiles` (as yourself, not as MoJ). Example [here](https://github.com/Gary-H9?tab=repositories). This will be loaded 

We have tested and the container still builds if a user does not have a dotfiles repository.
__________________

*in the english sense, not the devcontainer sense. 