### PR TITLE
📌 Update tech-docs

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: ministryofjustice/tech-docs-github-pages-publisher:data-platform
+      image: ministryofjustice/tech-docs-github-pages-publisher:ministryofjustice-fork
     defaults:
       run:
         working-directory: docs

--- a/docs/source/documentation/platform/infrastructure/developing.html.md.erb
+++ b/docs/source/documentation/platform/infrastructure/developing.html.md.erb
@@ -36,6 +36,8 @@ Once we begin our journey to the monorepo, this should become redundant, but tha
 
 - Docker
 
+    > If you are have an Apple Silicon Mac, you will need to enable Rosetta emulation, see Docker's [documentation](https://docs.docker.com/desktop/settings/mac/#general:~:text=Use%20Rosetta%20for%20x86/AMD64%20emulation%20on%20Apple%20Silicon) for more information.
+
     ```bash
     brew install --cask docker
     ```
@@ -203,7 +205,7 @@ The provided configuration file handles authentication to EKS clusters using AWS
 
 > Rebuilding the dev container will reset the Kubernetes configuration file, so you'll need to authenticate again.
 
-1. Login to Cloud Platform Kuberos (https://login.cloud-platform.service.justice.gov.uk/)
+1. Login to Cloud Platform Kuberos (<https://login.cloud-platform.service.justice.gov.uk>)
 
 1. Obtain the command from "Authenticate Manually"
 

--- a/scripts/docs/docker.sh
+++ b/scripts/docs/docker.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 MODE="${1}"
-IMAGE="docker.io/ministryofjustice/tech-docs-github-pages-publisher:data-platform"
+IMAGE="docker.io/ministryofjustice/tech-docs-github-pages-publisher:ministryofjustice-fork"
 
 case ${MODE} in
   deploy|preview|check-url-links)


### PR DESCRIPTION
This pull request bump tech-docs to use `ministryofjustice/tech-docs-github-pages-publisher:ministryofjustice-fork` which 

- Uses `3.4.0` of [`alphagov/tech-docs-gem`](https://github.com/alphagov/tech-docs-gem), which we merged into our fork [`ministryofjustice/tech-docs-gem`](https://github.com/ministryofjustice/tech-docs-gem)
- Switches to Debian base image

It also:

- Adds a note for enabling Rosetta emulation if using Apple Silicon Macs
- Fixed Cloud Platform login link