### PR TITLE
[DP-2782] Fix data product assets issue and bump the version

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.4.0] 2024-01-19
 
 ### Breaking changes
 
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `location: DataLocation` argument on all methods. This captures information
   about where a node in the metadata graph should be located, and what kind
   of database it comes from.
+
+- Renamed `create_or_update_*` methods to `upsert_*`.
 
 - Extracted `BaseCatalogueClient` base class from `CatalogueClient`. Use this
   as a type annotation to avoid coupling to the OpenMetadata implementation.

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
@@ -1,5 +1,4 @@
 from .client import DataHubCatalogueClient  # noqa: F401
-from .client import OpenMetadataCatalogueClient  # noqa: F401
 from .client import CatalogueError, ReferencedEntityMissing  # noqa: F401
 from .entities import DataProductMetadata  # noqa: F401
 from .entities import CatalogueMetadata, DataLocation, TableMetadata  # noqa: F401

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/__init__.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/__init__.py
@@ -2,4 +2,3 @@ from .base import BaseCatalogueClient  # noqa: F401
 from .base import CatalogueError  # noqa: F401
 from .base import ReferencedEntityMissing  # noqa: F401
 from .datahub import DataHubCatalogueClient  # noqa: F401
-from .openmetadata import OpenMetadataCatalogueClient  # noqa: F401

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub.py
@@ -294,11 +294,11 @@ class DataHubCatalogueClient(BaseCatalogueClient):
                 data_product_existing_properties is not None
                 and data_product_existing_properties.assets is not None
             ):
-                assets = data_product_existing_properties.assets.append(
-                    data_product_association
-                )
+                assets = data_product_existing_properties.assets[::]
+                assets.append(data_product_association)
             else:
                 assets = [data_product_association]
+
             data_product_properties = DataProductPropertiesClass(assets=assets)
 
             metadata_event = MetadataChangeProposalWrapper(

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.3.1"
+version = "0.4.0"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"
@@ -10,7 +10,7 @@ packages = [{ include = "data_platform_catalogue" }]
 [tool.poetry.dependencies]
 python = "^3.10"
 openmetadata-ingestion = "~1.2.0.1"
-acryl-datahub = {extras = ["datahub-rest"], version = "^0.12.1.3"}
+acryl-datahub = { extras = ["datahub-rest"], version = "^0.12.1.3" }
 freezegun = "^1.4.0"
 deepdiff = "^6.7.1"
 

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_two_tables_with_metadata.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_two_tables_with_metadata.json
@@ -1,0 +1,256 @@
+[
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_database.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "bla bla",
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_database.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "my_table",
+            "platform": "urn:li:dataPlatform:glue",
+            "version": 1,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "foo",
+                    "nullable": false,
+                    "description": "a",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "bar",
+                    "nullable": false,
+                    "description": "b",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "int",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "domain",
+    "entityUrn": "urn:li:domain:legal-aid",
+    "changeType": "UPSERT",
+    "aspectName": "domainProperties",
+    "aspect": {
+        "json": {
+            "name": "legal-aid",
+            "description": ""
+        }
+    }
+},
+{
+    "entityType": "dataproduct",
+    "entityUrn": "urn:li:dataProduct:my_data_product",
+    "changeType": "UPSERT",
+    "aspectName": "domains",
+    "aspect": {
+        "json": {
+            "domains": [
+                "urn:li:domain:legal-aid"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataproduct",
+    "entityUrn": "urn:li:dataProduct:my_data_product",
+    "changeType": "UPSERT",
+    "aspectName": "dataProductProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "email": "justice@justice.gov.uk",
+                "retention_period_in_days": "365",
+                "dpia_required": "False"
+            },
+            "name": "my_data_product",
+            "description": "bla bla"
+        }
+    }
+},
+{
+    "entityType": "dataproduct",
+    "entityUrn": "urn:li:dataProduct:my_data_product",
+    "changeType": "UPSERT",
+    "aspectName": "dataProductProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "assets": [
+                {
+                    "sourceUrn": "urn:li:dataProduct:my_data_product",
+                    "destinationUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_database.my_table,PROD)"
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_database.my_table2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "description": "this is a different table",
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_database.my_table2,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "my_table2",
+            "platform": "urn:li:dataPlatform:glue",
+            "version": 1,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "boo",
+                    "nullable": false,
+                    "description": "spooky",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.BooleanType": {}
+                        }
+                    },
+                    "nativeDataType": "boolean",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "yar",
+                    "nullable": false,
+                    "description": "shiver my timbers",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "domain",
+    "entityUrn": "urn:li:domain:legal-aid",
+    "changeType": "UPSERT",
+    "aspectName": "domainProperties",
+    "aspect": {
+        "json": {
+            "name": "legal-aid",
+            "description": ""
+        }
+    }
+},
+{
+    "entityType": "dataproduct",
+    "entityUrn": "urn:li:dataProduct:my_data_product",
+    "changeType": "UPSERT",
+    "aspectName": "domains",
+    "aspect": {
+        "json": {
+            "domains": [
+                "urn:li:domain:legal-aid"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataproduct",
+    "entityUrn": "urn:li:dataProduct:my_data_product",
+    "changeType": "UPSERT",
+    "aspectName": "dataProductProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "email": "justice@justice.gov.uk",
+                "retention_period_in_days": "365",
+                "dpia_required": "False"
+            },
+            "name": "my_data_product",
+            "description": "bla bla"
+        }
+    }
+},
+{
+    "entityType": "dataproduct",
+    "entityUrn": "urn:li:dataProduct:my_data_product",
+    "changeType": "UPSERT",
+    "aspectName": "dataProductProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {},
+            "assets": [
+                {
+                    "sourceUrn": "urn:li:dataProduct:my_data_product",
+                    "destinationUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_database.my_table2,PROD)"
+                }
+            ]
+        }
+    }
+}
+]

--- a/python-libraries/data-platform-catalogue/tests/test_client_openmetadata.py
+++ b/python-libraries/data-platform-catalogue/tests/test_client_openmetadata.py
@@ -1,8 +1,6 @@
 import pytest
-from data_platform_catalogue.client import (
-    OpenMetadataCatalogueClient,
-    ReferencedEntityMissing,
-)
+from data_platform_catalogue.client import ReferencedEntityMissing
+from data_platform_catalogue.client.openmetadata import OpenMetadataCatalogueClient
 from data_platform_catalogue.entities import (
     CatalogueMetadata,
     DataLocation,

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_openmetadata_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_openmetadata_server.py
@@ -11,7 +11,7 @@ import os
 
 import pytest
 from data_platform_catalogue import DataProductMetadata, TableMetadata
-from data_platform_catalogue.client import OpenMetadataCatalogueClient
+from data_platform_catalogue.client.openmetadata import OpenMetadataCatalogueClient
 from data_platform_catalogue.entities import DataLocation
 
 jwt_token = os.environ.get("JWT_TOKEN")


### PR DESCRIPTION
1. Fix a bug in the initial implementation of datahub. When we update a data product to add a new table to it, we were clearing the previously added assets.

2. Stop importing openmetadata by default - this allows the library to be used on python 3.11+

3. Bump the version so we can release