### PR TITLE
[DP-3074] Add filtering to search function

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.7.0] 2024-01-25
+
+### Added
+
+- Added filters param to the search function
+
 ## [0.6.0] 2024-01-24
 
 ### Added

--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added filters param to the search function
+- Return facets attribute to the search response. This is a dictionary mapping
+  fieldnames to `FacetOptions`, which expose values, display names and the
+  count of results with that value.
 
 ## [0.6.0] 2024-01-24
 

--- a/python-libraries/data-platform-catalogue/README.md
+++ b/python-libraries/data-platform-catalogue/README.md
@@ -70,6 +70,26 @@ except CatalogueError:
   print("oh no")
 ```
 
+## Search example
+
+```python
+response = client.search()
+
+# Total results across all pages
+print(response.total_results)
+
+# Iterate over search results
+for item in response.page_results:
+  print(item)
+
+# Iterate over facet options
+for option in response.facets['domains']:
+  print(option)
+
+# Filter by domain
+client.search(filters=[MultiSelectFilter("domains", [response.facets['domains'][0].value])])
+```
+
 ## Catalogue Implementations
 
 ### DataHub

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
@@ -8,7 +8,7 @@ from ..entities import (
     DataProductMetadata,
     TableMetadata,
 )
-from ..search_types import ResultType, SearchResponse
+from ..search_types import MultiSelectFilter, ResultType, SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -65,6 +65,7 @@ class BaseCatalogueClient(ABC):
             ResultType.DATA_PRODUCT,
             ResultType.TABLE,
         ),
+        filters: Sequence[MultiSelectFilter] = (),
     ) -> SearchResponse:
         """
         Wraps the catalogue's search function.

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -8,7 +8,11 @@ from data_platform_catalogue.client.base import (
     ReferencedEntityMissing,
     logger,
 )
-from data_platform_catalogue.search_types import ResultType, SearchResponse
+from data_platform_catalogue.search_types import (
+    MultiSelectFilter,
+    ResultType,
+    SearchResponse,
+)
 from datahub.emitter.mce_builder import make_data_platform_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
@@ -325,10 +329,15 @@ class DataHubCatalogueClient(BaseCatalogueClient):
             ResultType.DATA_PRODUCT,
             ResultType.TABLE,
         ),
+        filters: Sequence[MultiSelectFilter] = (),
     ) -> SearchResponse:
         """
         Wraps the catalogue's search function.
         """
         return self.search_client.search(
-            query=query, count=count, page=page, result_types=result_types
+            query=query,
+            count=count,
+            page=page,
+            result_types=result_types,
+            filters=filters,
         )

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -2,17 +2,6 @@ from typing import Sequence
 
 import datahub.emitter.mce_builder as mce_builder
 import datahub.metadata.schema_classes as schema_classes
-from data_platform_catalogue.client.base import (
-    BaseCatalogueClient,
-    CatalogueError,
-    ReferencedEntityMissing,
-    logger,
-)
-from data_platform_catalogue.search_types import (
-    MultiSelectFilter,
-    ResultType,
-    SearchResponse,
-)
 from datahub.emitter.mce_builder import make_data_platform_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
@@ -35,6 +24,8 @@ from ...entities import (
     DataProductMetadata,
     TableMetadata,
 )
+from ...search_types import MultiSelectFilter, ResultType, SearchResponse
+from ..base import BaseCatalogueClient, CatalogueError, ReferencedEntityMissing, logger
 from .search import SearchClient
 
 DATAHUB_DATA_TYPE_MAPPING = {

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
@@ -17,6 +17,31 @@ query Search(
     start
     count
     total
+    facets {
+      field
+      displayName
+      aggregations {
+        value
+        count
+        entity {
+          ... on Domain {
+            properties {
+              name
+            }
+          }
+          ... on Tag {
+            properties {
+              name
+            }
+          }
+          ... on GlossaryTerm {
+            properties {
+              name
+            }
+          }
+        }
+      }
+    }
     searchResults {
       insights {
         text

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
@@ -3,9 +3,16 @@ query Search(
   $count: Int!
   $start: Int!
   $types: [EntityType!]
+  $filters: [FacetFilterInput!]
 ) {
   searchAcrossEntities(
-    input: { types: $types, query: $query, start: $start, count: $count }
+    input: {
+      types: $types
+      query: $query
+      start: $start
+      count: $count
+      filters: $filters
+    }
   ) {
     start
     count

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -4,15 +4,16 @@ from datetime import datetime
 from importlib.resources import files
 from typing import Any, Literal, Sequence
 
-from data_platform_catalogue.search_types import (
+from datahub.configuration.common import GraphError
+from datahub.ingestion.graph.client import DataHubGraph
+
+from ...search_types import (
     FacetOption,
     MultiSelectFilter,
     ResultType,
     SearchResponse,
     SearchResult,
 )
-from datahub.configuration.common import GraphError
-from datahub.ingestion.graph.client import DataHubGraph
 
 logger = logging.getLogger(__name__)
 

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/openmetadata.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/openmetadata.py
@@ -1,12 +1,6 @@
 import json
 from http import HTTPStatus
 
-from data_platform_catalogue.client.base import (
-    BaseCatalogueClient,
-    CatalogueError,
-    ReferencedEntityMissing,
-    logger,
-)
 from metadata.generated.schema.api.data.createDatabase import CreateDatabaseRequest
 from metadata.generated.schema.api.data.createDatabaseSchema import (
     CreateDatabaseSchemaRequest,
@@ -40,6 +34,7 @@ from ..entities import (
     DataProductMetadata,
     TableMetadata,
 )
+from .base import BaseCatalogueClient, CatalogueError, ReferencedEntityMissing, logger
 
 OMD_DATA_TYPE_MAPPING = {
     "boolean": OpenMetadataDataType.BOOLEAN,

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
@@ -11,8 +11,23 @@ class ResultType(Enum):
 
 @dataclass
 class MultiSelectFilter:
-    filter_name: Literal["domains", "tags", "customProperties"]
+    """
+    Values to filter the result set by
+    """
+
+    filter_name: Literal["domains", "tags", "customProperties", "glossaryTerms"]
     included_values: list[Any]
+
+
+@dataclass
+class FacetOption:
+    """
+    A specific value that may be used to filter the search
+    """
+
+    value: str
+    label: str
+    count: int
 
 
 @dataclass
@@ -31,3 +46,7 @@ class SearchResult:
 class SearchResponse:
     total_results: int
     page_results: list[SearchResult]
+    facets: dict[
+        Literal["domains", "tags", "customProperties", "glossaryTerms"],
+        list[FacetOption],
+    ] = field(default_factory=dict)

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
@@ -1,12 +1,18 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from typing import Any
+from typing import Any, Literal
 
 
 class ResultType(Enum):
     DATA_PRODUCT = auto()
     TABLE = auto()
+
+
+@dataclass
+class MultiSelectFilter:
+    filter_name: Literal["domains", "tags", "customProperties"]
+    included_values: list[Any]
 
 
 @dataclass

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.6.0"
+version = "0.7.0"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from data_platform_catalogue.client.datahub.search import SearchClient
 from data_platform_catalogue.search_types import (
+    MultiSelectFilter,
     ResultType,
     SearchResponse,
     SearchResult,
@@ -306,4 +307,23 @@ def test_result_with_owner(mock_graph, searcher):
                 tags=[],
             )
         ],
+    )
+
+
+def test_filter(searcher, mock_graph):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 0,
+            "total": 0,
+            "searchResults": [],
+        }
+    }
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search(filters=[MultiSelectFilter("domains", ["Abc", "Def"])])
+
+    assert response == SearchResponse(
+        total_results=0,
+        page_results=[],
     )

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock
 import pytest
 from data_platform_catalogue.client.datahub.search import SearchClient
 from data_platform_catalogue.search_types import (
+    FacetOption,
     MultiSelectFilter,
     ResultType,
     SearchResponse,
@@ -326,4 +327,91 @@ def test_filter(searcher, mock_graph):
     assert response == SearchResponse(
         total_results=0,
         page_results=[],
+    )
+
+
+def test_facets(searcher, mock_graph):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 10,
+            "total": 10,
+            "searchResults": [],
+            "facets": [
+                {
+                    "field": "_entityType",
+                    "displayName": "Type",
+                    "aggregations": [
+                        {"value": "DATASET", "count": 1505, "entity": None}
+                    ],
+                },
+                {
+                    "field": "glossaryTerms",
+                    "displayName": "Glossary Term",
+                    "aggregations": [
+                        {
+                            "value": "urn:li:glossaryTerm:Classification.Sensitive",
+                            "count": 1,
+                            "entity": {"properties": {"name": "Sensitive"}},
+                        },
+                        {
+                            "value": "urn:li:glossaryTerm:Silver",
+                            "count": 1,
+                            "entity": {"properties": None},
+                        },
+                    ],
+                },
+                {
+                    "field": "domains",
+                    "displayName": "Domain",
+                    "aggregations": [
+                        {
+                            "value": "urn:li:domain:094dc54b-0ebc-40a6-a4cf-e1b75e8b8089",
+                            "count": 7,
+                            "entity": {"properties": {"name": "Pet Adoptions"}},
+                        },
+                        {
+                            "value": "urn:li:domain:7186eeff-a860-4b0a-989f-69473a0c9c67",
+                            "count": 4,
+                            "entity": {"properties": {"name": "E-Commerce"}},
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+
+    assert response == SearchResponse(
+        total_results=10,
+        page_results=[],
+        facets={
+            "glossaryTerms": [
+                FacetOption(
+                    value="urn:li:glossaryTerm:Classification.Sensitive",
+                    label="Sensitive",
+                    count=1,
+                ),
+                FacetOption(
+                    value="urn:li:glossaryTerm:Silver",
+                    label="urn:li:glossaryTerm:Silver",
+                    count=1,
+                ),
+            ],
+            "domains": [
+                FacetOption(
+                    value="urn:li:domain:094dc54b-0ebc-40a6-a4cf-e1b75e8b8089",
+                    label="Pet Adoptions",
+                    count=7,
+                ),
+                FacetOption(
+                    value="urn:li:domain:7186eeff-a860-4b0a-989f-69473a0c9c67",
+                    label="E-Commerce",
+                    count=4,
+                ),
+            ],
+        },
     )

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -102,3 +102,25 @@ def test_search_by_domain():
         result_types=(ResultType.DATA_PRODUCT,),
     )
     assert response.total_results == 0
+
+
+@runs_on_development_server
+def test_domain_facets_are_returned():
+    client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
+
+    client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
+
+    data_product = DataProductMetadata(
+        name="lfdskjflkjflkjsdflksfjds",
+        description="lfdskjflkjflkjsdflksfjds",
+        version="v1.0.0",
+        owner="7804c127-d677-4900-82f9-83517e51bb94",
+        email="justice@justice.gov.uk",
+        retention_period_in_days=365,
+        domain="Sample",
+        dpia_required=False,
+    )
+    client.upsert_data_product(data_product)
+
+    response = client.search()
+    assert response.facets["domains"]

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -13,7 +13,7 @@ import pytest
 from data_platform_catalogue import DataProductMetadata, TableMetadata
 from data_platform_catalogue.client.datahub.datahub_client import DataHubCatalogueClient
 from data_platform_catalogue.entities import DataLocation
-from data_platform_catalogue.search_types import ResultType
+from data_platform_catalogue.search_types import MultiSelectFilter, ResultType
 from datahub.metadata.schema_classes import DatasetPropertiesClass, SchemaMetadataClass
 
 jwt_token = os.environ.get("JWT_TOKEN")
@@ -91,3 +91,14 @@ def test_search_for_data_product():
     )
     assert response.total_results >= 1
     assert response.page_results[0].id == "urn:li:dataProduct:lfdskjflkjflkjsdflksfjds"
+
+
+@runs_on_development_server
+def test_search_by_domain():
+    client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
+
+    response = client.search(
+        filters=[MultiSelectFilter("domains", ["does-not-exist"])],
+        result_types=(ResultType.DATA_PRODUCT,),
+    )
+    assert response.total_results == 0


### PR DESCRIPTION
Add a way to filter by domain, tags, glossaryTerms, or customProperties when running a search query.

Resolves #3074

This adds a filter argument to the search function, and a facets attribute to the search response, mirroring the filters/facets objects in the underlying GraphQL API, and restricting to a fixed set of fields.

Example usage:

```python
response = client.search()

# Total results across all pages
print(response.total_results)

# Iterate over search results
for item in response.page_results:
  print(item)

# Iterate over facet options
for option in response.facets['domains']:
  print(option)

# Filter by domain
client.search(filters=[MultiSelectFilter("domains", [response.facets['domains'][0].value])])
```

Facet information will be returned for everything except customProperties.
