### PR TITLE
upgrade production cluster for airflow

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -224,7 +224,7 @@ resource "aws_eks_cluster" "airflow_prod_eks_cluster" {
     "controllerManager",
     "scheduler",
   ]
-  version = "1.24"
+  version = "1.25"
 
   vpc_config {
     subnet_ids          = aws_subnet.prod_private_subnet[*].id


### PR DESCRIPTION
This pr is to upgrade the airflow eks production cluster from 1.24  to 1.25 , links to #2812 