### PR TITLE
[DP-3106] Add a way to fetch lists of domains and other search facets

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -15,6 +15,8 @@ Enhanced the metadata returned with search results:
 
 - Added `number_of_assets` to data product metadata
 - Added `data_products` and `total_data_products` to dataset metadata
+- Added separate search_facets method
+- Added `SearchFacets`` class to make it easier to present facets
 
 ### Changed
 

--- a/python-libraries/data-platform-catalogue/README.md
+++ b/python-libraries/data-platform-catalogue/README.md
@@ -83,8 +83,10 @@ for item in response.page_results:
   print(item)
 
 # Iterate over facet options
-for option in response.facets['domains']:
-  print(option)
+for option in response.facets.options('domains'):
+  print(option.label)
+  print(option.value)
+  print(option.count)
 
 # Include a filter
 client.search(filters=[MultiSelectFilter("domains", [response.facets['domains'][0].value])])

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
@@ -8,13 +8,7 @@ from ..entities import (
     DataProductMetadata,
     TableMetadata,
 )
-from ..search_types import (
-    FacetOption,
-    MultiSelectFilter,
-    ResultType,
-    SearchFacets,
-    SearchResponse,
-)
+from ..search_types import MultiSelectFilter, ResultType, SearchFacets, SearchResponse
 
 logger = logging.getLogger(__name__)
 

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
@@ -8,7 +8,7 @@ from ..entities import (
     DataProductMetadata,
     TableMetadata,
 )
-from ..search_types import MultiSelectFilter, ResultType, SearchResponse
+from ..search_types import FacetOption, MultiSelectFilter, ResultType, SearchResponse
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +71,22 @@ class BaseCatalogueClient(ABC):
         Wraps the catalogue's search function.
         """
         raise NotImplementedError
+
+    def search_facets(
+        self,
+        query: str = "*",
+        result_types: Sequence[ResultType] = (
+            ResultType.DATA_PRODUCT,
+            ResultType.TABLE,
+        ),
+        filters: Sequence[MultiSelectFilter] = (),
+    ) -> dict[str, list[FacetOption],]:
+        """
+        Returns facets that can be used to filter the search results.
+        """
+        return self.search(
+            query=query, result_types=result_types, filters=filters
+        ).facets
 
     def list_data_products(self) -> SearchResponse:
         return self.search(count=500, result_types=[ResultType.DATA_PRODUCT])

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
@@ -8,7 +8,13 @@ from ..entities import (
     DataProductMetadata,
     TableMetadata,
 )
-from ..search_types import FacetOption, MultiSelectFilter, ResultType, SearchResponse
+from ..search_types import (
+    FacetOption,
+    MultiSelectFilter,
+    ResultType,
+    SearchFacets,
+    SearchResponse,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -80,13 +86,11 @@ class BaseCatalogueClient(ABC):
             ResultType.TABLE,
         ),
         filters: Sequence[MultiSelectFilter] = (),
-    ) -> dict[str, list[FacetOption],]:
+    ) -> SearchFacets:
         """
         Returns facets that can be used to filter the search results.
         """
-        return self.search(
-            query=query, result_types=result_types, filters=filters
-        ).facets
+        raise NotImplementedError
 
     def list_data_products(self) -> SearchResponse:
         return self.search(count=500, result_types=[ResultType.DATA_PRODUCT])

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -24,13 +24,7 @@ from ...entities import (
     DataProductMetadata,
     TableMetadata,
 )
-from ...search_types import (
-    FacetOption,
-    MultiSelectFilter,
-    ResultType,
-    SearchFacets,
-    SearchResponse,
-)
+from ...search_types import MultiSelectFilter, ResultType, SearchFacets, SearchResponse
 from ..base import BaseCatalogueClient, CatalogueError, ReferencedEntityMissing, logger
 from .search import SearchClient
 
@@ -353,4 +347,4 @@ class DataHubCatalogueClient(BaseCatalogueClient):
         """
         return self.search_client.search_facets(
             query=query, result_types=result_types, filters=filters
-        ).facets
+        )

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -24,7 +24,13 @@ from ...entities import (
     DataProductMetadata,
     TableMetadata,
 )
-from ...search_types import MultiSelectFilter, ResultType, SearchResponse
+from ...search_types import (
+    FacetOption,
+    MultiSelectFilter,
+    ResultType,
+    SearchFacets,
+    SearchResponse,
+)
 from ..base import BaseCatalogueClient, CatalogueError, ReferencedEntityMissing, logger
 from .search import SearchClient
 
@@ -332,3 +338,19 @@ class DataHubCatalogueClient(BaseCatalogueClient):
             result_types=result_types,
             filters=filters,
         )
+
+    def search_facets(
+        self,
+        query: str = "*",
+        result_types: Sequence[ResultType] = (
+            ResultType.DATA_PRODUCT,
+            ResultType.TABLE,
+        ),
+        filters: Sequence[MultiSelectFilter] = (),
+    ) -> SearchFacets:
+        """
+        Returns facets that can be used to filter the search results.
+        """
+        return self.search_client.search_facets(
+            query=query, result_types=result_types, filters=filters
+        ).facets

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/facets.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/facets.graphql
@@ -1,0 +1,41 @@
+query Facets(
+  $query: String!
+  $facets: [String!]
+  $types: [EntityType!]
+  $filters: [FacetFilterInput!]
+) {
+  aggregateAcrossEntities(
+    input: {
+      types: $types
+      query: $query
+      facets: $facets
+      orFilters: [{ and: $filters }]
+    }
+  ) {
+    facets {
+      field
+      displayName
+      aggregations {
+        value
+        count
+        entity {
+          ... on Domain {
+            properties {
+              name
+            }
+          }
+          ... on Tag {
+            properties {
+              name
+            }
+          }
+          ... on GlossaryTerm {
+            properties {
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -11,6 +11,7 @@ from ...search_types import (
     FacetOption,
     MultiSelectFilter,
     ResultType,
+    SearchFacets,
     SearchResponse,
     SearchResult,
 )
@@ -85,6 +86,22 @@ class SearchClient:
         return SearchResponse(
             total_results=response["total"], page_results=page_results, facets=facets
         )
+
+    def search_facets(
+        self,
+        query: str = "*",
+        result_types: Sequence[ResultType] = (
+            ResultType.DATA_PRODUCT,
+            ResultType.TABLE,
+        ),
+        filters: Sequence[MultiSelectFilter] = (),
+    ) -> SearchFacets:
+        """
+        Returns facets that can be used to filter the search results.
+        """
+        return self.search(
+            query=query, result_types=result_types, filters=filters
+        ).facets
 
     def _map_result_types(self, result_types: Sequence[ResultType]):
         """
@@ -211,9 +228,7 @@ class SearchClient:
             last_updated=last_updated,
         )
 
-    def _parse_facets(
-        self, facets: list[dict[str, Any]]
-    ) -> dict[str, list[FacetOption],]:
+    def _parse_facets(self, facets: list[dict[str, Any]]) -> SearchFacets:
         """
         Parse the facets and aggregate information from the query results
         """
@@ -234,4 +249,4 @@ class SearchClient:
 
             results[field] = options
 
-        return results
+        return SearchFacets(results)

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
@@ -50,3 +50,26 @@ class SearchResponse:
         str,
         list[FacetOption],
     ] = field(default_factory=dict)
+
+    def facet_options(self, field_name) -> list[FacetOption]:
+        """
+        Return a list of FacetOptions to display in a search facet.
+        Each option includes label, value and count.
+        """
+        return self.facets.get(field_name, [])
+
+    def facet_labels(self, field_name) -> list[str]:
+        """
+        Return a list of labels to display in a search facet.
+        """
+        return [f.label for f in self.facet_options(field_name)]
+
+    def lookup_facet_label(self, field_name, label) -> FacetOption | None:
+        """
+        Return the FacetOption matching a particular label.
+        """
+        options = self.facet_options(field_name)
+        for option in options:
+            if option.label == label:
+                return option
+        return None

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
@@ -43,33 +43,36 @@ class SearchResult:
 
 
 @dataclass
-class SearchResponse:
-    total_results: int
-    page_results: list[SearchResult]
-    facets: dict[
-        str,
-        list[FacetOption],
-    ] = field(default_factory=dict)
+class SearchFacets:
+    facets: dict[str, list[FacetOption]] = field(default_factory=dict)
 
-    def facet_options(self, field_name) -> list[FacetOption]:
+    def options(self, field_name) -> list[FacetOption]:
         """
         Return a list of FacetOptions to display in a search facet.
         Each option includes label, value and count.
+        Returns an empty list if there are no options to display.
         """
         return self.facets.get(field_name, [])
 
-    def facet_labels(self, field_name) -> list[str]:
+    def labels(self, field_name) -> list[str]:
         """
         Return a list of labels to display in a search facet.
         """
-        return [f.label for f in self.facet_options(field_name)]
+        return [f.label for f in self.options(field_name)]
 
-    def lookup_facet_label(self, field_name, label) -> FacetOption | None:
+    def lookup_label(self, field_name, label) -> FacetOption | None:
         """
         Return the FacetOption matching a particular label.
         """
-        options = self.facet_options(field_name)
+        options = self.options(field_name)
         for option in options:
             if option.label == label:
                 return option
         return None
+
+
+@dataclass
+class SearchResponse:
+    total_results: int
+    page_results: list[SearchResult]
+    facets: SearchFacets = field(default_factory=SearchFacets)

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.7.0"
+version = "0.8.0"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -356,11 +356,7 @@ def test_filter(searcher, mock_graph):
 
 def test_facets(searcher, mock_graph):
     datahub_response = {
-        "searchAcrossEntities": {
-            "start": 0,
-            "count": 10,
-            "total": 10,
-            "searchResults": [],
+        "aggregateAcrossEntities": {
             "facets": [
                 {
                     "field": "_entityType",

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -7,6 +7,7 @@ from data_platform_catalogue.search_types import (
     FacetOption,
     MultiSelectFilter,
     ResultType,
+    SearchFacets,
     SearchResponse,
     SearchResult,
 )
@@ -406,12 +407,10 @@ def test_facets(searcher, mock_graph):
 
     mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
 
-    response = searcher.search()
+    response = searcher.search_facets()
 
-    assert response == SearchResponse(
-        total_results=10,
-        page_results=[],
-        facets={
+    assert response == SearchFacets(
+        {
             "glossaryTerms": [
                 FacetOption(
                     value="urn:li:glossaryTerm:Classification.Sensitive",
@@ -436,7 +435,96 @@ def test_facets(searcher, mock_graph):
                     count=4,
                 ),
             ],
-        },
+        }
+    )
+
+
+def test_search_results_with_facets(searcher, mock_graph):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 10,
+            "total": 10,
+            "searchResults": [],
+            "facets": [
+                {
+                    "field": "_entityType",
+                    "displayName": "Type",
+                    "aggregations": [
+                        {"value": "DATASET", "count": 1505, "entity": None}
+                    ],
+                },
+                {
+                    "field": "glossaryTerms",
+                    "displayName": "Glossary Term",
+                    "aggregations": [
+                        {
+                            "value": "urn:li:glossaryTerm:Classification.Sensitive",
+                            "count": 1,
+                            "entity": {"properties": {"name": "Sensitive"}},
+                        },
+                        {
+                            "value": "urn:li:glossaryTerm:Silver",
+                            "count": 1,
+                            "entity": {"properties": None},
+                        },
+                    ],
+                },
+                {
+                    "field": "domains",
+                    "displayName": "Domain",
+                    "aggregations": [
+                        {
+                            "value": "urn:li:domain:094dc54b-0ebc-40a6-a4cf-e1b75e8b8089",
+                            "count": 7,
+                            "entity": {"properties": {"name": "Pet Adoptions"}},
+                        },
+                        {
+                            "value": "urn:li:domain:7186eeff-a860-4b0a-989f-69473a0c9c67",
+                            "count": 4,
+                            "entity": {"properties": {"name": "E-Commerce"}},
+                        },
+                    ],
+                },
+            ],
+        }
+    }
+
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+
+    assert response == SearchResponse(
+        total_results=10,
+        page_results=[],
+        facets=SearchFacets(
+            {
+                "glossaryTerms": [
+                    FacetOption(
+                        value="urn:li:glossaryTerm:Classification.Sensitive",
+                        label="Sensitive",
+                        count=1,
+                    ),
+                    FacetOption(
+                        value="urn:li:glossaryTerm:Silver",
+                        label="urn:li:glossaryTerm:Silver",
+                        count=1,
+                    ),
+                ],
+                "domains": [
+                    FacetOption(
+                        value="urn:li:domain:094dc54b-0ebc-40a6-a4cf-e1b75e8b8089",
+                        label="Pet Adoptions",
+                        count=7,
+                    ),
+                    FacetOption(
+                        value="urn:li:domain:7186eeff-a860-4b0a-989f-69473a0c9c67",
+                        label="E-Commerce",
+                        count=4,
+                    ),
+                ],
+            }
+        ),
     )
 
 

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -123,7 +123,7 @@ def test_domain_facets_are_returned():
     client.upsert_data_product(data_product)
 
     response = client.search()
-    assert response.facets["domains"]
+    assert response.facets.options("domains")
 
 
 @runs_on_development_server


### PR DESCRIPTION
Use the `aggregateAcrossEntities` graphQL query to retrieve lists of domains, tags and other search facets for a result set:

The response from aggregateAcrossEntities looks like this:

```graphql
{
  "data": {
    "aggregateAcrossEntities": {
      "facets": [
        {
          "field": "domains",
          "displayName": "Domain",
          "aggregations": [
            {
              "value": "urn:li:domain:094dc54b-0ebc-40a6-a4cf-e1b75e8b8089",
              "count": 7,
              "entity": {
                "properties": {
                  "name": "Pet Adoptions"
                }
              }
            },
            {
              "value": "urn:li:domain:7186eeff-a860-4b0a-989f-69473a0c9c67",
              "count": 4,
              "entity": {
                "properties": {
                  "name": "E-Commerce"
                }
              }
            },
            {
              "value": "urn:li:domain:7d64d0fa-66c3-445c-83db-3a324723daf8",
              "count": 3,
              "entity": {
                "properties": {
                  "name": "Marketing"
                }
              }
            }
          ]
        }
      ]
    }
  },
  "extensions": {}
}
```

I've wrapped the response in a new `FacetsResponse` object. 

```python
facets = client.search_facets()
for option in facets.options('domains'):
  print(option.label)
  print(option.value)
  print(option.count)
```

This also includes methods for looking up an option by label.

By default, the `search_facets` returns all the possible options. To render a filtered set of options, pass in the query, filter, and result_types arguments, to match the `search` method:

```python
facets = client.search_facets(query: "...", filters=[MultiSelectFilter(...)}, result_types=[...])
```