### PR TITLE
🦅 Set `analytics-platform-jupyter-notebook` public

### DIFF
--- a/terraform/github/analytical-platform-repositories.tf
+++ b/terraform/github/analytical-platform-repositories.tf
@@ -224,14 +224,10 @@ locals {
       }
     },
     "analytics-platform-jupyter-notebook" = {
-      name                                   = "analytics-platform-jupyter-notebook"
-      description                            = "Analytical Platform Jupyter Notebook"
-      topics                                 = ["ministryofjustice", "analytical-platform"]
-      use_template                           = false
-      visibility                             = "internal"
-      advanced_security_status               = "disabled"
-      secret_scanning_status                 = "disabled"
-      secret_scanning_push_protection_status = "disabled"
+      name         = "analytics-platform-jupyter-notebook"
+      description  = "Analytical Platform Jupyter Notebook"
+      topics       = ["ministryofjustice", "analytical-platform"]
+      use_template = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]


### PR DESCRIPTION
This pull request:

- Sets `analytics-platform-jupyter-notebook` public

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 