### PR TITLE
Switch to include list for DatabaseInput

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [7.5.3] - 2023-11-30
+
+### Changed
+
+- Prevent `clone_database` function from trying to pass a `CatalogId`
+  to glue when creating the new database (this parameter is invalid).
+
 ## [7.5.2] - 2023-11-30
 
 ### Changed

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "7.5.2",
+  "version": "7.5.3",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
+++ b/containers/daap-python-base/src/var/task/glue_and_athena_utils.py
@@ -83,8 +83,8 @@ def clone_database(
     current_tables = list_tables(database_name=existing_database_name, logger=logger)
 
     database = current_database["Database"]
-    database_keys_to_remove = ["CreateTime"]
-    db_meta = {k: v for k, v in database.items() if k not in database_keys_to_remove}
+    database_keys_to_keep = ["Name", "Description", "LocationUri", "Parameters"]
+    db_meta = {k: v for k, v in database.items() if k in database_keys_to_keep}
     db_meta["Name"] = new_database_name
     db_meta = {"DatabaseInput": {**db_meta}}
     logger.info(str(db_meta))


### PR DESCRIPTION
When cloning a database, do not pass every parameter returned by GetDatabase - it contains invalid input parameters, like CatalogId.

This bug is not reproduced when using moto to mock AWS glue, so I tested it by building a new version of delete table and running it against development.