### PR TITLE
👋 Remove Alex Vilela

### DIFF
--- a/terraform/github/data-engineering-teams.tf
+++ b/terraform/github/data-engineering-teams.tf
@@ -18,7 +18,6 @@ locals {
     "jhpyke",             # Jake Hamblin-Pyke
     "murad-ali-MoJ",      # Murad Ali
     "oliver-critchfield", # Oliver Critchfield
-    "AlexVilela",         # Alex Vilela
     "davidbridgwood",     # David Bridgwood
     "mshodge",            # Michael Hodge
     "Andy-Cook",          # Andy Cook

--- a/terraform/github/data-platform-teams.tf
+++ b/terraform/github/data-platform-teams.tf
@@ -25,7 +25,6 @@ locals {
       parent_team_id = module.data_platform_team.id
       members = [
         "bagg3rs",           # Richard Baguley
-        "AlexVilela",        # Alex Vilela
         "julialawrence",     # Julia Lawrence
         "jhpyke",            # Jacob Hamblin-Pyke
         "jacobwoffenden",    # Jacob Woffenden
@@ -68,7 +67,6 @@ locals {
       parent_team_id = module.data_platform_team.id
       members = [
         "bagg3rs",           # Richard Baguley
-        "AlexVilela",        # Alex Vilela
         "julialawrence",     # Julia Lawrence
         "jhpyke",            # Jacob Hamblin-Pyke
         "jacobwoffenden",    # Jacob Woffenden

--- a/terraform/pagerduty/schedules.tf
+++ b/terraform/pagerduty/schedules.tf
@@ -18,7 +18,6 @@ locals {
             module.users["michael.collins@digital.justice.gov.uk"].id,
             module.users["yikang.mao@justice.gov.uk"].id,
             module.users["gary.henderson@digital.justice.gov.uk"].id,
-            module.users["alex.vilela@digital.justice.gov.uk"].id,
             module.users["jacob.hamblin-pyke@digital.justice.gov.uk"].id,
             module.users["murad.ali@digital.justice.gov.uk"].id
           ]

--- a/terraform/pagerduty/teams.tf
+++ b/terraform/pagerduty/teams.tf
@@ -13,7 +13,6 @@ locals {
         module.users["michael.collins@digital.justice.gov.uk"].id,
         module.users["yikang.mao@justice.gov.uk"].id,
         module.users["gary.henderson@digital.justice.gov.uk"].id,
-        module.users["alex.vilela@digital.justice.gov.uk"].id,
         module.users["jacob.hamblin-pyke@digital.justice.gov.uk"].id,
         module.users["murad.ali@digital.justice.gov.uk"].id
       ]

--- a/terraform/pagerduty/users.tf
+++ b/terraform/pagerduty/users.tf
@@ -33,10 +33,6 @@ locals {
       email = "gary.henderson@digital.justice.gov.uk"
     },
     {
-      name  = "Alex Vilela"
-      email = "alex.vilela@digital.justice.gov.uk"
-    },
-    {
       name  = "Jacob Hamblin-Pyke"
       email = "jacob.hamblin-pyke@digital.justice.gov.uk"
     },


### PR DESCRIPTION
This pull request removes Alex Vilela from Data Engineering and Data Platform GitHub Teams and PagerDuty

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>