### PR TITLE
🚑 Fix documentation publishing

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,7 +50,7 @@ jobs:
           path: docs/docs # This looks strange, but actions run in the root of the repo, so to consume the compiled artifact we need to specify the path from the root of the repo
 
   deploy:
-    if: github.ref == 'refs/heads/main'
+    # if: github.ref == 'refs/heads/main'
     needs: [build]
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,18 +42,12 @@ jobs:
         id: compile
         run: /scripts/deploy.sh
 
-      - name: DEBUG
-        id: debug
-        run: |
-          ls -lrt
-
-      # - name: Upload artifact
-      #   id: upload_artifact
-      #   uses: actions/upload-pages-artifact@0252fc4ba7626f0298f0cf00902a25c6afc77fa8 # v3.0.0
-      #   with:
-      #     name: github-pages
-      #     path: docs/artifact.tar
-      #     retention-days: 1
+      - name: Upload artifact
+        id: upload_artifact
+        uses: actions/upload-pages-artifact@0252fc4ba7626f0298f0cf00902a25c6afc77fa8 # v3.0.0
+        with:
+          name: github-pages
+          path: docs/
 
   deploy:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -42,52 +42,18 @@ jobs:
         id: compile
         run: /scripts/deploy.sh
 
-      - name: Upload artifact
-        id: upload_artifact
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+      - name: DEBUG
+        id: debug
+        run: |
+          ls -lrt
 
-        with:
-          name: github-pages
-          path: docs/artifact.tar
-          retention-days: 1
-
-#   htmlproofer:
-#     needs: [build]
-#     name: htmlproofer
-#     runs-on: ubuntu-latest
-#     container:
-#       image: ministryofjustice/tech-docs-github-pages-publisher:data-platform
-#     defaults:
-#       run:
-#         working-directory: docs
-#     steps:
-#       - name: Checkout
-#         id: checkout
-#         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-
-#       - name: Compile Markdown to HTML and run htmlproofer
-#         id: compile
-#         run: /scripts/check-url-links.sh
-
-#   linkinator:
-#     needs: [build]
-#     name: linkinator
-#     runs-on: ubuntu-latest
-#     steps:
-#       - name: Download artifact
-#         id: download_artifact
-#         uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
-#         with:
-#           name: github-pages
-#           path: github-pages
-
-#       - name: Check URLs
-#         id: check_urls
-#         run: |
-#           cd github-pages
-#           tar -xvf artifact.tar
-#           npm install JustinBeckwith/linkinator#e3d929bbda79d28fb46d20c04a2a6f9a9bce6f5c # v4.1.2
-#           npx linkinator . --recurse --markdown
+      # - name: Upload artifact
+      #   id: upload_artifact
+      #   uses: actions/upload-pages-artifact@0252fc4ba7626f0298f0cf00902a25c6afc77fa8 # v3.0.0
+      #   with:
+      #     name: github-pages
+      #     path: docs/artifact.tar
+      #     retention-days: 1
 
   deploy:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -47,7 +47,7 @@ jobs:
         uses: actions/upload-pages-artifact@0252fc4ba7626f0298f0cf00902a25c6afc77fa8 # v3.0.0
         with:
           name: github-pages
-          path: docs/
+          path: docs/docs # This looks strange, but actions run in the root of the repo, so to consume the compiled artifact we need to specify the path from the root of the repo
 
   deploy:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -47,7 +47,10 @@ jobs:
         uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0
         with:
           name: github-pages
-          path: docs/docs # This looks strange, but actions run in the root of the repo, so to consume the compiled artifact we need to specify the path from the root of the repo
+          # This looks unusual, but it's correct
+          # `uses` (https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsuses) runs in the root of the repository
+          # so we need to specify the full path to the compiled documentation
+          path: docs/docs
 
   deploy:
     if: github.ref == 'refs/heads/main'

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Upload artifact
         id: upload_artifact
-        uses: actions/upload-pages-artifact@0252fc4ba7626f0298f0cf00902a25c6afc77fa8 # v3.0.0
+        uses: actions/upload-pages-artifact@a753861a5debcf57bf8b404356158c8e1e33150c # v2.0.0
         with:
           name: github-pages
           path: docs/docs # This looks strange, but actions run in the root of the repo, so to consume the compiled artifact we need to specify the path from the root of the repo

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -50,7 +50,7 @@ jobs:
           path: docs/docs # This looks strange, but actions run in the root of the repo, so to consume the compiled artifact we need to specify the path from the root of the repo
 
   deploy:
-    # if: github.ref == 'refs/heads/main'
+    if: github.ref == 'refs/heads/main'
     needs: [build]
     name: Deploy
     runs-on: ubuntu-latest

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deploy_github_pages.outputs.page_url }}
+      url: ${{ steps.deploy_github_pages.outputs.base_url }}
     permissions:
       pages: write
       id-token: write
@@ -67,4 +67,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deploy_github_pages
-        uses: actions/deploy-pages@f33f41b675f0ab2dc5a6863c9a170fe83af3571e # v4.0.0
+        uses: actions/deploy-pages@13b55b33dd8996121833dbc1db458c793a334630 # v3.0.1

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on: ubuntu-latest
     environment:
       name: github-pages
-      url: ${{ steps.deploy_github_pages.outputs.base_url }}
+      url: ${{ steps.configure_github_pages.outputs.base_url }}
     permissions:
       pages: write
       id-token: write


### PR DESCRIPTION
This pull request:

- Switches to using `actions/upload-pages-artifact` at `v2.0.0`
  - This is a GitHub Pages specific action that uses `actions/upload-artifact` internally
  - Pinning at `v2.0.0` because like `actions/deploy-pages` is broken
- Drops `actions/deploy-pages` to `v3.0.0`
  - GitHub's Actions team is having a nightmare
    - https://github.com/actions/deploy-pages/issues/286
    - https://github.com/actions/deploy-pages/issues/285
    - https://github.com/actions/deploy-pages/issues/284
- Removes commented out code, I'm not sure this works anymore, will revisit #2789

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>