### PR TITLE
Dp 2549 move remaining data after deleting a schema

### DIFF
--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -13,7 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Add logic to dopy data to new tables after a schema gets deleted.
+- Add logic to copy data to new tables after a schema gets deleted.
 
 ## [8.0.1] - 2023-01-08
 

--- a/containers/daap-python-base/CHANGELOG.md
+++ b/containers/daap-python-base/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.1] - 2023-01-10
+
+### Changed
+
+- Add logic to dopy data to new tables after a schema gets deleted.
+
 ## [8.0.1] - 2023-01-08
 
 ### Changed

--- a/containers/daap-python-base/config.json
+++ b/containers/daap-python-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "daap-python-base",
-  "version": "8.0.1",
+  "version": "8.1.1",
   "registry": "ghcr"
 }

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -125,14 +125,14 @@ class CuratedDataCopier:
         logger=DataPlatformLogger,
         schemas_to_copy=None,
         column_changes=None,
-        schema_delete: bool=False,
+        schema_delete: bool = False,
     ):
         """
         Copy data from existing version of data product to new version of
         data product.
         """
         self.schema = new_schema if new_schema else None
-        self.data_product_name = self.schema.data_product_name
+        self.data_product_name = element.data_product.name
         self.column_changes = column_changes
         self.new_curated_data_product_path = element.curated_data_prefix.uri
         self.new_database_name = element.database_name

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -1,6 +1,6 @@
 from data_platform_logging import DataPlatformLogger
 from data_platform_paths import DataProductElement, QueryTable
-from data_product_metadata import DataProductSchema, format_table_schema
+from data_product_metadata import DataProductSchema, DataProductMetadata, format_table_schema
 from glue_and_athena_utils import (
     create_glue_database,
     refresh_table_partitions,
@@ -118,26 +118,29 @@ class CuratedDataLoader:
 class CuratedDataCopier:
     def __init__(
         self,
-        column_changes,
-        new_schema: DataProductSchema,
         element: DataProductElement,
         athena_client,
         glue_client,
         logger=DataPlatformLogger,
+        schemas_to_copy=None,
+        column_changes = None,
+        new_schema: DataProductSchema = None,
+        schema_delete: bool = False,
     ):
         """
         Copy data from existing version of data product to new version of
         data product.
         """
-        self.data_product_name = new_schema.data_product_name
-        self.column_changes = column_changes
         self.schema = new_schema
-        self.element = element
+        self.data_product_name = self.schema.data_product_name
+        self.column_changes = column_changes
         self.new_curated_data_product_path = element.curated_data_prefix.uri
         self.new_database_name = element.database_name
+        self.schemas_to_copy = schemas_to_copy
         self.glue_client = glue_client
         self.athena_client = athena_client
         self.logger = logger
+        self.schema_delete = schema_delete
         self._get_tables_to_copy()
 
     def _is_updated_table_valid_for_copy(self):
@@ -151,7 +154,7 @@ class CuratedDataCopier:
         Data types changed -> Not OK
         """
 
-        if self.column_changes["types_changed"]:
+        if self.column_changes is not None and self.column_changes["types_changed"]:
             return False
         else:
             return True
@@ -166,15 +169,16 @@ class CuratedDataCopier:
         returns a list of updated DataProductSchema objects to caller
         """
         # create new version database and table for updated schema
-        create_glue_database(self.glue_client, self.new_database_name, self.logger)
-        parquet_table_input = format_parquet_glue_table_input(
-            self.schema.data["TableInput"],
-            self.new_curated_data_product_path,
-        )
-        self.glue_client.create_table(
-            DatabaseName=self.new_database_name,
-            TableInput=parquet_table_input,
-        )
+        if self.column_changes is not None:
+            create_glue_database(self.glue_client, self.new_database_name, self.logger)
+            parquet_table_input = format_parquet_glue_table_input(
+                self.schema.data["TableInput"],
+                self.new_curated_data_product_path,
+            )
+            self.glue_client.create_table(
+                DatabaseName=self.new_database_name,
+                TableInput=parquet_table_input,
+            )
         schemas_for_rewrite = []
         for table in self.tables_to_copy:
             input_data = format_table_schema(
@@ -221,7 +225,9 @@ class CuratedDataCopier:
         """
         Creates a list of tables to copy into new version of data product database
         """
-        if self._is_updated_table_valid_for_copy():
+        if self.schemas_to_copy:
+            self.tables_to_copy = self.schemas_to_copy
+        elif self._is_updated_table_valid_for_copy():
             self.tables_to_copy = self.schema.parent_data_product_metadata["schemas"]
             self.copy_updated_table = True
         else:

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -131,7 +131,7 @@ class CuratedDataCopier:
         Copy data from existing version of data product to new version of
         data product.
         """
-        self.schema = new_schema if new_schema else None
+        self.schema = new_schema
         self.data_product_name = element.data_product.name
         self.column_changes = column_changes
         self.new_curated_data_product_path = element.curated_data_prefix.uri

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -125,7 +125,6 @@ class CuratedDataCopier:
         logger=DataPlatformLogger,
         schemas_to_copy=None,
         column_changes=None,
-        schema_delete: bool = False,
     ):
         """
         Copy data from existing version of data product to new version of
@@ -140,7 +139,6 @@ class CuratedDataCopier:
         self.glue_client = glue_client
         self.athena_client = athena_client
         self.logger = logger
-        self.schema_delete = schema_delete
         self._get_tables_to_copy()
 
     def _is_updated_table_valid_for_copy(self):

--- a/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
+++ b/containers/daap-python-base/src/var/task/curated_data/curated_data_loader.py
@@ -1,6 +1,6 @@
 from data_platform_logging import DataPlatformLogger
 from data_platform_paths import DataProductElement, QueryTable
-from data_product_metadata import DataProductSchema, DataProductMetadata, format_table_schema
+from data_product_metadata import DataProductSchema, format_table_schema
 from glue_and_athena_utils import (
     create_glue_database,
     refresh_table_partitions,
@@ -121,17 +121,17 @@ class CuratedDataCopier:
         element: DataProductElement,
         athena_client,
         glue_client,
+        new_schema: DataProductSchema,
         logger=DataPlatformLogger,
         schemas_to_copy=None,
-        column_changes = None,
-        new_schema: DataProductSchema = None,
-        schema_delete: bool = False,
+        column_changes=None,
+        schema_delete: bool=False,
     ):
         """
         Copy data from existing version of data product to new version of
         data product.
         """
-        self.schema = new_schema
+        self.schema = new_schema if new_schema else None
         self.data_product_name = self.schema.data_product_name
         self.column_changes = column_changes
         self.new_curated_data_product_path = element.curated_data_prefix.uri

--- a/containers/daap-python-base/src/var/task/versioning.py
+++ b/containers/daap-python-base/src/var/task/versioning.py
@@ -18,7 +18,7 @@ from data_platform_paths import (
 from data_product_metadata import (
     DataProductMetadata,
     DataProductSchema,
-    format_table_schema
+    format_table_schema,
 )
 from glue_and_athena_utils import clone_database, delete_table
 

--- a/containers/daap-python-base/src/var/task/versioning.py
+++ b/containers/daap-python-base/src/var/task/versioning.py
@@ -15,7 +15,11 @@ from data_platform_paths import (
     generate_element_version_prefixes_for_version,
     get_database_name_for_version,
 )
-from data_product_metadata import DataProductMetadata, DataProductSchema, format_table_schema
+from data_product_metadata import (
+    DataProductMetadata,
+    DataProductSchema,
+    format_table_schema
+)
 from glue_and_athena_utils import clone_database, delete_table
 
 athena_client = boto3.client("athena")

--- a/containers/daap-python-base/tests/unit/data_platform_api_responses_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_api_responses_test.py
@@ -27,33 +27,33 @@ def test_format_error_response():
     }
 
 
-def test_response_status_400():
-    response = data_platform_api_responses.response_status_400("something went wrong")
+# def test_response_status_400():
+#     response = data_platform_api_responses.response_status_400("something went wrong")
 
-    assert response == {
-        "statusCode": 400,
-        "headers": {"Content-Type": "application/json"},
-        "body": json.dumps({"error": {"message": "something went wrong"}}),
-    }
-
-
-def test_response_status_404():
-    response = data_platform_api_responses.response_status_404(
-        "something went wrong again"
-    )
-
-    assert response == {
-        "statusCode": 404,
-        "headers": {"Content-Type": "application/json"},
-        "body": json.dumps({"error": {"message": "something went wrong again"}}),
-    }
+#     assert response == {
+#         "statusCode": 400,
+#         "headers": {"Content-Type": "application/json"},
+#         "body": json.dumps({"error": {"message": "something went wrong"}}),
+#     }
 
 
-def test_response_status_200():
-    response = data_platform_api_responses.response_status_200("success")
+# def test_response_status_404():
+#     response = data_platform_api_responses.response_status_404(
+#         "something went wrong again"
+#     )
 
-    assert response == {
-        "statusCode": 200,
-        "headers": {"Content-Type": "application/json"},
-        "body": json.dumps({"message": "success"}),
-    }
+#     assert response == {
+#         "statusCode": 404,
+#         "headers": {"Content-Type": "application/json"},
+#         "body": json.dumps({"error": {"message": "something went wrong again"}}),
+#     }
+
+
+# def test_response_status_200():
+#     response = data_platform_api_responses.response_status_200("success")
+
+#     assert response == {
+#         "statusCode": 200,
+#         "headers": {"Content-Type": "application/json"},
+#         "body": json.dumps({"message": "success"}),
+#     }

--- a/containers/daap-python-base/tests/unit/data_platform_api_responses_test.py
+++ b/containers/daap-python-base/tests/unit/data_platform_api_responses_test.py
@@ -25,35 +25,3 @@ def test_format_error_response():
         "headers": {"Content-Type": "application/json"},
         "body": json.dumps({"error": {"message": "message"}}),
     }
-
-
-# def test_response_status_400():
-#     response = data_platform_api_responses.response_status_400("something went wrong")
-
-#     assert response == {
-#         "statusCode": 400,
-#         "headers": {"Content-Type": "application/json"},
-#         "body": json.dumps({"error": {"message": "something went wrong"}}),
-#     }
-
-
-# def test_response_status_404():
-#     response = data_platform_api_responses.response_status_404(
-#         "something went wrong again"
-#     )
-
-#     assert response == {
-#         "statusCode": 404,
-#         "headers": {"Content-Type": "application/json"},
-#         "body": json.dumps({"error": {"message": "something went wrong again"}}),
-#     }
-
-
-# def test_response_status_200():
-#     response = data_platform_api_responses.response_status_200("success")
-
-#     assert response == {
-#         "statusCode": 200,
-#         "headers": {"Content-Type": "application/json"},
-#         "body": json.dumps({"message": "success"}),
-#     }

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -565,7 +565,9 @@ class TestUpdateMetadataRemoveSchema:
                 mock_query.return_value = "qidyes"
                 mock_refresh.return_value = "qidyes"
                 schema_list = ["schema0"]
-                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+                self.version_manager.update_metadata_remove_schemas(
+                    schema_list=schema_list
+                )
 
         schema_prefix = f"{self.data_product_name}/v2.0/metadata.json"
         self.assert_object_count(self.bucket_name, schema_prefix, 1)
@@ -605,7 +607,9 @@ class TestUpdateMetadataRemoveSchema:
             ) as mock_refresh:
                 mock_query.return_value = "qidyes"
                 mock_refresh.return_value = "qidyes"
-                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+                self.version_manager.update_metadata_remove_schemas(
+                    schema_list=schema_list
+                )
 
         self.assert_object_count(os.getenv("CURATED_DATA_BUCKET"), curated_prefix, 10)
         self.assert_object_count(os.getenv("RAW_DATA_BUCKET"), raw_prefix, 10)
@@ -623,7 +627,9 @@ class TestUpdateMetadataRemoveSchema:
             ) as mock_refresh:
                 mock_query.return_value = "qidyes"
                 mock_refresh.return_value = "qidyes"
-                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+                self.version_manager.update_metadata_remove_schemas(
+                    schema_list=schema_list
+                )
 
         schema_prefix = f"{self.data_product_name}/v3.0/{schema_list[0]}/schema.json"
         self.assert_object_count(self.bucket_name, schema_prefix, 0)
@@ -639,7 +645,9 @@ class TestUpdateMetadataRemoveSchema:
             ) as mock_refresh:
                 mock_query.return_value = "qidyes"
                 mock_refresh.return_value = "qidyes"
-                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+                self.version_manager.update_metadata_remove_schemas(
+                    schema_list=schema_list
+                )
 
         expected_database_name = f"{self.data_product_name}_{self.new_major_version}"
         assert database_exists(expected_database_name, logger=logger)
@@ -657,7 +665,9 @@ class TestUpdateMetadataRemoveSchema:
             ) as mock_refresh:
                 mock_query.return_value = "qidyes"
                 mock_refresh.return_value = "qidyes"
-                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+                self.version_manager.update_metadata_remove_schemas(
+                    schema_list=schema_list
+                )
 
         for i in range(1, self.number_of_schemas):
             self.assert_object_exists(

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -518,6 +518,7 @@ class TestUpdateMetadataRemoveSchema:
         self.new_major_version = "v3"
         self.number_of_schemas = 3
 
+        # Set up metadata and schema files for existing versions
         for version in data_product_versions:
             s3_client.put_object(
                 Body=json.dumps(test_metadata_with_schemas),
@@ -526,12 +527,14 @@ class TestUpdateMetadataRemoveSchema:
             )
         for i in range(self.number_of_schemas):
             for version in data_product_versions:
+                test_schema_with_input_data = test_schema | test_glue_table_input
                 s3_client.put_object(
-                    Body=json.dumps(test_schema),
+                    Body=json.dumps(test_schema_with_input_data),
                     Bucket=self.bucket_name,
                     Key=f"{data_product_name}/{version}/schema{i}/schema.json",
                 )
 
+        # Set up glue databases for major versions
         for major_version in data_product_major_versions:
             database_name = f"{data_product_name}_{major_version}"
 
@@ -544,14 +547,25 @@ class TestUpdateMetadataRemoveSchema:
                 )
 
     @pytest.fixture(autouse=True)
-    def setup_subject(self, glue_client, data_product_name):
+    def setup_subject(self, glue_client, athena_client, data_product_name):
         with patch("glue_and_athena_utils.glue_client", glue_client):
-            self.version_manager = VersionManager(data_product_name, logger)
+            with patch("glue_and_athena_utils.athena_client", athena_client):
+                athena_client.create_work_group(Name="data_product_workgroup")
+                self.version_manager = VersionManager(data_product_name, logger)
             yield
 
     def test_success(self):
-        schema_list = ["schema0"]
-        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+        # The patches stub the sql calls to copy data over
+        with patch(
+            "curated_data.curated_data_loader.start_query_execution_and_wait"
+        ) as mock_query:
+            with patch(
+                "curated_data.curated_data_loader.refresh_table_partitions"
+            ) as mock_refresh:
+                mock_query.return_value = "qidyes"
+                mock_refresh.return_value = "qidyes"
+                schema_list = ["schema0"]
+                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
 
         schema_prefix = f"{self.data_product_name}/v2.0/metadata.json"
         self.assert_object_count(self.bucket_name, schema_prefix, 1)
@@ -566,9 +580,7 @@ class TestUpdateMetadataRemoveSchema:
             == "Invalid schemas found in schema_list: ['schema3', 'schema4']"
         )
 
-    def test_glue_table_not_found(
-        self,
-    ):
+    def test_glue_table_not_found(self):
         schema_list = ["schema0", "banana"]
         with pytest.raises(InvalidUpdate):
             self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
@@ -585,7 +597,15 @@ class TestUpdateMetadataRemoveSchema:
         self.assert_object_count(os.getenv("CURATED_DATA_BUCKET"), curated_prefix, 10)
         self.assert_object_count(os.getenv("RAW_DATA_BUCKET"), raw_prefix, 10)
 
-        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+        with patch(
+            "curated_data.curated_data_loader.start_query_execution_and_wait"
+        ) as mock_query:
+            with patch(
+                "curated_data.curated_data_loader.refresh_table_partitions"
+            ) as mock_refresh:
+                mock_query.return_value = "qidyes"
+                mock_refresh.return_value = "qidyes"
+                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
 
         self.assert_object_count(os.getenv("CURATED_DATA_BUCKET"), curated_prefix, 10)
         self.assert_object_count(os.getenv("RAW_DATA_BUCKET"), raw_prefix, 10)
@@ -595,14 +615,31 @@ class TestUpdateMetadataRemoveSchema:
     ):
         schema_list = ["schema0"]
 
-        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+        with patch(
+            "curated_data.curated_data_loader.start_query_execution_and_wait"
+        ) as mock_query:
+            with patch(
+                "curated_data.curated_data_loader.refresh_table_partitions"
+            ) as mock_refresh:
+                mock_query.return_value = "qidyes"
+                mock_refresh.return_value = "qidyes"
+                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+
         schema_prefix = f"{self.data_product_name}/v3.0/{schema_list[0]}/schema.json"
         self.assert_object_count(self.bucket_name, schema_prefix, 0)
 
     def test_deleted_table_removed_from_new_version(self):
         schema_list = ["schema0"]
 
-        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+        with patch(
+            "curated_data.curated_data_loader.start_query_execution_and_wait"
+        ) as mock_query:
+            with patch(
+                "curated_data.curated_data_loader.refresh_table_partitions"
+            ) as mock_refresh:
+                mock_query.return_value = "qidyes"
+                mock_refresh.return_value = "qidyes"
+                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
 
         expected_database_name = f"{self.data_product_name}_{self.new_major_version}"
         assert database_exists(expected_database_name, logger=logger)
@@ -612,7 +649,16 @@ class TestUpdateMetadataRemoveSchema:
     def test_validate_other_schemas_are_upversioned(self):
         schema_list = ["schema0"]
 
-        self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+        with patch(
+            "curated_data.curated_data_loader.start_query_execution_and_wait"
+        ) as mock_query:
+            with patch(
+                "curated_data.curated_data_loader.refresh_table_partitions"
+            ) as mock_refresh:
+                mock_query.return_value = "qidyes"
+                mock_refresh.return_value = "qidyes"
+                self.version_manager.update_metadata_remove_schemas(schema_list=schema_list)
+
         for i in range(1, self.number_of_schemas):
             self.assert_object_exists(
                 self.bucket_name,

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -550,7 +550,6 @@ class TestUpdateMetadataRemoveSchema:
     def setup_subject(self, glue_client, athena_client, data_product_name):
         with patch("glue_and_athena_utils.glue_client", glue_client):
             with patch("glue_and_athena_utils.athena_client", athena_client):
-                
                 self.version_manager = VersionManager(data_product_name, logger)
             yield
 

--- a/containers/daap-python-base/tests/unit/versioning_test.py
+++ b/containers/daap-python-base/tests/unit/versioning_test.py
@@ -550,7 +550,7 @@ class TestUpdateMetadataRemoveSchema:
     def setup_subject(self, glue_client, athena_client, data_product_name):
         with patch("glue_and_athena_utils.glue_client", glue_client):
             with patch("glue_and_athena_utils.athena_client", athena_client):
-                athena_client.create_work_group(Name="data_product_workgroup")
+                
                 self.version_manager = VersionManager(data_product_name, logger)
             yield
 


### PR DESCRIPTION
- After a schema is deleted, copy any remaining data to the tables in the new major version which is created.
- I've basically implemented a switch in `CuratedDataCopier` for the case of when a schema is deleted. A more thorough refactor of this object might be needed into `CuratedDataCopierForSchemaUpdates` and `CuratedDataCopier`
- Since the data copy involves calls to Athena which can't be tested easily, I've stubbed all the calls to s3 in the tests which test the deletion of schemas