### PR TITLE
📈 Update `actions-runner` Helm chart

### DIFF
--- a/charts/actions-runner/CHANGELOG.md
+++ b/charts/actions-runner/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [2.0.0] - 2023-12-18
+
+### Changed
+
+- Squashes `runner.labels` into `github`
+
+- Removes `irsa`
+
+- Bumps to `2.0.0`
+
 ## [1.0.0] - 2023-12-14
 
 ### Changed

--- a/charts/actions-runner/Chart.yaml
+++ b/charts/actions-runner/Chart.yaml
@@ -4,7 +4,7 @@ name: actions-runner
 icon: https://assets.data-platform.service.justice.gov.uk/assets/justice-digital-logo.png
 type: application
 description: Deployed GitHub Actions Self-Hosted Runner
-version: 1.0.0
+version: 2.0.0
 appVersion: 2.311.0
 
 maintainers:

--- a/charts/actions-runner/ci/lint-values.yaml
+++ b/charts/actions-runner/ci/lint-values.yaml
@@ -3,9 +3,9 @@ github:
   organisation: ministryofjustice
   repository: data-platform
   token: this-is-not-a-real-token
+  runner:
+    labels: "self-hosted,data-platform"
 
-runner:
-  labels: "self-hosted,data-platform"
-
-irsa:
-  roleArn: arn:aws:iam::123456789012:role/this-is-not-a-real-role
+serviceAccount:
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/this-is-not-a-real-role

--- a/charts/actions-runner/templates/deployment.yaml
+++ b/charts/actions-runner/templates/deployment.yaml
@@ -41,6 +41,6 @@ spec:
                   name: {{ .Release.Name }}-github-token
                   key: token
             - name: RUNNER_LABELS
-              value: {{ .Values.runner.labels | quote }}
+              value: {{ .Values.github.runner.labels | quote }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}

--- a/charts/actions-runner/values.yaml
+++ b/charts/actions-runner/values.yaml
@@ -36,9 +36,5 @@ github:
   organisation:
   repository:
   token:
-
-runner:
-  labels:
-
-irsa:
-  roleArn:
+  runner:
+    labels:


### PR DESCRIPTION
This pull request:

- Squashes `runner.labels` into `github`
- Removes `irsa`
- Bumps to `2.0.0`