### PR TITLE
Add Airflow CreateCliToken Permission

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
@@ -77,6 +77,16 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:catalog"
     ]
   }
+  statement {
+    sid    = "AirflowAccess"
+    effect = "Allow"
+    actions = [
+      "airflow:CreateCliToken"
+    ]
+    resources = [
+      "arn:aws:airflow:*:${var.account_ids["analytical-platform-data-production"]}:environment/dev"
+    ]
+  }
 }
 
 module "create_a_derived_table_iam_policy" {


### PR DESCRIPTION
Added `airflow:CreateCliToken` permission to runner role for `dev` airflow environment. This is for testing triggering a DAG from a successful build GitHub action run in create-a-derived-table.