### PR TITLE
Upload artifact fix - roillback

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,7 +44,8 @@ jobs:
 
       - name: Upload artifact
         id: upload_artifact
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
+
         with:
           name: github-pages
           path: docs/artifact.tar


### PR DESCRIPTION
The dependabot upload_artifact upgrade to v4.0.0 contained a breaking change this pr is to roll it back to v3.1.3
