### PR TITLE
[DP-3106] Enhance metadata returned with search results

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,6 +7,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.0] 2024-01-29
+
+### Added
+
+Enhanced the metadata returned with search results:
+
+- Added `number_of_assets` to data product metadata
+- Added `data_products` and `total_data_products` to dataset metadata
+
+### Changed
+
+- Replaced deprecated Datahub `filters` parameter with `orFilters`
+
 ## [0.7.0] 2024-01-25
 
 ### Added

--- a/python-libraries/data-platform-catalogue/README.md
+++ b/python-libraries/data-platform-catalogue/README.md
@@ -86,9 +86,41 @@ for item in response.page_results:
 for option in response.facets['domains']:
   print(option)
 
-# Filter by domain
+# Include a filter
 client.search(filters=[MultiSelectFilter("domains", [response.facets['domains'][0].value])])
 ```
+
+## Search filters
+
+### Datahub
+
+Basic filters:
+
+- urn
+- customProperties
+- browsePaths / browsePathsV2
+- deprecated (boolean)
+- removed (boolean)
+- typeNames
+- name, qualifiedName
+- description, hasDescription
+
+Timestamps:
+
+- lastOperationTime (datetime)
+- createdAt (timestamp)
+- lastModifiedAt (timestamp)
+
+URNs:
+
+- platform / platformInstance
+- tags, hasTags
+- glossaryTerms, hasGlossaryTerms
+- domains, hasDomain
+- siblings
+- owners, hasOwners
+- roles, hasRoles
+- container
 
 ## Catalogue Implementations
 

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
@@ -58,6 +58,25 @@ query Search(
           platform {
             name
           }
+          relationships(
+            input: {
+              types: ["DataProductContains"]
+              direction: INCOMING
+              count: 10
+            }
+          ) {
+            total
+            relationships {
+              entity {
+                urn
+                ... on DataProduct {
+                  properties {
+                    name
+                  }
+                }
+              }
+            }
+          }
           ownership {
             owners {
               owner {

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
@@ -11,7 +11,7 @@ query Search(
       query: $query
       start: $start
       count: $count
-      filters: $filters
+      orFilters: [{ and: $filters }]
     }
   ) {
     start

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -196,6 +196,7 @@ class SearchClient:
                 "owner": owner_name,
                 "owner_email": owner_email,
                 "domain": domain,
+                "number_of_assets": properties["numAssets"],
             },
             tags=tags,
             last_updated=last_updated,

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -2,7 +2,7 @@ import json
 import logging
 from datetime import datetime
 from importlib.resources import files
-from typing import Any, Literal, Sequence
+from typing import Any, Sequence
 
 from datahub.configuration.common import GraphError
 from datahub.ingestion.graph.client import DataHubGraph

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -161,6 +161,13 @@ class SearchClient:
         tags = self._parse_tags(entity)
         last_updated = self._parse_last_updated(entity)
         name = entity["name"]
+        relationships = entity.get("relationships", {})
+        total_data_products = relationships.get("total", 0)
+        data_products = relationships.get("relationships", [])
+        data_products = [
+            {"id": i["entity"]["urn"], "name": i["entity"]["properties"]["name"]}
+            for i in data_products
+        ]
 
         return SearchResult(
             id=entity["urn"],
@@ -171,6 +178,8 @@ class SearchClient:
             metadata={
                 "owner": owner_name,
                 "owner_email": owner_email,
+                "total_data_products": total_data_products,
+                "data_products": data_products,
             },
             tags=tags,
             last_updated=last_updated,

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -203,10 +203,7 @@ class SearchClient:
 
     def _parse_facets(
         self, facets: list[dict[str, Any]]
-    ) -> dict[
-        Literal["domains", "tags", "customProperties", "glossaryTerms"],
-        list[FacetOption],
-    ]:
+    ) -> dict[str, list[FacetOption],]:
         """
         Parse the facets and aggregate information from the query results
         """

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 from datetime import datetime
 from enum import Enum, auto
-from typing import Any, Literal
+from typing import Any
 
 
 class ResultType(Enum):

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
@@ -15,7 +15,7 @@ class MultiSelectFilter:
     Values to filter the result set by
     """
 
-    filter_name: Literal["domains", "tags", "customProperties", "glossaryTerms"]
+    filter_name: str
     included_values: list[Any]
 
 
@@ -47,6 +47,6 @@ class SearchResponse:
     total_results: int
     page_results: list[SearchResult]
     facets: dict[
-        Literal["domains", "tags", "customProperties", "glossaryTerms"],
+        str,
         list[FacetOption],
     ] = field(default_factory=dict)

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -106,6 +106,7 @@ def test_one_search_result(mock_graph, searcher):
                     },
                     "owner": "",
                     "owner_email": "",
+                    "number_of_assets": 7,
                 },
                 tags=["custody"],
             )

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -177,7 +177,12 @@ def test_full_page(mock_graph, searcher):
                 result_type=ResultType.TABLE,
                 name="customers",
                 description="",
-                metadata={"owner": "", "owner_email": ""},
+                metadata={
+                    "owner": "",
+                    "owner_email": "",
+                    "data_products": [],
+                    "total_data_products": 0,
+                },
                 tags=[],
                 last_updated=datetime(2024, 1, 23, 6, 15, 2, 353000),
             ),
@@ -187,7 +192,12 @@ def test_full_page(mock_graph, searcher):
                 result_type=ResultType.TABLE,
                 name="customers2",
                 description="",
-                metadata={"owner": "", "owner_email": ""},
+                metadata={
+                    "owner": "",
+                    "owner_email": "",
+                    "data_products": [],
+                    "total_data_products": 0,
+                },
                 tags=[],
                 last_updated=None,
             ),
@@ -197,7 +207,12 @@ def test_full_page(mock_graph, searcher):
                 result_type=ResultType.TABLE,
                 name="customers3",
                 description="",
-                metadata={"owner": "", "owner_email": ""},
+                metadata={
+                    "owner": "",
+                    "owner_email": "",
+                    "data_products": [],
+                    "total_data_products": 0,
+                },
                 tags=[],
                 last_updated=None,
             ),
@@ -249,7 +264,12 @@ def test_query_match(mock_graph, searcher):
                 result_type=ResultType.TABLE,
                 name="customers",
                 description="",
-                metadata={"owner": "", "owner_email": ""},
+                metadata={
+                    "owner": "",
+                    "owner_email": "",
+                    "data_products": [],
+                    "total_data_products": 0,
+                },
                 tags=[],
             )
         ],
@@ -305,6 +325,8 @@ def test_result_with_owner(mock_graph, searcher):
                 metadata={
                     "owner": "Shannon Lovett",
                     "owner_email": "shannon@longtail.com",
+                    "data_products": [],
+                    "total_data_products": 0,
                 },
                 tags=[],
             )
@@ -415,4 +437,60 @@ def test_facets(searcher, mock_graph):
                 ),
             ],
         },
+    )
+
+
+def test_result_with_data_product(mock_graph, searcher):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 1,
+            "total": 1,
+            "searchResults": [
+                {
+                    "entity": {
+                        "type": "DATASET",
+                        "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",  # noqa E501
+                        "name": "calm-pagoda-323403.jaffle_shop.customers",
+                        "relationships": {
+                            "total": 1,
+                            "relationships": [
+                                {
+                                    "entity": {
+                                        "urn": "urn:abc",
+                                        "properties": {"name": "abc"},
+                                    }
+                                }
+                            ],
+                        },
+                        "properties": {
+                            "name": "customers",
+                        },
+                    },
+                }
+            ],
+        }
+    }
+
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+    assert response == SearchResponse(
+        total_results=1,
+        page_results=[
+            SearchResult(
+                id="urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                matches={},
+                result_type=ResultType.TABLE,
+                name="customers",
+                description="",
+                metadata={
+                    "owner": "",
+                    "owner_email": "",
+                    "data_products": [{"id": "urn:abc", "name": "abc"}],
+                    "total_data_products": 1,
+                },
+                tags=[],
+            )
+        ],
     )

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -83,6 +83,7 @@ def test_search_for_data_product():
         retention_period_in_days=365,
         domain="Sample",
         dpia_required=False,
+        tags=["test"],
     )
     client.upsert_data_product(data_product)
 
@@ -108,6 +109,25 @@ def test_search_by_domain():
 def test_domain_facets_are_returned():
     client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
 
+    data_product = DataProductMetadata(
+        name="lfdskjflkjflkjsdflksfjds",
+        description="lfdskjflkjflkjsdflksfjds",
+        version="v1.0.0",
+        owner="7804c127-d677-4900-82f9-83517e51bb94",
+        email="justice@justice.gov.uk",
+        retention_period_in_days=365,
+        domain="Sample",
+        dpia_required=False,
+        tags=["test"],
+    )
+    client.upsert_data_product(data_product)
+
+    response = client.search()
+    assert response.facets["domains"]
+
+
+@runs_on_development_server
+def test_filter_by_urn():
     client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
 
     data_product = DataProductMetadata(
@@ -119,8 +139,12 @@ def test_domain_facets_are_returned():
         retention_period_in_days=365,
         domain="Sample",
         dpia_required=False,
+        tags=["test"],
     )
-    client.upsert_data_product(data_product)
+    urn = client.upsert_data_product(data_product)
+    print(urn)
 
-    response = client.search()
-    assert response.facets["domains"]
+    response = client.search(
+        filters=[MultiSelectFilter(filter_name="urn", included_values=[urn])]
+    )
+    assert response.total_results == 1

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -148,3 +148,45 @@ def test_filter_by_urn():
         filters=[MultiSelectFilter(filter_name="urn", included_values=[urn])]
     )
     assert response.total_results == 1
+
+
+def test_fetch_dataset_belonging_to_data_product():
+    client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
+
+    data_product = DataProductMetadata(
+        name="test_data_product",
+        description="bla bla",
+        version="v1.0.0",
+        owner="7804c127-d677-4900-82f9-83517e51bb94",
+        email="justice@justice.gov.uk",
+        retention_period_in_days=365,
+        domain="Sample",
+        dpia_required=False,
+    )
+
+    table = TableMetadata(
+        name="test_table",
+        description="bla bla",
+        column_details=[
+            {"name": "foo", "type": "string", "description": "a"},
+            {"name": "bar", "type": "int", "description": "b"},
+        ],
+        retention_period_in_days=365,
+        tags=["test"],
+    )
+
+    urn = client.upsert_table(
+        metadata=table,
+        data_product_metadata=data_product,
+        location=DataLocation("test_data_product_v2"),
+    )
+
+    response = client.search(
+        filters=[MultiSelectFilter(filter_name="urn", included_values=[urn])]
+    )
+
+    assert response.total_results == 1
+
+    metadata = response.page_results[0].metadata
+    assert metadata["total_data_products"] == 1
+    assert metadata["data_products"][0]["name"] == "test_data_product"

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -142,7 +142,6 @@ def test_filter_by_urn():
         tags=["test"],
     )
     urn = client.upsert_data_product(data_product)
-    print(urn)
 
     response = client.search(
         filters=[MultiSelectFilter(filter_name="urn", included_values=[urn])]
@@ -150,6 +149,7 @@ def test_filter_by_urn():
     assert response.total_results == 1
 
 
+@runs_on_development_server
 def test_fetch_dataset_belonging_to_data_product():
     client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
 


### PR DESCRIPTION
- Added `number_of_assets` to data product metadata
- Added `data_products` and `total_data_products` to dataset metadata
- Replaced deprecated Datahub `filters` parameter with `orFilters`
- Documented possible filters for datahub