### PR TITLE
Add missing domain metadata to dataset search results, and add all available custom properties

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,6 +7,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] 2024-02-01
+
+### Changed
+
+- Datasets return domain information
+- Domain information is now returned as `domain_id` and `domain_name` metadata
+
 ## [0.9.0] 2024-01-31
 
 ### Added

--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Custom properties are now added to the metadata of each search result
 - Datasets return domain information
 - Domain information is now returned as `domain_id` and `domain_name` metadata
 

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.9.0"
+version = "0.10.0"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -135,7 +135,7 @@ def test_dataset_result(mock_graph, searcher):
                                 "id": "3dc18e48-c062-4407-84a9-73e23f768023",
                                 "properties": {
                                     "name": "HMPPS",
-                                    "description": "HMPPS is an executive agency that carries out sentences given by the courts, in custody and the community, and rehabilitates people through education and employment.",
+                                    "description": "HMPPS is an executive agency that ...",
                                 },
                             },
                             "editableProperties": None,

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -128,6 +128,13 @@ def test_dataset_result(mock_graph, searcher):
                         "name": "calm-pagoda-323403.jaffle_shop.customers",
                         "properties": {
                             "name": "customers",
+                            "customProperties": [
+                                {"key": "StoredAsSubDirectories", "value": "False"},
+                                {
+                                    "key": "CreatedByJob",
+                                    "value": "moj-reg-prod-hmpps-assess-risks-and-needs-prod-glue-job",
+                                },
+                            ],
                         },
                         "domain": {
                             "domain": {
@@ -166,6 +173,8 @@ def test_dataset_result(mock_graph, searcher):
                     "total_data_products": 0,
                     "domain_name": "HMPPS",
                     "domain_id": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
+                    "StoredAsSubDirectories": "False",
+                    "CreatedByJob": "moj-reg-prod-hmpps-assess-risks-and-needs-prod-glue-job",
                 },
                 tags=[],
             ),

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -98,20 +98,77 @@ def test_one_search_result(mock_graph, searcher):
                 name="Use of force",
                 description="Prisons in England and Wales are required to record all instances of Use of Force within their establishment. Use of Force can be planned or unplanned and may involve various categories of control and restraint (C&R) techniques such as physical restraint or handcuffs.\n\nPlease refer to [PSO 1600](https://www.gov.uk/government/publications/use-of-force-in-prisons-pso-1600) for the current guidance.",  # noqa E501
                 metadata={
-                    "domain": {
-                        "id": "3dc18e48-c062-4407-84a9-73e23f768023",
-                        "properties": {
-                            "name": "HMPPS",
-                            "description": "HMPPS is an executive agency that carries out sentences given by the courts, in custody and the community, and rehabilitates people through education and employment.",  # noqa E501
-                        },
-                        "urn": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
-                    },
+                    "domain_id": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
+                    "domain_name": "HMPPS",
                     "owner": "",
                     "owner_email": "",
                     "number_of_assets": 7,
                 },
                 tags=["custody"],
             )
+        ],
+    )
+
+
+def test_dataset_result(mock_graph, searcher):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 1,
+            "total": 1,
+            "searchResults": [
+                {
+                    "insights": [],
+                    "matchedFields": [],
+                    "entity": {
+                        "type": "DATASET",
+                        "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",  # noqa E501
+                        "platform": {"name": "bigquery"},
+                        "ownership": None,
+                        "name": "calm-pagoda-323403.jaffle_shop.customers",
+                        "properties": {
+                            "name": "customers",
+                        },
+                        "domain": {
+                            "domain": {
+                                "urn": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
+                                "id": "3dc18e48-c062-4407-84a9-73e23f768023",
+                                "properties": {
+                                    "name": "HMPPS",
+                                    "description": "HMPPS is an executive agency that carries out sentences given by the courts, in custody and the community, and rehabilitates people through education and employment.",
+                                },
+                            },
+                            "editableProperties": None,
+                            "tags": None,
+                            "lastIngested": 1705990502353,
+                        },
+                    },
+                }
+            ],
+        }
+    }
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+    assert response == SearchResponse(
+        total_results=1,
+        page_results=[
+            SearchResult(
+                id="urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers,PROD)",
+                matches={},
+                result_type=ResultType.TABLE,
+                name="customers",
+                description="",
+                metadata={
+                    "owner": "",
+                    "owner_email": "",
+                    "data_products": [],
+                    "total_data_products": 0,
+                    "domain_name": "HMPPS",
+                    "domain_id": "urn:li:domain:3dc18e48-c062-4407-84a9-73e23f768023",
+                },
+                tags=[],
+            ),
         ],
     )
 
@@ -184,6 +241,8 @@ def test_full_page(mock_graph, searcher):
                     "owner_email": "",
                     "data_products": [],
                     "total_data_products": 0,
+                    "domain_name": "",
+                    "domain_id": "",
                 },
                 tags=[],
                 last_updated=datetime(2024, 1, 23, 6, 15, 2, 353000),
@@ -199,6 +258,8 @@ def test_full_page(mock_graph, searcher):
                     "owner_email": "",
                     "data_products": [],
                     "total_data_products": 0,
+                    "domain_name": "",
+                    "domain_id": "",
                 },
                 tags=[],
                 last_updated=None,
@@ -214,6 +275,8 @@ def test_full_page(mock_graph, searcher):
                     "owner_email": "",
                     "data_products": [],
                     "total_data_products": 0,
+                    "domain_name": "",
+                    "domain_id": "",
                 },
                 tags=[],
                 last_updated=None,
@@ -271,6 +334,8 @@ def test_query_match(mock_graph, searcher):
                     "owner_email": "",
                     "data_products": [],
                     "total_data_products": 0,
+                    "domain_id": "",
+                    "domain_name": "",
                 },
                 tags=[],
             )
@@ -329,6 +394,8 @@ def test_result_with_owner(mock_graph, searcher):
                     "owner_email": "shannon@longtail.com",
                     "data_products": [],
                     "total_data_products": 0,
+                    "domain_id": "",
+                    "domain_name": "",
                 },
                 tags=[],
             )
@@ -593,6 +660,8 @@ def test_result_with_data_product(mock_graph, searcher):
                     "owner_email": "",
                     "data_products": [{"id": "urn:abc", "name": "abc"}],
                     "total_data_products": 1,
+                    "domain_id": "",
+                    "domain_name": "",
                 },
                 tags=[],
             )


### PR DESCRIPTION
1. Previously datasets were not returning domain information. This adds that back in and parses out the ID and name.
2. We were not returning any customProperties. Expose these to the frontend, so that customProperties become available to display once added to the catalogue.