### PR TITLE
Add JamesABaker to Data Engineering AWS Permission Groups

### DIFF
--- a/terraform/github/configuration/data-engineering-access.json
+++ b/terraform/github/configuration/data-engineering-access.json
@@ -495,5 +495,16 @@
       "analytical-platform-data-engineering-sandboxa-data-engineer",
       "analytical-platform-data-engineering-production-data-engineer"
     ]
+  },
+  {
+    "name": "James Baker",
+    "github": "JamesABaker",
+    "access": [
+      "analytical-platform-data-development-data-engineer",
+      "analytical-platform-data-production-data-engineer",
+      "analytical-platform-data-engineering-sandboxa-administrator",
+      "analytical-platform-data-engineering-sandboxa-data-engineer",
+      "analytical-platform-data-engineering-production-data-engineer"
+    ]
   }
 ]


### PR DESCRIPTION
This pull request introduces changes to the JSON file that manages user access to our data engineering AWS permission groups. Specifically, I have added my details (name and GitHub username) to the file, and assigned myself the same permission groups as Guy Wheeler.

The changes are as follows:

* Added a new user object with my name and GitHub username.

* Assigned the following permission groups to my user object:

```bash
analytical-platform-data-development-data-engineer
analytical-platform-data-production-data-engineer
analytical-platform-data-engineering-sandboxa-administrator
analytical-platform-data-engineering-sandboxa-data-engineer
analytical-platform-data-engineering-production-data-engineer
```

Please review these changes to ensure that the correct permissions have been assigned.