### PR TITLE
🏥 Add OIDC conformance to Auth0 clients

### DIFF
--- a/terraform/auth0/alpha-analytics-moj/clients.tf
+++ b/terraform/auth0/alpha-analytics-moj/clients.tf
@@ -3,6 +3,8 @@ resource "auth0_client" "visual_studio_code" {
   app_type            = "regular_web"
   callbacks           = ["https://*-vscode.tools.analytical-platform.service.justice.gov.uk/callback"]
   allowed_logout_urls = ["https://*-vscode.tools.analytical-platform.service.justice.gov.uk"]
+  oidc_conformant     = true
+  sso                 = true
 }
 
 resource "auth0_connection_client" "visual_studio_code_github" {

--- a/terraform/auth0/dev-analytics-moj/clients.tf
+++ b/terraform/auth0/dev-analytics-moj/clients.tf
@@ -3,6 +3,8 @@ resource "auth0_client" "visual_studio_code" {
   app_type            = "regular_web"
   callbacks           = ["https://*-vscode.tools.dev.analytical-platform.service.justice.gov.uk/callback"]
   allowed_logout_urls = ["https://*-vscode.tools.dev.analytical-platform.service.justice.gov.uk"]
+  oidc_conformant     = true
+  sso                 = true
 }
 
 resource "auth0_connection_client" "visual_studio_code_github" {


### PR DESCRIPTION
This pull request:

- Is part of #3210
- Adds `oidc_conformant` flag
- Adds `sso` flag

Nice one @jamesstottmoj 

Note:

`sso` flag had been set in the dev tenant, so I've backported it

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk>  