### PR TITLE
🚑 Fix JML ECR repository naming

### DIFF
--- a/containers/jml-extract-lambda/CHANGELOG.md
+++ b/containers/jml-extract-lambda/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.0.1] - 2024-01-17
+
+### Changed
+
+- Updated ECR repository name
+
 ## [1.0.0] - 2023-09-12
 
 ### Added

--- a/containers/jml-extract-lambda/config.json
+++ b/containers/jml-extract-lambda/config.json
@@ -1,11 +1,11 @@
 {
   "name": "jml-extract-lambda",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "registry": "ecr",
     "ecr": {
         "role": "arn:aws:iam::013433889002:role/modernisation-platform-oidc-cicd",
         "account": "374269020027",
         "region": "eu-west-2",
-        "repository": "data-platform-jml-extract-lambda"
+        "repository": "data-platform-jml-extract-lambda-ecr-repo"
     }
 }


### PR DESCRIPTION
This pull request:

- Fixes an issue pushing to Modernisation Platform's ECR

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>