### PR TITLE
Dpl 2107 major version increment

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.4.0] - 2023-11-24
+
+### Added
+
+- `create_next_major_version_data_product` function to `versioning`
+- `CuratedDataCopier` class to `curated_data_loader`
+- `sql_create_next_major_increment_table` and `sql_unload_for_major_updated_table`
+  functions to `CuratedDataQueryBuilder` to generate sql for created tables in new
+  version data product database. 
+
+
+
 ## [7.3.2] - 2023-11-23
 
 ### Changed

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `CuratedDataCopier` class to `curated_data_loader`
 - `sql_create_next_major_increment_table` and `sql_unload_for_major_updated_table`
   functions to `CuratedDataQueryBuilder` to generate sql for created tables in new
-  version data product database. 
+  version data product database.
 
 ## [7.3.2] - 2023-11-23
 

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -19,8 +19,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   functions to `CuratedDataQueryBuilder` to generate sql for created tables in new
   version data product database. 
 
-
-
 ## [7.3.2] - 2023-11-23
 
 ### Changed

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "7.3.2",
+  "version": "7.4.0",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -138,9 +138,9 @@ class CuratedDataCopier:
         self.glue_client = glue_client
         self.athena_client = athena_client
         self.logger = logger
-        self.get_tables_to_copy()
+        self._get_tables_to_copy()
 
-    def validate(self):
+    def _is_updated_table_valid_for_copy(self):
         """
         Check whether it is possible to copy the data of changed schema
         between two major versions
@@ -156,12 +156,14 @@ class CuratedDataCopier:
         else:
             return True
 
-    def run(self):
+    def run(self) -> list[DataProductSchema]:
         """
         This runs the actual copy of each data product table into the new database version
 
         The table for where schema has been updated is created via boto3
         as it will not always have data loaded to it via this method
+
+        returns a list of updated DataProductSchema objects to caller
         """
         # create new version database and table for updated schema
         create_glue_database(self.glue_client, self.new_database_name, self.logger)
@@ -215,11 +217,11 @@ class CuratedDataCopier:
 
         return schemas_for_rewrite
 
-    def get_tables_to_copy(self):
+    def _get_tables_to_copy(self):
         """
         Creates a list of tables to copy into new version of data product database
         """
-        if self.validate():
+        if self._is_updated_table_valid_for_copy():
             self.tables_to_copy = self.schema.parent_data_product_metadata["schemas"]
             self.copy_updated_table = True
         else:

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -167,7 +167,6 @@ class CuratedDataCopier:
         create_glue_database(self.glue_client, self.new_database_name, self.logger)
         parquet_table_input = format_parquet_glue_table_input(
             self.schema.data["TableInput"],
-            # os.path.join(self.new_curated_data_product_path, self.schema.table_name),
             self.new_curated_data_product_path,
         )
         self.glue_client.create_table(
@@ -210,7 +209,7 @@ class CuratedDataCopier:
                 glue_client=self.glue_client,
                 logger=self.logger,
             ).create_new_major_version_data_product_table(
-                is_updated_table=table == self.schema.table_name
+                is_updated_table=(table == self.schema.table_name)
             )
             new_version_key = self.element.data_product.schema_path(
                 schema_for_copy.table_name

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -106,7 +106,6 @@ class CuratedDataLoader:
                 database_name=self.curated_data_table.database,
                 sql=self.query_builder.sql_unload_for_major_updated_table(
                     curated_table=self.curated_data_table,
-                    column_metadata=self.column_metadata,
                 ),
                 logger=self.logger,
             )

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -96,7 +96,6 @@ class CuratedDataLoader:
                 database_name=self.curated_data_table.database,
                 sql=self.query_builder.sql_create_next_major_increment_table(
                     self.curated_data_table,
-                    self.column_metadata,
                 ),
                 logger=self.logger,
             )

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -173,7 +173,7 @@ class CuratedDataCopier:
             DatabaseName=self.new_database_name,
             TableInput=parquet_table_input,
         )
-
+        schemas_for_rewrite = []
         for table in self.tables_to_copy:
             input_data = format_table_schema(
                 (
@@ -211,11 +211,9 @@ class CuratedDataCopier:
             ).create_new_major_version_data_product_table(
                 is_updated_table=(table == self.schema.table_name)
             )
-            new_version_key = self.element.data_product.schema_path(
-                schema_for_copy.table_name
-            ).key
-            # save schema with updated database name for newly created version
-            schema_for_copy.write_json_to_s3(new_version_key)
+            schemas_for_rewrite.append(schema_for_copy)
+
+        return schemas_for_rewrite
 
     def get_tables_to_copy(self):
         """

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -1,5 +1,3 @@
-import os
-
 from data_platform_logging import DataPlatformLogger
 from data_platform_paths import DataProductElement, QueryTable
 from data_product_metadata import DataProductSchema, format_table_schema

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -1,5 +1,8 @@
+import os
+
 from data_platform_logging import DataPlatformLogger
-from data_platform_paths import QueryTable
+from data_platform_paths import DataProductElement, QueryTable
+from data_product_metadata import DataProductSchema, format_table_schema
 from glue_and_athena_utils import (
     create_glue_database,
     refresh_table_partitions,
@@ -80,3 +83,184 @@ class CuratedDataLoader:
             database_name=self.curated_data_table.database,
             table_name=self.curated_data_table.name,
         )
+
+    def create_new_major_version_data_product_table(self, is_updated_table):
+        """
+        Creates new data product version tables
+
+        As the updated table (cause of the verison increase) is already created
+        it uses an UNLOAD rather than CTAS query
+        """
+        if not is_updated_table:
+            qid = start_query_execution_and_wait(
+                database_name=self.curated_data_table.database,
+                sql=self.query_builder.sql_create_next_major_increment_table(
+                    self.curated_data_table,
+                    self.column_metadata,
+                ),
+                logger=self.logger,
+            )
+            self.logger.info(f"created {self.curated_data_table}, using query id {qid}")
+        else:
+            qid = start_query_execution_and_wait(
+                database_name=self.curated_data_table.database,
+                sql=self.query_builder.sql_unload_for_major_updated_table(
+                    curated_table=self.curated_data_table,
+                    column_metadata=self.column_metadata,
+                ),
+                logger=self.logger,
+            )
+            self.logger.info(
+                f"unloaded {self.curated_data_table}, using query id {qid}"
+            )
+            refresh_table_partitions(
+                database_name=self.curated_data_table.database,
+                table_name=self.curated_data_table.name,
+            )
+
+
+class CuratedDataCopier:
+    def __init__(
+        self,
+        column_changes,
+        new_schema: DataProductSchema,
+        element: DataProductElement,
+        athena_client,
+        glue_client,
+        logger=DataPlatformLogger,
+    ):
+        """
+        Copy data from existing version of data product to new version of
+        data product.
+        """
+        self.data_product_name = new_schema.data_product_name
+        self.column_changes = column_changes
+        self.schema = new_schema
+        self.element = element
+        self.new_curated_data_product_path = element.curated_data_prefix.uri
+        self.new_database_name = element.database_name
+        self.glue_client = glue_client
+        self.athena_client = athena_client
+        self.logger = logger
+        self.get_tables_to_copy()
+
+    def validate(self):
+        """
+        Check whether it is possible to copy the data of changed schema
+        between two major versions
+
+        Columns removed -> OK (will be ignored by athena)
+        Columns added -> OK (will be left as null)
+        Columns reordered -> OK
+        Data types changed -> Not OK
+        """
+
+        if self.column_changes["types_changed"]:
+            return False
+        else:
+            return True
+
+    def run(self):
+        """
+        This runs the actual copy of each data product table into the new database version
+
+        The table for where schema has been updated is created via boto3
+        as it will not always have data loaded to it via this method
+        """
+        # create new version database and table for updated schema
+        create_glue_database(self.glue_client, self.new_database_name, self.logger)
+        parquet_table_input = format_parquet_glue_table_input(
+            self.schema.data["TableInput"],
+            # os.path.join(self.new_curated_data_product_path, self.schema.table_name),
+            self.new_curated_data_product_path,
+        )
+        self.glue_client.create_table(
+            DatabaseName=self.new_database_name,
+            TableInput=parquet_table_input,
+        )
+
+        for table in self.tables_to_copy:
+            input_data = format_table_schema(
+                (
+                    DataProductSchema(
+                        data_product_name=self.data_product_name,
+                        table_name=table,
+                        logger=self.logger,
+                        input_data=None,
+                    )
+                    .load()
+                    .latest_version_saved_data
+                )
+            )
+            schema_for_copy = DataProductSchema(
+                data_product_name=self.data_product_name,
+                table_name=table,
+                logger=self.logger,
+                input_data=input_data,
+            )
+            schema_for_copy.convert_schema_to_glue_table_input_csv()
+            CuratedDataLoader(
+                column_metadata=schema_for_copy.data["TableInput"]["StorageDescriptor"][
+                    "Columns"
+                ],
+                table=QueryTable(
+                    database=schema_for_copy.database_name,
+                    name=schema_for_copy.table_name,
+                ),
+                table_path=self.new_curated_data_product_path.replace(
+                    self.schema.table_name, table
+                ),
+                athena_client=self.athena_client,
+                glue_client=self.glue_client,
+                logger=self.logger,
+            ).create_new_major_version_data_product_table(
+                is_updated_table=table == self.schema.table_name
+            )
+            new_version_key = self.element.data_product.schema_path(
+                schema_for_copy.table_name
+            ).key
+            # save schema with updated database name for newly created version
+            schema_for_copy.write_json_to_s3(new_version_key)
+
+    def get_tables_to_copy(self):
+        """
+        Creates a list of tables to copy into new version of data product database
+        """
+        if self.validate():
+            self.tables_to_copy = self.schema.parent_data_product_metadata["schemas"]
+            self.copy_updated_table = True
+        else:
+            self.tables_to_copy = [
+                table
+                for table in self.schema.parent_data_product_metadata["schemas"]
+                if not table == self.schema.table_name
+            ]
+            self.copy_updated_table = False
+
+        return self
+
+
+def format_parquet_glue_table_input(schema: dict, location: str) -> dict:
+    """
+    populate the saved schema glue table input with parameters to make partitioned
+    parquet curated table
+    """
+    schema["StorageDescriptor"][
+        "InputFormat"
+    ] = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetInputFormat"
+    schema["StorageDescriptor"][
+        "OutputFormat"
+    ] = "org.apache.hadoop.hive.ql.io.parquet.MapredParquetOutputFormat"
+    schema["StorageDescriptor"]["Location"] = location
+    schema["StorageDescriptor"]["SerdeInfo"] = {
+        "SerializationLibrary": "org.apache.hadoop.hive.ql.io.parquet.serde.ParquetHiveSerDe",
+        "Parameters": {"serialization.format": "1"},
+    }
+    schema["StorageDescriptor"]["Parameters"] = {
+        "classification": "parquet",
+        "compressionType": "SNAPPY",
+    }
+    schema["PartitionKeys"] = [{"Name": "extraction_timestamp", "Type": "varchar(16)"}]
+    schema["Parameters"] = {"classification": "parquet"}
+
+    return schema

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_query_builder.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_query_builder.py
@@ -76,9 +76,7 @@ class CuratedDataQueryBuilder:
 
         return partition_sql
 
-    def sql_create_next_major_increment_table(
-        self, new_curated_table: QueryTable, column_metadata: dict
-    ):
+    def sql_create_next_major_increment_table(self, new_curated_table: QueryTable):
         """
         This creates a table in the new version database of the latest snapshot
         from each table in a data product.

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_query_builder.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_query_builder.py
@@ -77,10 +77,20 @@ class CuratedDataQueryBuilder:
         return partition_sql
 
     def sql_create_next_major_increment_table(
-        new_v_database: str, existing_v_database: str, table_name: str
+        self, new_curated_table: QueryTable, column_metadata: dict
     ):
+        """
+        This creates a table in the new version database of the latest snapshot
+        from each table in a data product.
+
+        For tables that have not been updated as part of the version increment
+        """
+        previous_major_database = new_curated_table.database[:-1] + str(
+            int(new_curated_table.database[-1]) - 1
+        )
+
         sql = f"""
-            CREATE TABLE {new_v_database}.{table_name}
+            CREATE TABLE {new_curated_table.database}.{new_curated_table.name}
             WITH(
                 format='parquet',
                 write_compression = 'SNAPPY',
@@ -89,8 +99,39 @@ class CuratedDataQueryBuilder:
             ) AS
             SELECT
                 *
-            FROM {existing_v_database}.{table_name}
-            WHERE extraction_timestamp = (SELECT MAX(extraction_timestamp) from {existing_v_database}.{table_name})
+            FROM {previous_major_database}.{new_curated_table.name}
+            WHERE extraction_timestamp = (
+                SELECT MAX(extraction_timestamp)
+                FROM {previous_major_database}.{new_curated_table.name}
+            )
         """
 
+        return sql
+
+    def sql_unload_for_major_updated_table(self, curated_table: QueryTable):
+        """
+        Unloads latest snapshot data of the table that is updated to the partition folder
+        in the new version database
+        """
+        previous_major_database = curated_table.database[:-1] + str(
+            int(curated_table.database[-1]) - 1
+        )
+
+        sql = f"""
+            UNLOAD (
+                SELECT
+                    *
+                FROM {previous_major_database}.{curated_table.name}
+                WHERE extraction_timestamp = (
+                    SELECT MAX(extraction_timestamp)
+                    FROM {previous_major_database}.{curated_table.name}
+                )
+            )
+            TO '{self.table_path}'
+            WITH(
+                format='parquet',
+                compression = 'SNAPPY',
+                partitioned_by=ARRAY['extraction_timestamp']
+            )
+        """
         return sql

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_query_builder.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_query_builder.py
@@ -75,3 +75,22 @@ class CuratedDataQueryBuilder:
         """
 
         return partition_sql
+
+    def sql_create_next_major_increment_table(
+        new_v_database: str, existing_v_database: str, table_name: str
+    ):
+        sql = f"""
+            CREATE TABLE {new_v_database}.{table_name}
+            WITH(
+                format='parquet',
+                write_compression = 'SNAPPY',
+                external_location='{self.table_path}',
+                partitioned_by=ARRAY['extraction_timestamp']
+            ) AS
+            SELECT
+                *
+            FROM {existing_v_database}.{table_name}
+            WHERE extraction_timestamp = (SELECT MAX(extraction_timestamp) from {existing_v_database}.{table_name})
+        """
+
+        return sql

--- a/containers/daap-python-base/src/var/task/versioning.py
+++ b/containers/daap-python-base/src/var/task/versioning.py
@@ -298,7 +298,7 @@ class VersionManager:
 
     def update_schema(
         self, input_data: dict, table_name: str
-    ) -> tuple[str, dict, dict]:
+    ) -> tuple[str, dict, dict | None]:
         """
         Create a new version with updated schema.
         """
@@ -320,6 +320,7 @@ class VersionManager:
             )
             schema.convert_schema_to_glue_table_input_csv()
             schema.write_json_to_s3(new_version_key)
+            copy_resp = None
             # if major we need to create next major version data product data
             if state == UpdateType.MajorUpdate:
                 data_product_element = DataProductElement.load(

--- a/containers/daap-python-base/src/var/task/versioning.py
+++ b/containers/daap-python-base/src/var/task/versioning.py
@@ -7,6 +7,7 @@ from enum import Enum
 from typing import NamedTuple
 
 import boto3
+from curated_data.curated_data_loader import CuratedDataCopier
 from data_platform_logging import DataPlatformLogger, s3_security_opts
 from data_platform_paths import (
     DataProductConfig,
@@ -314,6 +315,9 @@ class VersionManager:
             )
             schema.convert_schema_to_glue_table_input_csv()
             schema.write_json_to_s3(new_version_key)
+            # if major we need to create next major version data product data
+            if state == UpdateType.MajorUpdate:
+                copier = CuratedDataCopier()
             return new_version, changes
         else:
             raise InvalidUpdate()

--- a/containers/daap-python-base/src/var/task/versioning.py
+++ b/containers/daap-python-base/src/var/task/versioning.py
@@ -17,6 +17,9 @@ from data_platform_paths import (
 from data_product_metadata import DataProductMetadata, DataProductSchema
 from glue_and_athena_utils import delete_glue_table
 
+athena_client = boto3.client("athena")
+glue_client = boto3.client("glue")
+
 
 class Version(NamedTuple):
     """
@@ -551,9 +554,6 @@ def s3_recursive_delete(bucket_name: str, prefixes: list[str]) -> None:
 def create_next_major_version_data_product_and_data(
     schema, data_product_element, changes, logger
 ):
-    athena_client = boto3.client("athena")
-    glue_client = boto3.client("glue")
-
     copier = CuratedDataCopier(
         column_changes=changes[schema.table_name]["columns"],
         new_schema=schema,

--- a/containers/daap-python-base/tests/unit/conftest.py
+++ b/containers/daap-python-base/tests/unit/conftest.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 
 import boto3
 import pytest
-from moto import mock_glue, mock_s3
+from moto import mock_athena, mock_glue, mock_s3
 
 sys.path.append(join(dirname(__file__), "../", "../", "src", "var", "task"))
 
@@ -68,6 +68,17 @@ def glue_client(region_name):
     """
     with mock_glue():
         client = boto3.client("glue", region_name=region_name)
+
+        yield client
+
+
+@pytest.fixture
+def athena_client(region_name):
+    """
+    Create a mock glue catalogue
+    """
+    with mock_athena():
+        client = boto3.client("athena", region_name=region_name)
 
         yield client
 

--- a/containers/daap-python-base/tests/unit/curated_data/test_curated_data_loader.py
+++ b/containers/daap-python-base/tests/unit/curated_data/test_curated_data_loader.py
@@ -56,12 +56,6 @@ test_params1 = [
     (changes3_remove_add_desc_column, valid_copy3, expected_copy3),
 ]
 
-test_params2 = [
-    (changes1_remove_a_column, expected_copy1),
-    (changes2_remove_a_column_type_changed, expected_copy2),
-    (changes3_remove_add_desc_column, expected_copy3),
-]
-
 
 class TestCuratedDataCopier:
     @pytest.fixture(autouse=True)

--- a/containers/daap-python-base/tests/unit/curated_data/test_curated_data_loader.py
+++ b/containers/daap-python-base/tests/unit/curated_data/test_curated_data_loader.py
@@ -1,0 +1,163 @@
+import json
+import logging
+from unittest.mock import patch
+
+import pytest
+from curated_data.curated_data_loader import (
+    CuratedDataCopier,
+    format_parquet_glue_table_input,
+)
+from data_platform_paths import DataProductElement
+from data_product_metadata import DataProductSchema
+
+test_metadata = {
+    "name": "test_product",
+    "description": "just testing the metadata json validation/registration",
+    "domain": "MoJ",
+    "dataProductOwner": "matthew.laverty@justice.gov.uk",
+    "dataProductOwnerDisplayName": "matt laverty",
+    "email": "matthew.laverty@justice.gov.uk",
+    "status": "draft",
+    "retentionPeriod": 3000,
+    "dpiaRequired": False,
+    "schemas": ["test_table", "test_table1"],
+}
+
+
+changes1 = {
+    "removed_columns": ["col_1"],
+    "added_columns": None,
+    "types_changed": None,
+    "descriptions_changed": None,
+}
+
+changes2 = {
+    "removed_columns": ["col_1"],
+    "added_columns": None,
+    "types_changed": ["col_1"],
+    "descriptions_changed": None,
+}
+
+changes3 = {
+    "removed_columns": ["col_1"],
+    "added_columns": ["col_3", "col_4"],
+    "types_changed": None,
+    "descriptions_changed": ["col_2"],
+}
+
+valid_copy1 = True
+valid_copy2 = False
+valid_copy3 = True
+
+expected_copy1 = ["test_table", "test_table1"]
+expected_copy2 = ["test_table1"]
+expected_copy3 = ["test_table", "test_table1"]
+
+test_params1 = [
+    (changes1, valid_copy1, expected_copy1),
+    (changes2, valid_copy2, expected_copy2),
+    (changes3, valid_copy3, expected_copy3),
+]
+
+test_params2 = [
+    (changes1, expected_copy1),
+    (changes2, expected_copy2),
+    (changes3, expected_copy3),
+]
+
+
+class TestCuratedDataCopier:
+    @pytest.fixture(autouse=True)
+    def setup(self, metadata_bucket, s3_client):
+        self.s3_client = s3_client
+        self.bucket_name = metadata_bucket
+
+        s3_client.put_object(
+            Body=json.dumps(test_metadata),
+            Bucket=self.bucket_name,
+            Key=f"{test_metadata['name']}/v1.0/metadata.json",
+        )
+
+    @pytest.mark.parametrize("changes, valid_copy, expected_copy", test_params1)
+    def test_init(self, athena_client, glue_client, changes, valid_copy, expected_copy):
+        new_schema = DataProductSchema(
+            data_product_name="test_product",
+            table_name="test_table",
+            logger=logging.getLogger(),
+            input_data={
+                "tableDescription": "test",
+                "columns": [{"name": "col_5", "type": "int", "description": "test"}],
+            },
+        )
+        element = DataProductElement.load(new_schema.table_name, "test_product")
+        copier = CuratedDataCopier(
+            column_changes=changes,
+            new_schema=new_schema,
+            element=element,
+            athena_client=athena_client,
+            glue_client=glue_client,
+            logger=logging.getLogger(),
+        )
+
+        assert copier.copy_updated_table == valid_copy
+        assert copier.tables_to_copy == expected_copy
+
+    @pytest.mark.parametrize("changes, expected_copy", test_params2)
+    def test_run(self, s3_client, athena_client, glue_client, changes, expected_copy):
+        schema = DataProductSchema(
+            data_product_name="test_product",
+            table_name="test_table",
+            logger=logging.getLogger(),
+            input_data={
+                "tableDescription": "test",
+                "columns": [{"name": "col_1", "type": "string", "description": "test"}],
+            },
+        )
+        schema2 = DataProductSchema(
+            data_product_name="test_product",
+            table_name="test_table1",
+            logger=logging.getLogger(),
+            input_data={
+                "tableDescription": "test",
+                "columns": [
+                    {"name": "col_500", "type": "string", "description": "test"}
+                ],
+            },
+        )
+        schema.convert_schema_to_glue_table_input_csv()
+        schema2.convert_schema_to_glue_table_input_csv()
+        with patch("data_product_metadata.s3_client", s3_client):
+            schema.write_json_to_s3("test_product/v1.0/test_table/schema.json")
+            schema.write_json_to_s3("test_product/v1.0/test_table1/schema.json")
+        new_schema = DataProductSchema(
+            data_product_name="test_product",
+            table_name="test_table",
+            logger=logging.getLogger(),
+            input_data={
+                "tableDescription": "test",
+                "columns": [{"name": "col_5", "type": "int", "description": "test"}],
+            },
+        )
+        new_schema.convert_schema_to_glue_table_input_csv()
+        element = DataProductElement.load(new_schema.table_name, "test_product")
+        copier = CuratedDataCopier(
+            column_changes=changes,
+            new_schema=new_schema,
+            element=element,
+            athena_client=athena_client,
+            glue_client=glue_client,
+            logger=logging.getLogger(),
+        )
+        with patch(
+            "curated_data.curated_data_loader.start_query_execution_and_wait"
+        ) as mock_query:
+            with patch(
+                "curated_data.curated_data_loader.refresh_table_partitions"
+            ) as mock_refresh:
+                mock_query.return_value = "qidyes"
+                mock_refresh.return_value = "qidyes"
+
+                schema_list = copier.run()
+
+        schema_names = [schema.table_name for schema in schema_list]
+        assert schema_names == expected_copy

--- a/containers/daap-python-base/tests/unit/curated_data/test_curated_data_loader.py
+++ b/containers/daap-python-base/tests/unit/curated_data/test_curated_data_loader.py
@@ -3,10 +3,7 @@ import logging
 from unittest.mock import patch
 
 import pytest
-from curated_data.curated_data_loader import (
-    CuratedDataCopier,
-    format_parquet_glue_table_input,
-)
+from curated_data.curated_data_loader import CuratedDataCopier
 from data_platform_paths import DataProductElement
 from data_product_metadata import DataProductSchema
 

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -22,7 +22,7 @@ test_metadata_no_schema = {
 }
 
 test_metadata = copy.deepcopy(test_metadata_no_schema)
-test_metadata.update({"name": "test_product", "schemas":["test_table"]})
+test_metadata.update({"name": "test_product", "schemas": ["test_table"]})
 
 test_metadata_with_schemas = copy.deepcopy(test_metadata_no_schema)
 test_metadata_with_schemas.update(
@@ -339,8 +339,8 @@ class TestVersionManager:
         assert version == "v1.1"
         self.assert_has_keys(
             {
-                "test_product1/v1.1/metadata.json",
-                "test_product1/v1.1/table-name/schema.json",
+                "test_product_with_schemas/v1.1/metadata.json",
+                "test_product_with_schemas/v1.1/table-name/schema.json",
             },
             "v1.1",
             data_product_name,

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -298,10 +298,13 @@ class TestVersionManager:
 
         version_manager = VersionManager(test_metadata["name"], logging.getLogger())
 
-        version, changes = version_manager.update_schema(input_data, "test_table")
+        version, changes, copy_response = version_manager.update_schema(
+            input_data, "test_table"
+        )
 
         assert version == "v1.1"
         assert changes == expected
+        assert copy_response == None
         self.assert_has_keys(
             {
                 "test_product/v1.1/metadata.json",
@@ -366,12 +369,13 @@ class TestVersionManager:
                 "versioning.athena_client",
                 athena_client,
             ):
-                version, changes = version_manager.update_schema(
+                version, changes, copy_response = version_manager.update_schema(
                     input_data, "test_table"
                 )
 
         assert version == "v2.0"
         assert changes == expected
+        assert copy_response == {"test_table copied": False}
         self.assert_has_keys(
             {
                 "test_product/v2.0/metadata.json",

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -304,7 +304,7 @@ class TestVersionManager:
 
         assert version == "v1.1"
         assert changes == expected
-        assert copy_response == None
+        assert copy_response is None
         self.assert_has_keys(
             {
                 "test_product/v1.1/metadata.json",


### PR DESCRIPTION
This implements the creation of a new database version via update schema, when a schema update has resulted in a major version increment.

It copies the latest snapshot of data from all tables (other than updated table) from the previous version to the new version database

For the table that has been updated it creates an empty table as per the updated schema and then applies logic as to whether data for the updated table can be copied over tot he new version data product or if it should remain empty until new data has been uploaded by a user.

said logic:
```
Columns removed -> OK (will be ignored by athena)
Columns added -> OK (will be left as null)
Columns reordered -> OK
Data types changed -> Not OK
```

It seems to be working but still in need of some refinement.

### Additions
- `CuratedDataCopier` class to `curated_data_loader.py`, handles creation of the new database and the copying of each table in the data product to it. It defines whether the updated table is valid for copying via the changes passed in from versioning and calls a new method of `CuratedDataLoader` for each table.
- `CuratedDataLoader.create_new_major_version_data_product_table()` method added, which is what the above calls. This runs new queries added to the `CuratedDataQueryBuilder` class.
- `sql_create_next_major_increment_table()` and `sql_unload_for_major_updated_table()` added to the `CuratedDataQueryBuilder` class for generating the sql to run to create tables in new version database for unchanged and changed tables respectively.
