### PR TITLE
DP 886/static analysis Sagemaker and OIDC

### DIFF
--- a/terraform/aws/analytical-platform-development/sagemaker/kms-keys.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/kms-keys.tf
@@ -1,0 +1,8 @@
+##################################################
+# EKS Encryption Key
+##################################################
+
+resource "aws_kms_key" "eks" {
+  description         = "EKS Secret Encryption Key"
+  enable_key_rotation = true
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/kms-keys.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/kms-keys.tf
@@ -1,8 +1,7 @@
 ##################################################
-# EKS Encryption Key
+# EFS Encryption Key
 ##################################################
 
-resource "aws_kms_key" "eks" {
-  description         = "EKS Secret Encryption Key"
-  enable_key_rotation = true
+resource "aws_kms_key" "sagemaker_cmk" {
+  description = "EFS Secret Encryption Key for Sagemaker"
 }

--- a/terraform/aws/analytical-platform-development/sagemaker/kms-keys.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/kms-keys.tf
@@ -1,7 +1,0 @@
-##################################################
-# EFS Encryption Key
-##################################################
-
-resource "aws_kms_key" "sagemaker_cmk" {
-  description = "EFS Secret Encryption Key for Sagemaker"
-}

--- a/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
@@ -1,6 +1,9 @@
 resource "aws_sagemaker_domain" "studio_domain" {
   domain_name = var.domain_name
-  auth_mode   = var.auth_mode
+  auth_mode   = var.auth_mode #
+
+  # KMS customer managed key for encryption of EFS
+  kms_key_id = aws_kms_key.sagemaker_cmk.key_id
 
   default_space_settings {
     execution_role = aws_iam_role.sagemaker_studio_execution_role.arn

--- a/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/sagemaker.tf
@@ -1,9 +1,7 @@
 resource "aws_sagemaker_domain" "studio_domain" {
+  #checkov:skip=CKV_AWS_187: low severity change requires destroy and replace
   domain_name = var.domain_name
-  auth_mode   = var.auth_mode #
-
-  # KMS customer managed key for encryption of EFS
-  kms_key_id = aws_kms_key.sagemaker_cmk.key_id
+  auth_mode   = var.auth_mode
 
   default_space_settings {
     execution_role = aws_iam_role.sagemaker_studio_execution_role.arn

--- a/terraform/aws/analytical-platform/oidc/oidc-providers.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-providers.tf
@@ -5,6 +5,7 @@ data "aws_iam_policy_document" "analytical_platform_data_engineering_production_
     actions   = ["sts:AssumeRole"]
     resources = [format("arn:aws:iam::%s:role/github-actions-infrastructure", var.account_ids["analytical-platform-data-engineering-production"])]
   }
+  #tfsec:ignore:avd-aws-0057:needs to access multiple resources
   statement {
     #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
     sid       = "AllowOIDCToDecryptKMS"
@@ -12,6 +13,7 @@ data "aws_iam_policy_document" "analytical_platform_data_engineering_production_
     actions   = ["kms:Decrypt"]
     resources = ["*"]
   }
+  #tfsec:ignore:avd-aws-0057:needs to access multiple resources
   statement {
     sid    = "AllowOIDCReadState"
     effect = "Allow"
@@ -70,6 +72,7 @@ data "aws_iam_policy_document" "analytical_platform_data_engineering_sandbox_a_g
     actions   = ["sts:AssumeRole"]
     resources = [format("arn:aws:iam::%s:role/github-actions-infrastructure", var.account_ids["analytical-platform-data-engineering-sandbox-a"])]
   }
+  #tfsec:ignore:avd-aws-0057:needs to access multiple resources
   statement {
     #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
     sid       = "AllowOIDCToDecryptKMS"
@@ -77,6 +80,7 @@ data "aws_iam_policy_document" "analytical_platform_data_engineering_sandbox_a_g
     actions   = ["kms:Decrypt"]
     resources = ["*"]
   }
+  #tfsec:ignore:avd-aws-0057:needs to access multiple resources
   statement {
     sid    = "AllowOIDCReadState"
     effect = "Allow"
@@ -178,6 +182,7 @@ data "aws_iam_policy_document" "analytical_platform_management_production_github
     actions   = ["sts:AssumeRole"]
     resources = formatlist("arn:aws:iam::%s:role/github-actions-infrastructure", values(var.account_ids))
   }
+  #tfsec:ignore:avd-aws-0057:needs to access multiple resources
   statement {
     #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
     sid       = "AllowOIDCToDecryptKMS"
@@ -185,6 +190,7 @@ data "aws_iam_policy_document" "analytical_platform_management_production_github
     actions   = ["kms:Decrypt"]
     resources = ["*"]
   }
+  #tfsec:ignore:avd-aws-0057:needs to access multiple resources
   statement {
     sid    = "AllowOIDCReadState"
     effect = "Allow"

--- a/terraform/aws/analytical-platform/oidc/oidc-providers.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-providers.tf
@@ -6,6 +6,7 @@ data "aws_iam_policy_document" "analytical_platform_data_engineering_production_
     resources = [format("arn:aws:iam::%s:role/github-actions-infrastructure", var.account_ids["analytical-platform-data-engineering-production"])]
   }
   statement {
+    #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
     sid       = "AllowOIDCToDecryptKMS"
     effect    = "Allow"
     actions   = ["kms:Decrypt"]
@@ -21,6 +22,7 @@ data "aws_iam_policy_document" "analytical_platform_data_engineering_production_
     resources = ["arn:aws:s3:::global-tf-state-aqsvzyd5u9/*", "arn:aws:s3:::global-tf-state-aqsvzyd5u9/"]
   }
   statement {
+    #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
     sid    = "AllowOIDCWriteState"
     effect = "Allow"
     actions = [
@@ -69,6 +71,7 @@ data "aws_iam_policy_document" "analytical_platform_data_engineering_sandbox_a_g
     resources = [format("arn:aws:iam::%s:role/github-actions-infrastructure", var.account_ids["analytical-platform-data-engineering-sandbox-a"])]
   }
   statement {
+    #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
     sid       = "AllowOIDCToDecryptKMS"
     effect    = "Allow"
     actions   = ["kms:Decrypt"]
@@ -84,6 +87,7 @@ data "aws_iam_policy_document" "analytical_platform_data_engineering_sandbox_a_g
     resources = ["arn:aws:s3:::global-tf-state-aqsvzyd5u9/*", "arn:aws:s3:::global-tf-state-aqsvzyd5u9/"]
   }
   statement {
+    #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
     sid    = "AllowOIDCWriteState"
     effect = "Allow"
     actions = [
@@ -175,6 +179,7 @@ data "aws_iam_policy_document" "analytical_platform_management_production_github
     resources = formatlist("arn:aws:iam::%s:role/github-actions-infrastructure", values(var.account_ids))
   }
   statement {
+    #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
     sid       = "AllowOIDCToDecryptKMS"
     effect    = "Allow"
     actions   = ["kms:Decrypt"]
@@ -193,6 +198,7 @@ data "aws_iam_policy_document" "analytical_platform_management_production_github
     ]
   }
   statement {
+    #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
     sid    = "AllowOIDCWriteState"
     effect = "Allow"
     actions = [

--- a/terraform/aws/analytical-platform/oidc/oidc-roles.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-roles.tf
@@ -36,6 +36,7 @@ data "aws_iam_policy_document" "github_oidc_role" {
     for_each = each.value.stateConfig
 
     content {
+      #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
       sid    = "AllowOIDCWriteState"
       effect = "Allow"
       actions = [
@@ -76,6 +77,7 @@ data "aws_iam_policy_document" "github_oidc_role" {
     }
   }
   statement {
+    #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
     sid       = "AllowOIDCToDecryptKMS"
     effect    = "Allow"
     resources = ["*"]


### PR DESCRIPTION
I have reviewed the errors being reported by checkov and trivy for the OIDC (analytical-platform) and Sagemaker (analytical-platform-development) resources.

Failures from checkov for Sagemaker would require destructive replacement to resources to add KMS CMK key, so this error was skipped.
Failures from checkov and trivy for OIDC related to wildcard permissions for kms:Decrypt and s3:Get, as well as for s3:PutObjectAcl. These have also been skipped as the there is a need to access a large number of resources, and for the latter error, only a service account can s3:PutObjectAcl which helps to mitigate security risk.
