### PR TITLE
Delete table database versioning (revised PR with unit tests)

### DIFF
--- a/containers/daap-delete-table-for-data-product/CHANGELOG.md
+++ b/containers/daap-delete-table-for-data-product/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- updated to base image 7.5.0
+
 ## [2.2.1] - 2023-11-16
 
 ### Changed

--- a/containers/daap-delete-table-for-data-product/Dockerfile
+++ b/containers/daap-delete-table-for-data-product/Dockerfile
@@ -1,4 +1,5 @@
 FROM ghcr.io/ministryofjustice/data-platform-daap-python-base:7.0.0
+# change to 7.5.0 once released
 
 ARG VERSION
 

--- a/containers/daap-delete-table-for-data-product/src/var/task/delete_table.py
+++ b/containers/daap-delete-table-for-data-product/src/var/task/delete_table.py
@@ -66,7 +66,7 @@ def handler(event, context):
     except ValueError as e:
         return format_error_response(HTTPStatus.BAD_REQUEST, event, str(e))
     except Exception as e:
-        message = "Error while removing schemas. New version may be incorrect state"
+        message = "Unexpected error while removing schemas. The new version may be in an invalid state"
         logger.error(message, exc_info=e)
         return format_error_response(HTTPStatus.INTERNAL_SERVER_ERROR, event, message)
     else:

--- a/containers/daap-delete-table-for-data-product/src/var/task/delete_table.py
+++ b/containers/daap-delete-table-for-data-product/src/var/task/delete_table.py
@@ -65,6 +65,10 @@ def handler(event, context):
         return format_error_response(HTTPStatus.BAD_REQUEST, event, str(e))
     except ValueError as e:
         return format_error_response(HTTPStatus.BAD_REQUEST, event, str(e))
+    except Exception as e:
+        message = "Error while removing schemas. New version may be incorrect state"
+        logger.error(message, exc_info=e)
+        return format_error_response(HTTPStatus.INTERNAL_SERVER_ERROR, event, message)
     else:
         msg = f"Successfully removed table '{table_name}'"
         msg += f", data files and generated new matadata version '{new_version}'"

--- a/containers/daap-delete-table-for-data-product/tests/unit/conftest.py
+++ b/containers/daap-delete-table-for-data-product/tests/unit/conftest.py
@@ -187,13 +187,13 @@ def create_schema(
 
 @pytest.fixture
 def create_glue_database(glue_client, data_product_name):
-    glue_client.create_database(DatabaseInput={"Name": data_product_name})
+    glue_client.create_database(DatabaseInput={"Name": data_product_name + "_v2"})
 
 
 @pytest.fixture
 def create_glue_table(create_glue_database, glue_client, data_product_name, table_name):
     glue_client.create_table(
-        DatabaseName=data_product_name, TableInput={"Name": table_name}
+        DatabaseName=data_product_name + "_v2", TableInput={"Name": table_name}
     )
 
 

--- a/containers/daap-delete-table-for-data-product/tests/unit/mock_test.py
+++ b/containers/daap-delete-table-for-data-product/tests/unit/mock_test.py
@@ -59,7 +59,7 @@ class TestHandler:
         assert response["statusCode"] == HTTPStatus.BAD_REQUEST
         assert f"{table_name}" in json.loads(response["body"])["error"]["message"]
 
-    def test_deletion_of_raw_files(
+    def test_does_not_delete_raw_files(
         self,
         event,
         fake_context,
@@ -91,9 +91,9 @@ class TestHandler:
                 Bucket=bucket,
                 Prefix=prefix,
             )
-            assert response.get("KeyCount") == 0
+            assert response.get("KeyCount") == 10
 
-    def test_deletion_of_curated_files(
+    def test_does_not_delete_curated_files(
         self,
         event,
         fake_context,
@@ -126,7 +126,7 @@ class TestHandler:
                 Bucket=bucket,
                 Prefix=prefix,
             )
-            assert response.get("KeyCount") == 0
+            assert response.get("KeyCount") == 10
 
     def test_deletion_of_old_schema_version(
         self,

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `delete_table` data_product_name parameter changed to
   database_name
 - removed `glue_client` from `create_database`
+- add `get_database_name_for_version` function to paths module
 
 ## [7.4.0] - 2023-11-24
 

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,12 +9,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.5.0] - 2023-11-27
+
+### Changed
+
 - renamed glue_and_athena_utils functions to drop `glue` from the name and
   use create/get/list/update/delete terminology
 - `delete_table` data_product_name parameter changed to
   database_name
-- removed `glue_client` from `create_database`
-- add `get_database_name_for_version` function to paths module
+- made `glue_client` optional in `create_database` to match other functions
+
+### Added
+
+- `clone_database` function in `glue_and_athena_utils`
+- `get_database_name_for_version` function in `data_platform_paths`
 
 ## [7.4.0] - 2023-11-24
 

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- renamed glue_and_athena_utils functions to drop `glue` from the name and
+  use create/get/list/update/delete terminology
+- `delete_table` data_product_name parameter changed to
+  database_name
+- removed `glue_client` from `create_database`
+
 ## [7.4.0] - 2023-11-24
 
 ### Added
@@ -25,10 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed `KeyError` bug with `BaseJsonSchema.changed_fields()` if new fields
   are added
-
-## [7.3.1] - 2023-11-21
-
-### Added
 
 - `get_all_major_versions` helpder function to `data_platform_paths.py`
 - `delete_database` utility function to `glue_and_athena_utils.py`

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "7.4.0",
+  "version": "7.5.0",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -264,7 +264,12 @@ def generate_all_element_version_prefixes(
 def generate_element_version_prefixes_for_version(
     path_prefix: str, data_product_name: str, table_name: str, version: str
 ) -> str:
-    """Generates element prefixes for all data product versions"""
+    """
+    Generates element prefixes for all data product versions
+
+    >>> generate_element_version_prefixes_for_version('curated', 'my-data-product', 'some-table', 'v1.0')
+    'curated/my-data-product/v1/some-table/'
+    """
     major_version = version.split(".")[0]
 
     return f"{path_prefix}/{data_product_name}/{major_version}/{table_name}/"

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -93,6 +93,12 @@ def specification_path(
     )
 
 
+def get_database_name_for_version(
+    data_product_name: str, latest_major_version: str
+) -> str:
+    return data_product_name + "_" + latest_major_version
+
+
 def get_new_version(version, increment_type):
     if increment_type == "minor":
         new_version = version.split(".")[0] + "." + str(int(version.split(".")[-1]) + 1)
@@ -264,7 +270,9 @@ class DataProductElement:
     @property
     def database_name(self) -> str:
         latest_major_version = self.data_product.latest_major_version
-        return self.data_product.name + "_" + latest_major_version
+        return get_database_name_for_version(
+            self.data_product.name, latest_major_version
+        )
 
     @staticmethod
     def load(element_name, data_product_name):

--- a/containers/daap-python-base/src/var/task/data_platform_paths.py
+++ b/containers/daap-python-base/src/var/task/data_platform_paths.py
@@ -246,15 +246,28 @@ def generate_all_element_version_prefixes(
     """Generates element prefixes for all data product versions"""
 
     data_product_versions = get_all_versions(data_product_name)
-    major_versions = {version.split(".")[0] for version in data_product_versions}
     element_prefixes = []
 
-    for major_version in major_versions:
+    for version in data_product_versions:
         element_prefixes.append(
-            f"{path_prefix}/{data_product_name}/{major_version}/{table_name}/"
+            generate_element_version_prefixes_for_version(
+                path_prefix=path_prefix,
+                data_product_name=data_product_name,
+                table_name=table_name,
+                version=version,
+            )
         )
 
     return element_prefixes
+
+
+def generate_element_version_prefixes_for_version(
+    path_prefix: str, data_product_name: str, table_name: str, version: str
+) -> str:
+    """Generates element prefixes for all data product versions"""
+    major_version = version.split(".")[0]
+
+    return f"{path_prefix}/{data_product_name}/{major_version}/{table_name}/"
 
 
 @dataclass

--- a/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
+++ b/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
@@ -38,7 +38,7 @@ def create_database(
 def get_database(database_name: str, logger: DataPlatformLogger) -> dict | None:
     """Get the database for the given database name"""
     try:
-        datebase = glue_client.get_database(Name=database_name)
+        database = glue_client.get_database(Name=database_name)
     except ClientError as e:
         if e.response["Error"]["Code"] == "EntityNotFoundException":
             logger.error(f"Database name {database_name} not found.")
@@ -47,7 +47,7 @@ def get_database(database_name: str, logger: DataPlatformLogger) -> dict | None:
             logger.error(f"Unexpected error: {e}")
             raise
     else:
-        return datebase
+        return database
 
 
 def database_exists(database_name: str, logger: DataPlatformLogger) -> bool:
@@ -71,7 +71,7 @@ def clone_database(
     existing_database_name: str, new_database_name: str, logger: DataPlatformLogger
 ) -> None:
     """
-    Make a copy of a database with a new name, copying all metadata except ids and timestamps.
+    Make a copy of a database with a new name, copying all metadata except ids and timestamps. This function makes a new empty database with the same metadata definition, note it does NOT copy any of the tables or data within a database.
     """
     current_database = get_database(database_name=existing_database_name, logger=logger)
     current_tables = list_tables(database_name=existing_database_name, logger=logger)

--- a/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
+++ b/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
@@ -10,19 +10,23 @@ athena_client = boto3.client("athena")
 
 
 def create_glue_database(
-    glue_client: BaseClient, database_name: str, logger: DataPlatformLogger
+    glue_client: BaseClient,
+    database_name: str,
+    logger: DataPlatformLogger,
+    db_meta: dict | None = None,
 ):
     """If a glue database doesn't exist, create a glue database"""
     try:
         glue_client.get_database(Name=database_name)
     except ClientError as e:
         if e.response["Error"]["Code"] == "EntityNotFoundException":
-            db_meta = {
-                "DatabaseInput": {
-                    "Description": "database for {} products".format(database_name),
-                    "Name": database_name,
+            if not db_meta:
+                db_meta = {
+                    "DatabaseInput": {
+                        "Description": "database for {} products".format(database_name),
+                        "Name": database_name,
+                    }
                 }
-            }
             glue_client.create_database(**db_meta)
         else:
             logger.error("Unexpected error: %s" % e)

--- a/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
+++ b/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
@@ -93,20 +93,25 @@ def clone_database(
         db_meta=db_meta,
     )
 
-    table_keys_to_remove = [
-        "DatabaseName",
-        "CreateTime",
-        "UpdateTime",
-        "CatalogId",
-        "VersionId",
-        "FederatedTable",
+    table_keys_to_keep = [
+        "Name",
+        "Description",
+        "Owner",
+        "Retention",
+        "StorageDescriptor",
+        "PartitionKeys",
+        "ViewOriginalText",
+        "ViewExpandedText",
+        "TableType",
+        "Parameters",
+        "TargetTable",
     ]
 
     if not current_tables:
         return
 
     for table in current_tables:
-        table_meta = {k: v for k, v in table.items() if k not in table_keys_to_remove}
+        table_meta = {k: v for k, v in table.items() if k in table_keys_to_keep}
         table_meta = {"TableInput": {**table_meta}}
         create_table(
             database_name=new_database_name, logger=logger, table_meta=table_meta

--- a/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
+++ b/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
@@ -9,15 +9,17 @@ glue_client = boto3.client("glue")
 athena_client = boto3.client("athena")
 
 
-def create_glue_database(
-    glue_client: BaseClient,
+def create_database(
     database_name: str,
     logger: DataPlatformLogger,
     db_meta: dict | None = None,
+    client: BaseClient = None,
 ):
     """If a glue database doesn't exist, create a glue database"""
+    if client is None:
+        client = glue_client
     try:
-        glue_client.get_database(Name=database_name)
+        client.get_database(Name=database_name)
     except ClientError as e:
         if e.response["Error"]["Code"] == "EntityNotFoundException":
             if not db_meta:
@@ -27,52 +29,131 @@ def create_glue_database(
                         "Name": database_name,
                     }
                 }
-            glue_client.create_database(**db_meta)
+            client.create_database(**db_meta)
         else:
             logger.error("Unexpected error: %s" % e)
             raise
 
 
-def delete_glue_database(database_name: str, logger: DataPlatformLogger) -> None:
+def get_database(database_name: str, logger: DataPlatformLogger) -> dict | None:
+    """Get the database for the given database name"""
+    try:
+        datebase = glue_client.get_database(Name=database_name)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "EntityNotFoundException":
+            logger.error(f"Database name {database_name} not found.")
+            return None
+        else:
+            logger.error(f"Unexpected error: {e}")
+            raise
+    else:
+        return datebase
+
+
+def database_exists(database_name: str, logger: DataPlatformLogger) -> dict | None:
+    """Check if a database exists with the given name"""
+    return get_database(database_name=database_name, logger=logger) is not None
+
+
+def delete_database(database_name: str, logger: DataPlatformLogger) -> None:
     """Delete a glue database with the given database name"""
     try:
         glue_client.delete_database(Name=database_name)
-    except glue_client.exceptions.EntityNotFoundException:
-        logger.info(f"Glue database '{database_name}' not found.")
-
-
-def delete_glue_table(
-    data_product_name: str,
-    table_name: str,
-    logger: DataPlatformLogger,
-) -> str | None:
-    """Attempts to locate and delete a glue table for the given data product"""
-    try:
-        glue_client.get_table(DatabaseName=data_product_name, Name=table_name)
     except ClientError as e:
         if e.response["Error"]["Code"] == "EntityNotFoundException":
-            error_message = f"Could not locate glue table '{table_name}' in database '{data_product_name}'"
-            logger.error(error_message)
-            raise ValueError(error_message)
+            logger.info(f"Glue database '{database_name}' not found.")
         else:
+            logger.error("Unexpected error: %s" % e)
             raise
-    else:
-        result = glue_client.delete_table(
-            DatabaseName=data_product_name, Name=table_name
-        )
-        return result
 
 
-def refresh_table_partitions(
-    database_name: str, table_name: str, workgroup: str = "data_product_workgroup"
+def clone_database(
+    existing_database_name: str, new_database_name: str, logger: DataPlatformLogger
 ) -> None:
     """
-    Refreshes partitions for a given table
+    Make a copy of a database with a new name, copying all metadata except ids and timestamps.
     """
-    athena_client.start_query_execution(
-        QueryString=f"MSCK REPAIR TABLE {database_name}.{table_name}",
-        WorkGroup=workgroup,
+    current_database = get_database(database_name=existing_database_name, logger=logger)
+    current_tables = list_tables(database_name=existing_database_name, logger=logger)
+
+    database = current_database.get("Database")
+    database_keys_to_remove = ["CreateTime"]
+    db_meta = {k: v for k, v in database.items() if k not in database_keys_to_remove}
+    db_meta["Name"] = new_database_name
+    db_meta = {"DatabaseInput": {**db_meta}}
+    logger.info(str(db_meta))
+
+    create_glue_database(
+        database_name=new_database_name,
+        glue_client=glue_client,
+        logger=logger,
+        db_meta=db_meta,
     )
+
+    table_keys_to_remove = [
+        "DatabaseName",
+        "CreateTime",
+        "UpdateTime",
+        "CatalogId",
+        "VersionId",
+        "FederatedTable",
+    ]
+    tables = current_tables.get("TableList", [])
+    for table in tables:
+        table_meta = {k: v for k, v in table.items() if k not in table_keys_to_remove}
+        table_meta = {"TableInput": {**table_meta}}
+        create_table(
+            database_name=new_database_name, logger=logger, table_meta=table_meta
+        )
+
+
+def create_table(
+    database_name: str,
+    logger: DataPlatformLogger,
+    table_name: str | None = None,
+    table_meta: dict | None = None,
+) -> None:
+    """Create a glue table on the given database."""
+    if not table_meta:
+        table_meta = {"TableInput": {"Name": table_name}}
+    try:
+        glue_client.create_table(DatabaseName=database_name, **table_meta)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "AlreadyExistsException":
+            logger.error(f"Table {table_meta['TableInput']['Name']} already exists.")
+        else:
+            logger.error("Unexpected error: %s" % e)
+            raise
+
+
+def get_table(
+    database_name: str, table_name: str, logger: DataPlatformLogger
+) -> dict | None:
+    """Get the table for the given table name and database"""
+    try:
+        table = glue_client.get_table(DatabaseName=database_name, Name=table_name)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "AlreadyExistsException":
+            logger.error(f"Table name {table_name} not found.")
+        else:
+            logger.error("Unexpected error: %s" % e)
+            raise
+    else:
+        return table
+
+
+def list_tables(database_name: str, logger: DataPlatformLogger) -> list[dict] | None:
+    """Get the table for the given table name and database"""
+    try:
+        tables = glue_client.get_tables(DatabaseName=database_name)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "AlreadyExistsException":
+            logger.error(f"Database name {database_name} not found.")
+        else:
+            logger.error("Unexpected error: %s" % e)
+            raise
+    else:
+        return tables
 
 
 def table_exists(database_name: str, table_name: str) -> bool:
@@ -90,6 +171,39 @@ def table_exists(database_name: str, table_name: str) -> bool:
         else:
             raise
     return True
+
+
+def delete_table(
+    database_name: str,
+    table_name: str,
+    logger: DataPlatformLogger,
+) -> str | None:
+    """Attempts to locate and delete a glue table for the given data product"""
+    try:
+        glue_client.get_table(DatabaseName=database_name, Name=table_name)
+    except ClientError as e:
+        if e.response["Error"]["Code"] == "EntityNotFoundException":
+            error_message = f"Could not locate glue table '{table_name}' in database '{database_name}'"
+            logger.error(error_message)
+            raise ValueError(error_message)
+        else:
+            logger.error("Unexpected error: %s" % e)
+            raise
+    else:
+        result = glue_client.delete_table(DatabaseName=database_name, Name=table_name)
+        return result
+
+
+def refresh_table_partitions(
+    database_name: str, table_name: str, workgroup: str = "data_product_workgroup"
+) -> None:
+    """
+    Refreshes partitions for a given table
+    """
+    athena_client.start_query_execution(
+        QueryString=f"MSCK REPAIR TABLE {database_name}.{table_name}",
+        WorkGroup=workgroup,
+    )
 
 
 def start_query_execution_and_wait(
@@ -135,3 +249,47 @@ def start_query_execution_and_wait(
         raise ValueError(response["QueryExecution"]["Status"].get("StateChangeReason"))
 
     return query_id
+
+
+def get_glue_database(*args, **kwargs):
+    """
+    Alias for backwards compatability
+    """
+    return get_database(*args, **kwargs)
+
+
+def delete_glue_table(
+    data_product_name: str,
+    table_name: str,
+    logger: DataPlatformLogger,
+):
+    """
+    Alias for backwards compatability
+    """
+    return delete_table(
+        database_name=data_product_name, table_name=table_name, logger=logger
+    )
+
+
+def create_glue_database(
+    glue_client: BaseClient,
+    database_name: str,
+    logger: DataPlatformLogger,
+    db_meta: dict | None = None,
+):
+    """
+    Alias for backwards compatability
+    """
+    return create_database(
+        database_name=database_name,
+        logger=logger,
+        db_meta=db_meta,
+        client=glue_client,
+    )
+
+
+def delete_glue_database(*args, **kwargs):
+    """
+    Alias for backwards compatability
+    """
+    return delete_table(*args, **kwargs)

--- a/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
+++ b/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
@@ -71,7 +71,10 @@ def clone_database(
     existing_database_name: str, new_database_name: str, logger: DataPlatformLogger
 ) -> None:
     """
-    Make a copy of a database with a new name, copying all metadata except ids and timestamps. This function makes a new empty database with the same metadata definition, note it does NOT copy any of the tables or data within a database.
+    Make a copy of a database with a new name, copying all metadata except ids and timestamps.
+
+    This function makes a new empty database with the same metadata definition, note it does NOT copy any of the
+    tables or data within a database.
     """
     current_database = get_database(database_name=existing_database_name, logger=logger)
     current_tables = list_tables(database_name=existing_database_name, logger=logger)

--- a/containers/daap-python-base/src/var/task/versioning.py
+++ b/containers/daap-python-base/src/var/task/versioning.py
@@ -404,7 +404,8 @@ class VersionManager:
         self, data_product_name, latest_version, new_version
     ):
         """
-        Copy the athena database from the old version to the new version
+        Copy the athena database configuration from the old version to the new version
+        Only the metadata is copied, none of the contents data
         """
         latest_major_version = Version.parse(latest_version).format_major_version()
         new_major_version = Version.parse(new_version).format_major_version()

--- a/containers/daap-python-base/tests/unit/conftest.py
+++ b/containers/daap-python-base/tests/unit/conftest.py
@@ -197,19 +197,6 @@ def create_curated_bucket(s3_client, region_name):
 
 
 @pytest.fixture
-def create_glue_database(glue_client, data_product_name):
-    glue_client.create_database(DatabaseInput={"Name": data_product_name})
-
-
-@pytest.fixture
-def create_glue_tables(create_glue_database, glue_client, data_product_name):
-    for i in range(3):
-        glue_client.create_table(
-            DatabaseName=data_product_name, TableInput={"Name": f"schema{i}"}
-        )
-
-
-@pytest.fixture
 def data_product_name():
     return "data-product"
 

--- a/containers/daap-python-base/tests/unit/data_platform_paths_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_paths_test.py
@@ -16,6 +16,7 @@ from data_platform_paths import (
     data_product_log_bucket_and_key,
     generate_all_element_version_prefixes,
     get_curated_data_bucket,
+    get_database_name_for_version,
     get_landing_zone_bucket,
     get_latest_version,
     get_log_bucket,
@@ -386,3 +387,7 @@ def test_generate_all_element_version_prefixes(region_name, s3_client):
     result = generate_all_element_version_prefixes("raw", "data_product", "table")
 
     assert set(result) == {"raw/data_product/v1/table/", "raw/data_product/v2/table/"}
+
+
+def test_database_name():
+    get_database_name_for_version("foo", "v1") == "foo_v1"

--- a/containers/daap-python-base/tests/unit/glue_and_athena_utils_test.py
+++ b/containers/daap-python-base/tests/unit/glue_and_athena_utils_test.py
@@ -115,7 +115,7 @@ class TestDatabaseOperations:
             logger=logger,
         )
         result = list_tables(database_name=database_name, logger=logger)
-        assert [i["Name"] for i in result["TableList"]] == ["foo"]
+        assert [i["Name"] for i in result] == ["foo"]
 
 
 class TestTableOperations:
@@ -166,7 +166,7 @@ class TestTableOperations:
         )
 
         result = list_tables(database_name=database_name, logger=logger)
-        assert [i["Name"] for i in result["TableList"]] == [table_name_1, table_name_2]
+        assert [i["Name"] for i in result] == [table_name_1, table_name_2]
 
     def test_table_exists(self, database_name, table_name, table_meta):
         create_database(database_name, logging.getLogger())
@@ -189,6 +189,4 @@ class TestTableOperations:
         create_database(database_name, logging.getLogger())
         create_table(database_name=database_name, logger=logger, table_meta=table_meta)
 
-        resp = delete_table(database_name, table_name, logging.getLogger())
-
-        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+        delete_table(database_name, table_name, logging.getLogger())

--- a/containers/daap-python-base/tests/unit/glue_and_athena_utils_test.py
+++ b/containers/daap-python-base/tests/unit/glue_and_athena_utils_test.py
@@ -1,78 +1,194 @@
 import logging
 from unittest.mock import patch
 
-from glue_and_athena_utils import create_glue_database, delete_glue_table, table_exists
+import pytest
+from glue_and_athena_utils import (
+    clone_database,
+    create_database,
+    create_table,
+    database_exists,
+    delete_database,
+    delete_table,
+    get_database,
+    get_table,
+    list_tables,
+    table_exists,
+)
+
+logger = logging.getLogger()
 
 
-class TestCreateGlueDatabase:
-    def test_create_by_name(self, glue_client):
-        database_name = "test_db"
-        create_glue_database(glue_client, database_name, logging.getLogger())
-        response = glue_client.get_database(Name=database_name)
+@pytest.fixture(autouse=True)
+def patch_glue_client(glue_client):
+    with patch("glue_and_athena_utils.glue_client", glue_client):
+        yield
+
+
+@pytest.fixture
+def database_name():
+    return "test_db"
+
+
+@pytest.fixture
+def description():
+    return "test_description"
+
+
+class TestDatabaseOperations:
+    @pytest.fixture
+    def database_name(self):
+        return "test_db"
+
+    @pytest.fixture
+    def description(self):
+        return "test_description"
+
+    def test_create_and_get(self, database_name):
+        create_database(database_name=database_name, logger=logger)
+        response = get_database(database_name=database_name, logger=logger)
+
         assert response["Database"]["Name"] == database_name
 
-    def test_create_with_db_meta(self, glue_client):
-        database_name = "test_db"
-        description = database_name
+    def test_create_with_db_meta(self, database_name, description):
         db_meta = {
             "DatabaseInput": {
                 "Description": description,
-                "Name": "test_db",
+                "Name": database_name,
             }
         }
-        create_glue_database(
-            glue_client, database_name, logging.getLogger(), db_meta=db_meta
-        )
-        response = glue_client.get_database(Name=database_name)
+        create_database(database_name=database_name, logger=logger, db_meta=db_meta)
+        response = get_database(database_name=database_name, logger=logger)
+
         assert response["Database"]["Name"] == database_name
         assert response["Database"]["Description"] == description
 
+    def test_database_exists(self, database_name):
+        create_database(database_name=database_name, logger=logger)
 
-def test_delete_glue_table(glue_client):
-    database_name = "test_db"
-    table_name = "test_table"
-    create_glue_database(glue_client, database_name, logging.getLogger())
+        assert database_exists(database_name=database_name, logger=logger)
 
-    glue_client.create_table(
-        DatabaseName=database_name,
-        TableInput={
-            "Name": table_name,
-            "StorageDescriptor": {
-                "Columns": [
-                    {
-                        "Name": "col1",
-                        "Type": "string",
-                    },
-                ],
-            },
-        },
-    )
-    with patch("glue_and_athena_utils.glue_client", glue_client):
-        resp = delete_glue_table(database_name, table_name, logging.getLogger())
+    def test_delete_existing_database(self, database_name):
+        create_database(database_name=database_name, logger=logger)
 
-    assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200
+        delete_database(database_name=database_name, logger=logger)
+
+        assert not database_exists(database_name=database_name, logger=logger)
+
+    def test_delete_missing_database(self, database_name):
+        delete_database(database_name=database_name, logger=logger)
+
+        assert not database_exists(database_name=database_name, logger=logger)
+
+    def test_clone_database(self, database_name, description):
+        db_meta = {
+            "DatabaseInput": {
+                "Description": description,
+                "Name": database_name,
+            }
+        }
+        create_database(
+            database_name=database_name,
+            logger=logger,
+            db_meta=db_meta,
+        )
+
+        clone_database(
+            existing_database_name=database_name,
+            new_database_name="new",
+            logger=logger,
+        )
+        result = get_database(database_name="new", logger=logger)
+
+        assert result["Database"]["Name"] == "new"
+        assert result["Database"]["Description"] == description
+
+    def test_clone_database_with_tables(self, database_name):
+        create_database(
+            database_name=database_name,
+            logger=logger,
+        )
+        create_table(database_name=database_name, table_name="foo", logger=logger)
+
+        clone_database(
+            existing_database_name=database_name,
+            new_database_name="new",
+            logger=logger,
+        )
+        result = list_tables(database_name=database_name, logger=logger)
+        assert [i["Name"] for i in result["TableList"]] == ["foo"]
 
 
-def test_table_exists(glue_client):
-    database_name = "test_db"
-    table_name = "test_table"
-    create_glue_database(glue_client, database_name, logging.getLogger())
+class TestTableOperations:
+    @pytest.fixture
+    def table_name(self):
+        return "test_table"
 
-    glue_client.create_table(
-        DatabaseName=database_name,
-        TableInput={
-            "Name": table_name,
-            "StorageDescriptor": {
-                "Columns": [
-                    {
-                        "Name": "col1",
-                        "Type": "string",
-                    },
-                ],
-            },
-        },
-    )
+    @pytest.fixture
+    def table_meta(self, table_name):
+        return {
+            "TableInput": {
+                "Name": table_name,
+                "StorageDescriptor": {
+                    "Columns": [
+                        {
+                            "Name": "col1",
+                            "Type": "string",
+                        },
+                    ],
+                },
+            }
+        }
 
-    with patch("glue_and_athena_utils.glue_client", glue_client):
+    def test_create_and_get_table(self, database_name, table_name, table_meta):
+        create_database(database_name, logging.getLogger())
+
+        create_table(
+            database_name=database_name,
+            logger=logger,
+            table_meta=table_meta,
+        )
+
+        result = get_table(
+            database_name=database_name, table_name=table_name, logger=logger
+        )
+        assert result["Table"]["Name"] == table_name
+
+    def test_list_tables(self, database_name, table_name):
+        table_name_1 = table_name + "_1"
+        table_name_2 = table_name + "_2"
+        create_database(database_name, logging.getLogger())
+
+        create_table(
+            database_name=database_name, logger=logger, table_name=table_name_1
+        )
+        create_table(
+            database_name=database_name, logger=logger, table_name=table_name_2
+        )
+
+        result = list_tables(database_name=database_name, logger=logger)
+        assert [i["Name"] for i in result["TableList"]] == [table_name_1, table_name_2]
+
+    def test_table_exists(self, database_name, table_name, table_meta):
+        create_database(database_name, logging.getLogger())
+
+        create_table(
+            database_name=database_name,
+            logger=logger,
+            table_meta=table_meta,
+        )
+
         result = table_exists(database_name, table_name)
         assert result
+
+    def test_delete_table(
+        self,
+        database_name,
+        table_name,
+        table_meta,
+    ):
+        create_database(database_name, logging.getLogger())
+        create_table(database_name=database_name, logger=logger, table_meta=table_meta)
+
+        resp = delete_table(database_name, table_name, logging.getLogger())
+
+        assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200

--- a/containers/daap-python-base/tests/unit/glue_and_athena_utils_test.py
+++ b/containers/daap-python-base/tests/unit/glue_and_athena_utils_test.py
@@ -4,11 +4,28 @@ from unittest.mock import patch
 from glue_and_athena_utils import create_glue_database, delete_glue_table, table_exists
 
 
-def test_create_glue_database(glue_client):
-    database_name = "test_db"
-    create_glue_database(glue_client, database_name, logging.getLogger())
-    response = glue_client.get_database(Name=database_name)
-    assert response["Database"]["Name"] == database_name
+class TestCreateGlueDatabase:
+    def test_create_by_name(self, glue_client):
+        database_name = "test_db"
+        create_glue_database(glue_client, database_name, logging.getLogger())
+        response = glue_client.get_database(Name=database_name)
+        assert response["Database"]["Name"] == database_name
+
+    def test_create_with_db_meta(self, glue_client):
+        database_name = "test_db"
+        description = database_name
+        db_meta = {
+            "DatabaseInput": {
+                "Description": description,
+                "Name": "test_db",
+            }
+        }
+        create_glue_database(
+            glue_client, database_name, logging.getLogger(), db_meta=db_meta
+        )
+        response = glue_client.get_database(Name=database_name)
+        assert response["Database"]["Name"] == database_name
+        assert response["Database"]["Description"] == description
 
 
 def test_delete_glue_table(glue_client):

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -450,15 +450,22 @@ class TestUpdateMetadataRemoveSchema:
         data_product_name,
         data_product_versions,
         data_product_major_versions,
+        create_raw_and_curated_data,
     ):
+        self.s3_client = s3_client
         self.bucket_name = metadata_bucket
+        self.data_product_name = data_product_name
+        self.latest_major_version = "v2"
+        self.new_major_version = "v3"
+        self.number_of_schemas = 3
+
         for version in data_product_versions:
             s3_client.put_object(
                 Body=json.dumps(test_metadata_with_schemas),
                 Bucket=self.bucket_name,
                 Key=f"{data_product_name}/{version}/metadata.json",
             )
-        for i in range(3):
+        for i in range(self.number_of_schemas):
             for version in data_product_versions:
                 s3_client.put_object(
                     Body=json.dumps(test_schema),
@@ -466,38 +473,35 @@ class TestUpdateMetadataRemoveSchema:
                     Key=f"{data_product_name}/{version}/schema{i}/schema.json",
                 )
 
-        self.latest_major_version = "v2"
         for major_version in data_product_major_versions:
             database_name = f"{data_product_name}_{major_version}"
 
             glue_client.create_database(DatabaseInput={"Name": database_name})
 
-            for i in range(3):
+            for i in range(self.number_of_schemas):
                 glue_client.create_table(
                     DatabaseName=database_name,
                     TableInput={"Name": f"schema{i}"},
                 )
 
-    def test_success(
-        self, s3_client, create_raw_and_curated_data, data_product_name, glue_client
-    ):
-        version_manager = VersionManager(data_product_name, logging.getLogger())
-        schema_list = ["schema0"]
+    @pytest.fixture(autouse=True)
+    def setup_subject(self, glue_client, data_product_name):
         with patch("glue_and_athena_utils.glue_client", glue_client):
-            version_manager.update_metadata_remove_schemas(schema_list=schema_list)
-            schema_prefix = f"{data_product_name}/v2.0/metadata.json"
-            response = s3_client.list_objects_v2(
-                Bucket=self.bucket_name,
-                Prefix=schema_prefix,
-            )
-        assert response.get("KeyCount") == 1
+            self.version_manager = VersionManager(data_product_name, logger)
+            yield
 
-    def test_invalid_schemas(self, data_product_name):
-        version_manager = VersionManager(data_product_name, logging.getLogger())
+    def test_success(self):
+        schema_list = ["schema0"]
+        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+
+        schema_prefix = f"{self.data_product_name}/v2.0/metadata.json"
+        self.assert_object_count(self.bucket_name, schema_prefix, 1)
+
+    def test_invalid_schemas(self):
         schema_list = ["schema3", "schema4"]
 
         with pytest.raises(InvalidUpdate) as exc:
-            version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+            self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
         assert (
             str(exc.value)
             == "Invalid schemas found in schema_list: ['schema3', 'schema4']"
@@ -505,133 +509,64 @@ class TestUpdateMetadataRemoveSchema:
 
     def test_glue_table_not_found(
         self,
-        s3_client,
-        create_raw_and_curated_data,
-        data_product_name,
-        glue_client,
-        table_name,
     ):
-        version_manager = VersionManager(data_product_name, logging.getLogger())
         schema_list = ["schema0", "banana"]
-        with patch("glue_and_athena_utils.glue_client", glue_client):
-            with pytest.raises(InvalidUpdate):
-                version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+        with pytest.raises(InvalidUpdate):
+            self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
 
-    def test_schema_glue_table_deleted(
-        self, s3_client, create_raw_and_curated_data, data_product_name, glue_client
-    ):
-        version_manager = VersionManager(data_product_name, logging.getLogger())
+    def test_data_files_not_deleted_from_existing_versions(self):
+        curated_prefix = (
+            f"curated/{self.data_product_name}/{self.latest_major_version}/schema0/"
+        )
+        raw_prefix = (
+            f"raw/{self.data_product_name}/{self.latest_major_version}/schema0/"
+        )
         schema_list = ["schema0"]
-        with patch("glue_and_athena_utils.glue_client", glue_client):
-            # Call the handler
-            version_manager.update_metadata_remove_schemas(schema_list=schema_list)
 
-            assert not table_exists(
-                database_name=self.latest_major_version, table_name=schema_list[0]
-            )
+        self.assert_object_count(os.getenv("CURATED_DATA_BUCKET"), curated_prefix, 10)
+        self.assert_object_count(os.getenv("RAW_DATA_BUCKET"), raw_prefix, 10)
 
-    def test_data_files_deleted(
-        self,
-        s3_client,
-        create_raw_and_curated_data,
-        data_product_name,
-        glue_client,
-        data_product_major_versions,
-    ):
-        version_manager = VersionManager(data_product_name, logging.getLogger())
-        schema_list = ["schema0"]
-        with patch("glue_and_athena_utils.glue_client", glue_client):
-            # Validate we have the required number of files
-            for version in data_product_major_versions:
-                curated_prefix = f"curated/{data_product_name}/{version}/schema0/"
-                response = s3_client.list_objects_v2(
-                    Bucket=os.getenv("CURATED_DATA_BUCKET"),
-                    Prefix=curated_prefix,
-                )
-                assert response.get("KeyCount") == 10
+        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
 
-                raw_prefix = f"raw/{data_product_name}/{version}/schema0/"
-                response = s3_client.list_objects_v2(
-                    Bucket=os.getenv("RAW_DATA_BUCKET"),
-                    Prefix=raw_prefix,
-                )
-                assert response.get("KeyCount") == 10
-
-            # Call the handler
-            version_manager.update_metadata_remove_schemas(schema_list=schema_list)
-
-            # Validate files are deleted
-            for version in data_product_major_versions:
-                curated_prefix = f"curated/{data_product_name}/{version}/schema0/"
-                response = s3_client.list_objects_v2(
-                    Bucket=os.getenv("CURATED_DATA_BUCKET"),
-                    Prefix=curated_prefix,
-                )
-                assert response.get("KeyCount") == 0
-
-                raw_prefix = f"raw/{data_product_name}/{version}/schema0/"
-                response = s3_client.list_objects_v2(
-                    Bucket=os.getenv("RAW_DATA_BUCKET"),
-                    Prefix=raw_prefix,
-                )
-                assert response.get("KeyCount") == 0
+        self.assert_object_count(os.getenv("CURATED_DATA_BUCKET"), curated_prefix, 10)
+        self.assert_object_count(os.getenv("RAW_DATA_BUCKET"), raw_prefix, 10)
 
     def test_deleted_schema_files_removed_from_new_version(
         self,
-        s3_client,
-        create_raw_and_curated_data,
-        data_product_name,
-        glue_client,
-        data_product_versions,
     ):
-        version_manager = VersionManager(data_product_name, logging.getLogger())
         schema_list = ["schema0"]
 
-        with patch("glue_and_athena_utils.glue_client", glue_client):
-            version_manager.update_metadata_remove_schemas(schema_list=schema_list)
-            schema_prefix = f"{data_product_name}/v3.0/{schema_list[0]}/schema.json"
-            response = s3_client.list_objects_v2(
-                Bucket=self.bucket_name,
-                Prefix=schema_prefix,
+        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+        schema_prefix = f"{self.data_product_name}/v3.0/{schema_list[0]}/schema.json"
+        self.assert_object_count(self.bucket_name, schema_prefix, 0)
+
+    def test_deleted_table_removed_from_new_version(self):
+        schema_list = ["schema0"]
+
+        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+
+        expected_database_name = f"{self.data_product_name}_{self.new_major_version}"
+        assert database_exists(expected_database_name, logger=logger)
+        assert table_exists(expected_database_name, "schema1")
+        assert not table_exists(expected_database_name, "schema0")
+
+    def test_validate_other_schemas_are_upversioned(self):
+        schema_list = ["schema0"]
+
+        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+        for i in range(1, self.number_of_schemas):
+            self.assert_object_exists(
+                self.bucket_name,
+                f"{self.data_product_name}/v3.0/schema{i}/schema.json",
             )
-            assert response.get("KeyCount") == 0
 
-    def test_deleted_table_removed_from_new_version(
-        self,
-        data_product_name,
-        glue_client,
-        create_raw_and_curated_data,
-        data_product_versions,
-    ):
-        version_manager = VersionManager(data_product_name, logging.getLogger())
-        schema_list = ["schema0"]
+    def assert_object_count(self, bucket, prefix, expected_count):
+        response = self.s3_client.list_objects_v2(
+            Bucket=bucket,
+            Prefix=prefix,
+        )
+        actual_count = response.get("KeyCount")
+        assert actual_count == expected_count
 
-        with patch("glue_and_athena_utils.glue_client", glue_client):
-            version_manager.update_metadata_remove_schemas(schema_list=schema_list)
-
-            expected_database_name = f"{data_product_name}_v3"
-            assert database_exists(expected_database_name, logger=logger)
-            assert table_exists(expected_database_name, "schema1")
-            assert not table_exists(expected_database_name, "schema0")
-
-    def test_validate_other_schemas_are_upversioned(
-        self,
-        s3_client,
-        create_raw_and_curated_data,
-        data_product_name,
-        glue_client,
-        data_product_versions,
-    ):
-        version_manager = VersionManager(data_product_name, logging.getLogger())
-        schema_list = ["schema0"]
-
-        with patch("glue_and_athena_utils.glue_client", glue_client):
-            # Call the handler
-            version_manager.update_metadata_remove_schemas(schema_list=schema_list)
-            for i in range(1, 3):
-                schema_prefix = f"{data_product_name}/v2.0/schema{i}/schema.json"
-                response = s3_client.list_objects_v2(
-                    Bucket=self.bucket_name,
-                    Prefix=schema_prefix,
-                )
-                assert response.get("KeyCount") == 1
+    def assert_object_exists(self, bucket, key):
+        return self.assert_object_count(bucket, key, 1)


### PR DESCRIPTION
This takes the changes to versioning.py from https://github.com/ministryofjustice/data-platform/pull/2465, adds unit tests, and reworks the behaviour slightly.

This could do with more integration testing, but I have tested the happy path by running the container locally, and once this is rolled out to API gateway we will do some further testing in order to document the scenarios here: https://dsdmoj.atlassian.net/wiki/spaces/DataPlatform/pages/4557963328/user+journeys+via+API+WIP

## New behaviour for delete table
1. We decided Thursday morning that the delete table endpoint should return early if a schema doesn't exist, even if there may be data hanging around. I.e. we shouldn't attempt to delete data for which there is no metadata. In future we will ensure that any generated schemas are written to s3 as a prerequisite of loading data into a table.

2. For now, we will just delete the table & data from the new version. This deviates from our original plan of deleting from all historical versions (i.e. "delete means delete"), but we had some doubts about implementing contradictory behaviour (i.e. creating a new major version while at the same time making breaking changes to existing versions doesn't make sense). I've created https://github.com/ministryofjustice/data-platform/issues/2500 to revisit the delete means delete behaviour. For now the exact logic doesn't matter as long as the endpoint behaves consistently.

So the expected behaviour when deleting a table is now:

1. If the schema is not found, do nothing
2. Create a new version of the database with the new version number in
3. If the glue table is there, delete it **from the new version only**
4. Data will still be there in historical versions

## Copying tables between databases
Originally this had an exclude list of fields that should not be copied over when we copy tables. I've changed this to an include list so that the code is less likely to break completely if amazon starts returning additional fields in the get table response. (When testing this I ran into several fields that weren't handled by the previous version of this code)
 
## Refactor of glue_and_athena_utils
This now contains functions for creating, deleting, and fetching databases and tables. I've renamed some of the existing functions in this module to follow a common naming convention, but kept aliases with the old names.