### PR TITLE
Bump version

### DIFF
--- a/containers/daap-athena-load/CHANGELOG.md
+++ b/containers/daap-athena-load/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.0] 2024-01-05
+
 - Renamed `extraction_timestamp` to `load_timestamp`
 - Update base image to 8.0.0
 

--- a/containers/daap-athena-load/config.json
+++ b/containers/daap-athena-load/config.json
@@ -1,6 +1,6 @@
 {
   "name": "daap-athena-load",
-  "version": "2.0.0",
+  "version": "3.0.0",
   "registry": "ecr",
   "ecr": {
     "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",


### PR DESCRIPTION
This switches to using `load_timestamp` instead of `extraction_timestamp` in the athena tables.

After this is deployed I will have to nuke the existing curated tables since these will have the old extraction_timestamp