### PR TITLE
:octocat: Link VS Code client to GitHub

### DIFF
--- a/terraform/auth0/alpha-analytics-moj/clients.tf
+++ b/terraform/auth0/alpha-analytics-moj/clients.tf
@@ -4,3 +4,8 @@ resource "auth0_client" "visual_studio_code" {
   callbacks           = ["https://*-vscode.tools.analytical-platform.service.justice.gov.uk/callback"]
   allowed_logout_urls = ["https://*-vscode.tools.analytical-platform.service.justice.gov.uk"]
 }
+
+resource "auth0_connection_client" "visual_studio_code_github" {
+  client_id     = auth0_client.visual_studio_code.id
+  connection_id = "con_RWgK9R3ISqKJLcZu"
+}

--- a/terraform/auth0/dev-analytics-moj/clients.tf
+++ b/terraform/auth0/dev-analytics-moj/clients.tf
@@ -4,3 +4,8 @@ resource "auth0_client" "visual_studio_code" {
   callbacks           = ["https://*-vscode.tools.dev.analytical-platform.service.justice.gov.uk/callback"]
   allowed_logout_urls = ["https://*-vscode.tools.dev.analytical-platform.service.justice.gov.uk"]
 }
+
+resource "auth0_connection_client" "visual_studio_code_github" {
+  client_id     = auth0_client.visual_studio_code.id
+  connection_id = "con_9AZZa8FvELBflX8B"
+}


### PR DESCRIPTION
This pull request:

- Links VS Code client to GitHub connection

Note:

This is hardcoded (_for now?..._) because https://registry.terraform.io/providers/auth0/auth0/latest/docs/data-sources/connection doesn't return `connection_id`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 