### PR TITLE
[DP-2983] Add a method for search

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,4 @@ __pycache__
 .github/path-filter/pytest.yml
 .github/path-filter/containers.yml
 .github/path-filter/terraform.yml
-**/**datahub
 .coverage

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
@@ -1,4 +1,3 @@
-from .client import DataHubCatalogueClient  # noqa: F401
 from .client import CatalogueError, ReferencedEntityMissing  # noqa: F401
 from .entities import DataProductMetadata  # noqa: F401
 from .entities import CatalogueMetadata, DataLocation, TableMetadata  # noqa: F401

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/__init__.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/__init__.py
@@ -1,4 +1,3 @@
 from .base import BaseCatalogueClient  # noqa: F401
 from .base import CatalogueError  # noqa: F401
 from .base import ReferencedEntityMissing  # noqa: F401
-from .datahub import DataHubCatalogueClient  # noqa: F401

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
@@ -7,6 +7,7 @@ from ..entities import (
     DataProductMetadata,
     TableMetadata,
 )
+from ..search_types import SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -53,3 +54,11 @@ class BaseCatalogueClient(ABC):
         data_product_metadata: DataProductMetadata | None = None,
     ) -> str:
         pass
+
+    def search(
+        self, query: str = "*", count: int = 20, page: str | None = None
+    ) -> SearchResponse:
+        """
+        Wraps the catalogue's search function.
+        """
+        raise NotImplementedError

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
@@ -1,5 +1,6 @@
 import logging
 from abc import ABC, abstractmethod
+from typing import Sequence
 
 from ..entities import (
     CatalogueMetadata,
@@ -7,7 +8,7 @@ from ..entities import (
     DataProductMetadata,
     TableMetadata,
 )
-from ..search_types import SearchResponse
+from ..search_types import ResultType, SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -56,7 +57,14 @@ class BaseCatalogueClient(ABC):
         pass
 
     def search(
-        self, query: str = "*", count: int = 20, page: str | None = None
+        self,
+        query: str = "*",
+        count: int = 20,
+        page: str | None = None,
+        result_types: Sequence[ResultType] = (
+            ResultType.DATA_PRODUCT,
+            ResultType.TABLE,
+        ),
     ) -> SearchResponse:
         """
         Wraps the catalogue's search function.

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/__init__.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/__init__.py
@@ -1,0 +1,1 @@
+from .datahub_client import DataHubCatalogueClient  # noqa: F401

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -1,3 +1,5 @@
+from typing import Sequence
+
 import datahub.emitter.mce_builder as mce_builder
 import datahub.metadata.schema_classes as schema_classes
 from data_platform_catalogue.client.base import (
@@ -6,7 +8,7 @@ from data_platform_catalogue.client.base import (
     ReferencedEntityMissing,
     logger,
 )
-from data_platform_catalogue.search_types import SearchResponse
+from data_platform_catalogue.search_types import ResultType, SearchResponse
 from datahub.emitter.mce_builder import make_data_platform_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
@@ -315,9 +317,18 @@ class DataHubCatalogueClient(BaseCatalogueClient):
         return dataset_urn
 
     def search(
-        self, query: str = "*", count: int = 20, page: str | None = None
+        self,
+        query: str = "*",
+        count: int = 20,
+        page: str | None = None,
+        result_types: Sequence[ResultType] = (
+            ResultType.DATA_PRODUCT,
+            ResultType.TABLE,
+        ),
     ) -> SearchResponse:
         """
         Wraps the catalogue's search function.
         """
-        return self.search_client.search(query=query, count=count, page=page)
+        return self.search_client.search(
+            query=query, count=count, page=page, result_types=result_types
+        )

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
@@ -1,11 +1,11 @@
-query Search($query: String!, $count: Int!, $start: Int!) {
+query Search(
+  $query: String!
+  $count: Int!
+  $start: Int!
+  $types: [EntityType!]
+) {
   searchAcrossEntities(
-    input: {
-      types: [DATASET, DATA_PRODUCT]
-      query: $query
-      start: $start
-      count: $count
-    }
+    input: { types: $types, query: $query, start: $start, count: $count }
   ) {
     start
     count

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
@@ -1,0 +1,144 @@
+query Search($query: String!, $count: Int!, $start: Int!) {
+  searchAcrossEntities(
+    input: {
+      types: [DATASET, DATA_PRODUCT]
+      query: $query
+      start: $start
+      count: $count
+    }
+  ) {
+    start
+    count
+    total
+    searchResults {
+      insights {
+        text
+      }
+      matchedFields {
+        name
+        value
+      }
+      entity {
+        type
+        ... on Dataset {
+          urn
+          type
+          platform {
+            name
+          }
+          ownership {
+            owners {
+              owner {
+                ... on CorpUser {
+                  urn
+                  properties {
+                    fullName
+                    email
+                  }
+                }
+                ... on CorpGroup {
+                  urn
+                  properties {
+                    displayName
+                    email
+                  }
+                }
+              }
+            }
+          }
+          name
+          properties {
+            name
+            qualifiedName
+            description
+            customProperties {
+              key
+              value
+            }
+            created
+            lastModified
+          }
+          editableProperties {
+            description
+          }
+          tags {
+            tags {
+              tag {
+                urn
+                properties {
+                  name
+                  description
+                }
+              }
+            }
+          }
+          lastIngested
+          domain {
+            domain {
+              urn
+              id
+              properties {
+                name
+                description
+              }
+            }
+          }
+        }
+        ... on DataProduct {
+          urn
+          type
+          ownership {
+            owners {
+              owner {
+                ... on CorpUser {
+                  urn
+                  properties {
+                    fullName
+                    email
+                  }
+                }
+                ... on CorpGroup {
+                  urn
+                  properties {
+                    displayName
+                    email
+                  }
+                }
+              }
+            }
+          }
+          properties {
+            name
+            description
+            customProperties {
+              key
+              value
+            }
+            numAssets
+          }
+          domain {
+            domain {
+              urn
+              id
+              properties {
+                name
+                description
+              }
+            }
+          }
+          tags {
+            tags {
+              tag {
+                urn
+                properties {
+                  name
+                  description
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -1,0 +1,162 @@
+import json
+import logging
+from datetime import datetime
+from importlib.resources import files
+from typing import Any
+
+from data_platform_catalogue.search_types import (
+    ResultType,
+    SearchResponse,
+    SearchResult,
+)
+from datahub.configuration.common import GraphError
+from datahub.ingestion.graph.client import DataHubGraph
+
+logger = logging.getLogger(__name__)
+
+
+class SearchClient:
+    def __init__(self, graph: DataHubGraph):
+        self.graph = graph
+        self.search_query = (
+            files("data_platform_catalogue.client.datahub.graphql")
+            .joinpath("search.graphql")
+            .read_text()
+        )
+
+    def search(
+        self, query: str = "*", count: int = 20, page: str | None = None
+    ) -> SearchResponse:
+        """
+        Wraps the catalogue's search function.
+        """
+        if page is None:
+            start = 0
+        else:
+            start = int(page)
+
+        variables = {"count": count, "query": query, "start": start}
+
+        try:
+            response = self.graph.execute_graphql(self.search_query, variables)
+        except GraphError as e:
+            raise Exception("Unable to execute search") from e
+
+        page_results = []
+        response = response["searchAcrossEntities"]
+
+        logger.debug(json.dumps(response, indent=2))
+
+        for result in response["searchResults"]:
+            entity = result["entity"]
+            entity_type = entity["type"]
+            matched_fields = {
+                i["name"]: i["value"] for i in result.get("matchedFields", [])
+            }
+
+            if entity_type == "DATA_PRODUCT":
+                page_results.append(self._parse_data_product(entity, matched_fields))
+            elif entity_type == "DATASET":
+                page_results.append(self._parse_dataset(entity, matched_fields))
+            else:
+                raise ValueError(f"Unexpected entity type: {entity_type}")
+
+        return SearchResponse(
+            total_results=response["total"], page_results=page_results
+        )
+
+    def _parse_owner(self, entity: dict[str, Any]):
+        """
+        Parse ownership information, if it is set.
+        """
+        ownership = entity.get("ownership") or {}
+        owners = [i["owner"] for i in ownership.get("owners", [])]
+        if owners:
+            properties = owners[0].get("properties") or {}
+            owner_email = properties.get("email", "")
+            owner_name = properties.get("fullName", properties.get("displayName", ""))
+        else:
+            owner_email = ""
+            owner_name = ""
+
+        return owner_email, owner_name
+
+    def _parse_last_updated(self, entity: dict[str, Any]) -> datetime | None:
+        """
+        Parse the last updated timestamp, if available
+        """
+        timestamp = entity.get("lastIngested")
+        if timestamp is None:
+            return None
+        return datetime.utcfromtimestamp(timestamp / 1000)
+
+    def _parse_tags(self, entity: dict[str, Any]) -> list[str]:
+        """
+        Parse tag information into a flat list of strings for displaying
+        as part of the search result.
+        """
+        outer_tags = entity.get("tags") or {}
+        tags = []
+        for tag in outer_tags.get("tags", []):
+            properties = tag["tag"]["properties"]
+            if properties:
+                tags.append(properties["name"])
+        return tags
+
+    def _parse_properties(self, entity: dict[str, Any]) -> dict[str, Any]:
+        """
+        Parse properties and editableProperties into a single dictionary.
+        """
+        properties = entity["properties"] or {}
+        editable_properties = entity.get("editableProperties") or {}
+        properties.update(editable_properties)
+        return properties
+
+    def _parse_dataset(self, entity: dict[str, Any], matches) -> SearchResult:
+        """
+        Map a dataset entity to a SearchResult
+        """
+        owner_email, owner_name = self._parse_owner(entity)
+        properties = self._parse_properties(entity)
+        tags = self._parse_tags(entity)
+        last_updated = self._parse_last_updated(entity)
+        name = entity["name"]
+
+        return SearchResult(
+            id=entity["urn"],
+            result_type=ResultType.TABLE,
+            matches=matches,
+            name=properties.get("name", name),
+            description=properties.get("description", ""),
+            metadata={
+                "owner": owner_name,
+                "owner_email": owner_email,
+            },
+            tags=tags,
+            last_updated=last_updated,
+        )
+
+    def _parse_data_product(self, entity: dict[str, Any], matches) -> SearchResult:
+        """
+        Map a data product entity to a SearchResult
+        """
+        domain = entity["domain"]["domain"]
+        owner_email, owner_name = self._parse_owner(entity)
+        properties = self._parse_properties(entity)
+        tags = self._parse_tags(entity)
+        last_updated = self._parse_last_updated(entity)
+
+        return SearchResult(
+            id=entity["urn"],
+            result_type=ResultType.DATA_PRODUCT,
+            matches=matches,
+            name=properties["name"],
+            description=properties.get("description", ""),
+            metadata={
+                "owner": owner_name,
+                "owner_email": owner_email,
+                "domain": domain,
+            },
+            tags=tags,
+            last_updated=last_updated,
+        )

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
@@ -1,0 +1,27 @@
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum, auto
+from typing import Any
+
+
+class ResultType(Enum):
+    DATA_PRODUCT = auto()
+    TABLE = auto()
+
+
+@dataclass
+class SearchResult:
+    id: str
+    result_type: ResultType
+    name: str
+    description: str = ""
+    matches: dict[str, str] = field(default_factory=dict)
+    metadata: dict[str, Any] = field(default_factory=dict)
+    tags: list[str] = field(default_factory=list)
+    last_updated: datetime | None = None
+
+
+@dataclass
+class SearchResponse:
+    total_results: int
+    page_results: list[SearchResult]

--- a/python-libraries/data-platform-catalogue/tests/test_client_datahub.py
+++ b/python-libraries/data-platform-catalogue/tests/test_client_datahub.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 
 import pytest
-from data_platform_catalogue.client import DataHubCatalogueClient
+from data_platform_catalogue.client.datahub.datahub_client import DataHubCatalogueClient
 from data_platform_catalogue.entities import (
     CatalogueMetadata,
     DataLocation,

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -1,0 +1,309 @@
+from datetime import datetime
+from unittest.mock import MagicMock
+
+import pytest
+from data_platform_catalogue.client.datahub.search import SearchClient
+from data_platform_catalogue.search_types import (
+    ResultType,
+    SearchResponse,
+    SearchResult,
+)
+
+
+@pytest.fixture
+def mock_graph():
+    return MagicMock()
+
+
+@pytest.fixture
+def searcher(mock_graph):
+    return SearchClient(mock_graph)
+
+
+def test_empty_search_results(mock_graph, searcher):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 0,
+            "total": 0,
+            "searchResults": [],
+        }
+    }
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+    assert response == SearchResponse(total_results=0, page_results=[])
+
+
+def test_one_search_result(mock_graph, searcher):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 1,
+            "total": 1,
+            "searchResults": [
+                {
+                    "entity": {
+                        "type": "DATA_PRODUCT",
+                        "urn": "urn:li:dataProduct:6cc5cbc4-c002-42c3-b80b-ed55df17d39f",
+                        "ownership": None,
+                        "properties": {
+                            "name": "Use of force",
+                            "description": "Prisons in England and Wales are required to record all instances of Use of Force within their establishment. Use of Force can be planned or unplanned and may involve various categories of control and restraint (C&R) techniques such as physical restraint or handcuffs.\n\nPlease refer to [PSO 1600](https://www.gov.uk/government/publications/use-of-force-in-prisons-pso-1600) for the current guidance.",  # noqa E501
+                            "customProperties": [],
+                            "numAssets": 7,
+                        },
+                        "domain": {
+                            "domain": {
+                                "urn": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
+                                "id": "3dc18e48-c062-4407-84a9-73e23f768023",
+                                "properties": {
+                                    "name": "HMPPS",
+                                    "description": "HMPPS is an executive agency that carries out sentences given by the courts, in custody and the community, and rehabilitates people through education and employment.",  # noqa E501
+                                },
+                            }
+                        },
+                        "tags": {
+                            "tags": [
+                                {
+                                    "tag": {
+                                        "urn": "urn:li:tag:custody",
+                                        "properties": {
+                                            "name": "custody",
+                                            "description": "Data about prisons and prisoners. Not just NOMIS!",
+                                        },
+                                    }
+                                }
+                            ]
+                        },
+                    }
+                }
+            ],
+        }
+    }
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+    assert response == SearchResponse(
+        total_results=1,
+        page_results=[
+            SearchResult(
+                id="urn:li:dataProduct:6cc5cbc4-c002-42c3-b80b-ed55df17d39f",
+                matches={},
+                result_type=ResultType.DATA_PRODUCT,
+                name="Use of force",
+                description="Prisons in England and Wales are required to record all instances of Use of Force within their establishment. Use of Force can be planned or unplanned and may involve various categories of control and restraint (C&R) techniques such as physical restraint or handcuffs.\n\nPlease refer to [PSO 1600](https://www.gov.uk/government/publications/use-of-force-in-prisons-pso-1600) for the current guidance.",  # noqa E501
+                metadata={
+                    "domain": {
+                        "id": "3dc18e48-c062-4407-84a9-73e23f768023",
+                        "properties": {
+                            "name": "HMPPS",
+                            "description": "HMPPS is an executive agency that carries out sentences given by the courts, in custody and the community, and rehabilitates people through education and employment.",  # noqa E501
+                        },
+                        "urn": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
+                    },
+                    "owner": "",
+                    "owner_email": "",
+                },
+                tags=["custody"],
+            )
+        ],
+    )
+
+
+def test_full_page(mock_graph, searcher):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 3,
+            "total": 5,
+            "searchResults": [
+                {
+                    "insights": [],
+                    "matchedFields": [],
+                    "entity": {
+                        "type": "DATASET",
+                        "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",  # noqa E501
+                        "platform": {"name": "bigquery"},
+                        "ownership": None,
+                        "name": "calm-pagoda-323403.jaffle_shop.customers",
+                        "properties": {
+                            "name": "customers",
+                        },
+                        "editableProperties": None,
+                        "tags": None,
+                        "lastIngested": 1705990502353,
+                    },
+                },
+                {
+                    "insights": [],
+                    "matchedFields": [],
+                    "entity": {
+                        "type": "DATASET",
+                        "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers2,PROD)",  # noqa E501
+                        "name": "calm-pagoda-323403.jaffle_shop.customers2",
+                        "properties": {
+                            "name": "customers2",
+                        },
+                    },
+                },
+                {
+                    "insights": [],
+                    "matchedFields": [],
+                    "entity": {
+                        "type": "DATASET",
+                        "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers3,PROD)",  # noqa E501
+                        "name": "calm-pagoda-323403.jaffle_shop.customers3",
+                        "properties": {
+                            "name": "customers3",
+                        },
+                    },
+                },
+            ],
+        }
+    }
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+    assert response == SearchResponse(
+        total_results=5,
+        page_results=[
+            SearchResult(
+                id="urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                matches={},
+                result_type=ResultType.TABLE,
+                name="customers",
+                description="",
+                metadata={"owner": "", "owner_email": ""},
+                tags=[],
+                last_updated=datetime(2024, 1, 23, 6, 15, 2, 353000),
+            ),
+            SearchResult(
+                id="urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers2,PROD)",
+                matches={},
+                result_type=ResultType.TABLE,
+                name="customers2",
+                description="",
+                metadata={"owner": "", "owner_email": ""},
+                tags=[],
+                last_updated=None,
+            ),
+            SearchResult(
+                id="urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers3,PROD)",
+                matches={},
+                result_type=ResultType.TABLE,
+                name="customers3",
+                description="",
+                metadata={"owner": "", "owner_email": ""},
+                tags=[],
+                last_updated=None,
+            ),
+        ],
+    )
+
+
+def test_query_match(mock_graph, searcher):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 1,
+            "total": 1,
+            "searchResults": [
+                {
+                    "insights": [],
+                    "matchedFields": [
+                        {
+                            "name": "urn",
+                            "value": "urn:li:dataset:(urn:li:dataPlatform:looker,long_tail_companions.view.customer_focused,PROD)",  # noqa E501
+                        },
+                        {"name": "name", "value": "customer_focused"},
+                    ],
+                    "entity": {
+                        "type": "DATASET",
+                        "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",  # noqa E501
+                        "name": "calm-pagoda-323403.jaffle_shop.customers",
+                        "properties": {
+                            "name": "customers",
+                        },
+                    },
+                }
+            ],
+        }
+    }
+
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+    assert response == SearchResponse(
+        total_results=1,
+        page_results=[
+            SearchResult(
+                id="urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                matches={
+                    "urn": "urn:li:dataset:(urn:li:dataPlatform:looker,long_tail_companions.view.customer_focused,PROD)",  # noqa E501
+                    "name": "customer_focused",
+                },
+                result_type=ResultType.TABLE,
+                name="customers",
+                description="",
+                metadata={"owner": "", "owner_email": ""},
+                tags=[],
+            )
+        ],
+    )
+
+
+def test_result_with_owner(mock_graph, searcher):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 1,
+            "total": 1,
+            "searchResults": [
+                {
+                    "entity": {
+                        "type": "DATASET",
+                        "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",  # noqa E501
+                        "name": "calm-pagoda-323403.jaffle_shop.customers",
+                        "ownership": {
+                            "owners": [
+                                {
+                                    "owner": {
+                                        "urn": "urn:li:corpuser:shannon@longtail.com",
+                                        "properties": {
+                                            "fullName": "Shannon Lovett",
+                                            "email": "shannon@longtail.com",
+                                        },
+                                    }
+                                }
+                            ]
+                        },
+                        "properties": {
+                            "name": "customers",
+                        },
+                    },
+                }
+            ],
+        }
+    }
+
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+    assert response == SearchResponse(
+        total_results=1,
+        page_results=[
+            SearchResult(
+                id="urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                matches={},
+                result_type=ResultType.TABLE,
+                name="customers",
+                description="",
+                metadata={
+                    "owner": "Shannon Lovett",
+                    "owner_email": "shannon@longtail.com",
+                },
+                tags=[],
+            )
+        ],
+    )

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -13,6 +13,7 @@ import pytest
 from data_platform_catalogue import DataProductMetadata, TableMetadata
 from data_platform_catalogue.client.datahub.datahub_client import DataHubCatalogueClient
 from data_platform_catalogue.entities import DataLocation
+from data_platform_catalogue.search_types import ResultType
 from datahub.metadata.schema_classes import DatasetPropertiesClass, SchemaMetadataClass
 
 jwt_token = os.environ.get("JWT_TOKEN")
@@ -85,6 +86,8 @@ def test_search_for_data_product():
     )
     client.upsert_data_product(data_product)
 
-    response = client.search(query="lfdskjflkjflkjsdflksfjds")
+    response = client.search(
+        query="lfdskjflkjflkjsdflksfjds", result_types=(ResultType.DATA_PRODUCT,)
+    )
     assert response.total_results >= 1
     assert response.page_results[0].id == "urn:li:dataProduct:lfdskjflkjflkjsdflksfjds"

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -11,7 +11,7 @@ import os
 
 import pytest
 from data_platform_catalogue import DataProductMetadata, TableMetadata
-from data_platform_catalogue.client import DataHubCatalogueClient
+from data_platform_catalogue.client.datahub.datahub_client import DataHubCatalogueClient
 from data_platform_catalogue.entities import DataLocation
 from datahub.metadata.schema_classes import DatasetPropertiesClass, SchemaMetadataClass
 
@@ -59,3 +59,32 @@ def test_upsert_test_hierarchy():
     # Ensure data went through
     assert client.graph.get_aspect(table_fqn, DatasetPropertiesClass)
     assert client.graph.get_aspect(table_fqn, SchemaMetadataClass)
+
+
+@runs_on_development_server
+def test_search():
+    client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
+    response = client.search()
+    assert response.total_results > 20
+    assert len(response.page_results) == 20
+
+
+@runs_on_development_server
+def test_search_for_data_product():
+    client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
+
+    data_product = DataProductMetadata(
+        name="lfdskjflkjflkjsdflksfjds",
+        description="lfdskjflkjflkjsdflksfjds",
+        version="v1.0.0",
+        owner="7804c127-d677-4900-82f9-83517e51bb94",
+        email="justice@justice.gov.uk",
+        retention_period_in_days=365,
+        domain="Sample",
+        dpia_required=False,
+    )
+    client.upsert_data_product(data_product)
+
+    response = client.search(query="lfdskjflkjflkjsdflksfjds")
+    assert response.total_results >= 1
+    assert response.page_results[0].id == "urn:li:dataProduct:lfdskjflkjflkjsdflksfjds"


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/data-platform/issues/2983

This method accepts a query and pagination variables, and returns the total number of results plus the results to display on the current page.

For each search result, return:

- the result type: Table or Data Product
- ID, name and description
- tags
- a dictionary of additional metadata fields (exactly what this will contain will depend on what tests well with users)
- information about the properties which matched
- the time the metadata was last updated

The raw responses from Datahub are logged at DEBUG level.

For now I've excluded filters, facets, and sorting but these are supported by the underlying API.

See
- https://datahubproject.io/docs/graphql/inputObjects#facetfilterinput
- https://datahubproject.io/docs/graphql/objects#facetmetadata
- https://datahubproject.io/docs/graphql/inputObjects#searchsortinput