### PR TITLE
👥 Sean's access

### DIFF
--- a/terraform/github/analytical-platform-teams.tf
+++ b/terraform/github/analytical-platform-teams.tf
@@ -41,7 +41,8 @@ locals {
       description    = "Analytical Platform Development Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
-        local.data_platform_teams["data-platform-apps-and-tools"].members
+        local.data_platform_teams["data-platform-apps-and-tools"].members,
+        "seanprivett", # Sean Privett
       ])
     },
     "analytical-platform-production-administrator" = {
@@ -49,7 +50,8 @@ locals {
       description    = "Analytical Platform Production Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
-        local.data_platform_teams["data-platform-apps-and-tools"].members
+        local.data_platform_teams["data-platform-apps-and-tools"].members,
+        "seanprivett", # Sean Privett
       ])
     },
     /* Analytical Platform Data */

--- a/terraform/github/analytical-platform-teams.tf
+++ b/terraform/github/analytical-platform-teams.tf
@@ -61,6 +61,7 @@ locals {
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
         local.data_platform_teams["data-platform-apps-and-tools"].members,
+        "seanprivett", # Sean Privett
       ])
     },
     "analytical-platform-data-development-data-engineer" = {
@@ -80,7 +81,8 @@ locals {
       description    = "Analytical Platform Data Production Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
-        local.data_platform_teams["data-platform-apps-and-tools"].members
+        local.data_platform_teams["data-platform-apps-and-tools"].members,
+        "seanprivett", # Sean Privett
       ])
     },
     "analytical-platform-data-production-data-engineer" = {
@@ -140,7 +142,8 @@ locals {
       description    = "Analytical Platform Data Engineering Production Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
-        local.data_platform_teams["data-platform-apps-and-tools"].members
+        local.data_platform_teams["data-platform-apps-and-tools"].members,
+        "seanprivett", # Sean Privett
       ])
     },
     "analytical-platform-data-engineering-production-data-engineer" = {
@@ -167,7 +170,8 @@ locals {
       description    = "Analytical Platform Landing Development Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
-        local.data_platform_teams["data-platform-apps-and-tools"].members
+        local.data_platform_teams["data-platform-apps-and-tools"].members,
+        "seanprivett", # Sean Privett
       ])
     },
     /* Analytical Platform Management */
@@ -176,7 +180,8 @@ locals {
       description    = "Analytical Platform Management Development Administrator"
       parent_team_id = module.analytical_platform_team.id
       members = flatten([
-        local.data_platform_teams["data-platform-apps-and-tools"].members
+        local.data_platform_teams["data-platform-apps-and-tools"].members,
+        "seanprivett", # Sean Privett
       ])
     },
     /* MI Platform */

--- a/terraform/github/configuration/data-engineering-access.json
+++ b/terraform/github/configuration/data-engineering-access.json
@@ -435,16 +435,5 @@
       "analytical-platform-data-engineering-sandboxa-administrator",
       "analytical-platform-data-engineering-sandboxa-data-engineer"
     ]
-  },
-  {
-    "name": "Sean Privett",
-    "github": "seanprivett",
-    "access": [
-      "analytical-platform-data-development-data-engineer",
-      "analytical-platform-data-production-data-engineer",
-      "analytical-platform-data-engineering-sandboxa-administrator",
-      "analytical-platform-data-engineering-sandboxa-data-engineer",
-      "analytical-platform-data-engineering-production-data-engineer"
-    ]
   }
 ]

--- a/terraform/github/configuration/data-engineering-access.json
+++ b/terraform/github/configuration/data-engineering-access.json
@@ -435,5 +435,16 @@
       "analytical-platform-data-engineering-sandboxa-administrator",
       "analytical-platform-data-engineering-sandboxa-data-engineer"
     ]
+  },
+  {
+    "name": "Sean Privett",
+    "github": "seanprivett",
+    "access": [
+      "analytical-platform-data-development-data-engineer",
+      "analytical-platform-data-production-data-engineer",
+      "analytical-platform-data-engineering-sandboxa-administrator",
+      "analytical-platform-data-engineering-sandboxa-data-engineer",
+      "analytical-platform-data-engineering-production-data-engineer"
+    ]
   }
 ]

--- a/terraform/github/data-platform-teams.tf
+++ b/terraform/github/data-platform-teams.tf
@@ -50,6 +50,7 @@ locals {
         "tom-webber",      # Tom Webber
         "mitchdawson1982", # Mitch Dawson
         "MatMoore",        # Mat Moore
+        "seanprivett",     # Sean Privett
       ]
     },
     "data-platform-audit-and-security" = {


### PR DESCRIPTION
This pull request:

- ~Removes Sean from Data Engineering configuration~
- Adds Sean to `data-platform-labs` team
- Adds Sean to `analytical-platform-*-administrator` teams

TODO:

- [x] Determine what further access Sean requires to AP estate
  - Sean wants to create billing reports on AP
  - We only have two permission sets assigned to AP ([source](https://github.com/ministryofjustice/modernisation-platform/blob/main/environments/analytical-platform.json))
  - `administrator` is the only **current** route to do this

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>