### PR TITLE
upgrade helm chart for airflow dev

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/helm-charts.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/helm-charts.tf
@@ -2,7 +2,7 @@ resource "helm_release" "kyverno_dev" {
   name       = "kyverno"
   repository = "https://kyverno.github.io/kyverno/"
   chart      = "kyverno"
-  version    = "2.5.3"
+  version    = "2.6.0"
   namespace  = kubernetes_namespace.kyverno_dev.metadata[0].name
   provider   = helm.dev-airflow-cluster
   values = [


### PR DESCRIPTION
This pr is upgrade the helm chart version to 2.6.0 this is a prerequisite requirement for the minimum version needed for EKS cluster 