### PR TITLE
🛂 cjs-dashboard-app GitHub Actions role

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -284,6 +284,17 @@ updates:
     reviewers:
       - "ministryofjustice/data-platform-apps-and-tools"
   - package-ecosystem: "terraform"
+    directory: "terraform/aws/analytical-platform-data-production/cjs-dashboard-app"
+    schedule:
+      interval: "daily"
+      time: "09:00"
+      timezone: "Europe/London"
+    commit-message:
+      prefix: "terraform"
+      include: "scope"
+    reviewers:
+      - "ministryofjustice/data-platform-apps-and-tools"
+  - package-ecosystem: "terraform"
     directory: "terraform/aws/analytical-platform-data-production/control-panel-message-broker"
     schedule:
       interval: "daily"

--- a/.github/path-filter/terraform.yml
+++ b/.github/path-filter/terraform.yml
@@ -10,6 +10,7 @@ aws-analytical-platform-baseline: terraform/aws/analytical-platform/baseline/**
 aws-analytical-platform-data-engineering-production-10ds: terraform/aws/analytical-platform-data-engineering-production/10ds/**
 aws-analytical-platform-data-production-airflow: terraform/aws/analytical-platform-data-production/airflow/**
 aws-analytical-platform-data-production-artifact-repos: terraform/aws/analytical-platform-data-production/artifact-repos/**
+aws-analytical-platform-data-production-cjs-dashboard-app: terraform/aws/analytical-platform-data-production/cjs-dashboard-app/**
 aws-analytical-platform-data-production-control-panel-message-broker: terraform/aws/analytical-platform-data-production/control-panel-message-broker/**
 aws-analytical-platform-data-production-create-a-derived-table: terraform/aws/analytical-platform-data-production/create-a-derived-table/**
 aws-analytical-platform-data-production-openmetadata: terraform/aws/analytical-platform-data-production/openmetadata/**
@@ -23,6 +24,7 @@ aws-analytical-platform-management-production-cluster: terraform/aws/analytical-
 aws-analytical-platform-oidc: terraform/aws/analytical-platform/oidc/**
 aws-analytical-platform-production-cluster: terraform/aws/analytical-platform-production/cluster/**
 cloud-platform-live-data-platform-development-static-assets: terraform/cloud-platform/live/data-platform-development/static-assets/**
-cloud-platform-live-data-platform-production-github-actions-self-hosted-runners: terraform/cloud-platform/live/data-platform-production/github-actions-self-hosted-runners/**
+cloud-platform-live-data-platform-production-actions-runners: terraform/cloud-platform/live/data-platform-production/actions-runners/**
+dpat-eks-production-actions-runners: terraform/dpat-eks/production/actions-runners/**
 github: terraform/github/**
 pagerduty: terraform/pagerduty/**

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.32.1"
+  constraints = ">= 4.0.0, 5.32.1"
+  hashes = [
+    "h1:UBks+d4PBTLdkQfzGvdt7rZ9nASr7gecv9iJuL/e6L8=",
+    "zh:0c603e0ea9ec481f1588ca44d3464fe43ed936a8452e0c70d347c8e71a1b19a4",
+    "zh:0d43c845330ea4aaa152caf35819069215fcf17e4468b9d94c631f7d4178b1ac",
+    "zh:1211275208e8142bfa27987fdeb3eae40075ff569bf198330975f470bc4f5137",
+    "zh:1d8e7e4a2ff45a8b56037d030e2978fc04007941f62f1e265e251801a1d0c3cc",
+    "zh:4f6a8a6c9413b8b9267673cb7fb9dee7dc81946f7cc17d23e2104304f4ec4472",
+    "zh:6d769c74f8157260a37a32a1036b77f9795e21df2df7cadf4c7acc85b2dfd96e",
+    "zh:778fd9bf80424a62ebf5f059dcabfc4a588b0791ba18c1cf727bbdc1aed40351",
+    "zh:7bf1b063065bbe39b71e2a5895915fcbcc0cf7f553f84388e81888506d292fce",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b57506c3f46e850543fc1ee9522f231311e8540730db76bbf7a3f4d81777a4bd",
+    "zh:d37c8655b2a31435a116a1af7031f2bcdecf4c7e7e74903b88203798fb39043e",
+    "zh:db369802896eb10bbfed00bf3bd568b35fb5d903d3624d555b6574c5c4e2d94e",
+    "zh:e9992bfccf8205c495aebb7da917404496f96b5d3ea4a915a8884994ca8d860c",
+    "zh:ed1e0ef83cde313f1ccb3e18fc9dc63bf6ca473ec07554df5e24c706708a6866",
+    "zh:f0d19ed41352da9be308dff72899ecf5af7a42b592cf37fb98e9064e7622d35e",
+  ]
+}

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/data.tf
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/data.tf
@@ -1,0 +1,9 @@
+data "aws_caller_identity" "session" {
+  provider = aws.session
+}
+
+data "aws_iam_session_context" "session" {
+  provider = aws.session
+
+  arn = data.aws_caller_identity.session.arn
+}

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-policies.tf
@@ -1,0 +1,26 @@
+data "aws_iam_policy_document" "cjs_dashboard_app" {
+  statement {
+    sid    = "BucketAccess"
+    effect = "Allow"
+    actions = [
+      "s3:List*",
+      "s3:GetObject*",
+      "s3:GetBucket*",
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-cjs-dashboard",
+      "arn:aws:s3:::mojap-cjs-dashboard/*"
+    ]
+  }
+}
+
+module "cjs_dashboard_app_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.33.0"
+
+  name_prefix = "cjs-dashboard-app"
+
+  policy = data.aws_iam_policy_document.cjs_dashboard_app.json
+}

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-policies.tf
@@ -3,9 +3,8 @@ data "aws_iam_policy_document" "cjs_dashboard_app" {
     sid    = "BucketAccess"
     effect = "Allow"
     actions = [
-      "s3:List*",
-      "s3:GetObject*",
-      "s3:GetBucket*",
+      "s3:ListBucket",
+      "s3:GetObject"
     ]
     resources = [
       "arn:aws:s3:::mojap-cjs-dashboard",

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-policies.tf
@@ -19,7 +19,7 @@ module "cjs_dashboard_app_iam_policy" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
   version = "5.33.0"
 
-  name_prefix = "cjs-dashboard-app"
+  name_prefix = "github-cjs-dashboard-app"
 
   policy = data.aws_iam_policy_document.cjs_dashboard_app.json
 }

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-roles.tf
@@ -1,0 +1,12 @@
+module "cjs_dashboard_app_iam_role" {
+  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+  version = "5.33.0"
+
+  name = "github-cjs-dashboard-app"
+
+  subjects = ["ministryofjustice/cjs_scorecard_exploratory_analysis:*"]
+
+  policies = {
+    cjs_dashboard_app = module.cjs_dashboard_app_iam_policy.arn
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/iam-roles.tf
@@ -1,4 +1,6 @@
 module "cjs_dashboard_app_iam_role" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
   version = "5.33.0"
 

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/terraform.tf
@@ -1,0 +1,42 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-data-production/cjs-dashboard-app/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.32.1"
+    }
+  }
+  required_version = "~> 1.5"
+}
+
+provider "aws" {
+  alias = "session"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/terraform.tfvars
@@ -1,0 +1,15 @@
+account_ids = {
+  analytical-platform-data-production       = "593291632749"
+  analytical-platform-management-production = "042130406152"
+}
+
+tags = {
+  business-unit          = "Platforms"
+  application            = "Data Platform"
+  component              = "cjs-dashboard-app"
+  environment            = "production"
+  is-production          = "true"
+  owner                  = "data-platform:data-platform-tech@digital.justice.gov.uk"
+  infrastructure-support = "data-platform:data-platform-tech@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/cjs-dashboard-app"
+}

--- a/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/cjs-dashboard-app/variables.tf
@@ -1,0 +1,9 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}


### PR DESCRIPTION
This pull request:

- Resolves #2951
- Adds a new component for cjs-dashboard-app in analytical-platform-data-production
- Adds a policy and role to allow `ministryofjustice/cjs_scorecard_exploratory_analysis` access to `arn:aws:s3:::mojap-cjs-dashboard`

Note(s) for the reviewer:

- I did briefly explore adding this into <https://github.com/ministryofjustice/data-platform/blob/main/terraform/aws/analytical-platform/oidc/oidc-roles.tf>, however I am unsure if that code allows for specifying granular policy statements other than just allowing the subject to assume either `github-actions-infrastructure` or `data-engineering-infrastructure`, which allow usage of the `AdministratorAccess` policy
- Based on the above, a separate (or update to the existing) component might be more appropriate for hosting these policies and roles, however I've created a new one like we did for `create-a-derived-table`, but we should look at consolidating them longer term #2976

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>