### PR TITLE
use fully qualified name in upsert_table

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.16.2] 2024-02-28
+
+### Changed
+
+- upsert_table sets datset name as fully qualified name
+
 ## [0.16.1] 2024-02-20
 
 ### Added

--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,11 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.2] 2024-02-28
+## [0.17.0] 2024-02-28
 
-### Changed
+### Added
 
-- upsert_table sets datset name as fully qualified name
+- upsert_table now sets datset name as single table name and
+ `qualifiedName` as the fully qualified name we define.
 
 ## [0.16.1] 2024-02-20
 

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -238,7 +238,7 @@ class DataHubCatalogueClient(BaseCatalogueClient):
         )
 
         dataset_properties = DatasetPropertiesClass(
-            name=metadata.name,
+            name=name,
             description=metadata.description,
             customProperties={
                 "sourceDatasetName": metadata.source_dataset_name,

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -238,7 +238,8 @@ class DataHubCatalogueClient(BaseCatalogueClient):
         )
 
         dataset_properties = DatasetPropertiesClass(
-            name=name,
+            name=metadata.name,
+            qualifiedName=name,
             description=metadata.description,
             customProperties={
                 "sourceDatasetName": metadata.source_dataset_name,

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.16.1"
+version = "0.16.2"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.16.2"
+version = "0.17.0"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table.json
@@ -12,7 +12,8 @@
                 "sensitivityLevel": "TOP_SECRET",
                 "rowCount": "1177"
             },
-            "name": "my_database.my_table",
+            "name": "my_table",
+            "qualifiedName": "my_database.my_table",
             "description": "bla bla",
             "tags": []
         }

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table.json
@@ -12,7 +12,7 @@
                 "sensitivityLevel": "TOP_SECRET",
                 "rowCount": "1177"
             },
-            "name": "my_table",
+            "name": "my_database.my_table",
             "description": "bla bla",
             "tags": []
         }

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table_with_metadata.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table_with_metadata.json
@@ -12,7 +12,8 @@
                 "sensitivityLevel": "TOP_SECRET",
                 "rowCount": "1177"
             },
-            "name": "my_database.my_table",
+            "name": "my_table",
+            "qualifiedName": "my_database.my_table",
             "description": "bla bla",
             "tags": []
         }

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table_with_metadata.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table_with_metadata.json
@@ -12,7 +12,7 @@
                 "sensitivityLevel": "TOP_SECRET",
                 "rowCount": "1177"
             },
-            "name": "my_table",
+            "name": "my_database.my_table",
             "description": "bla bla",
             "tags": []
         }

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_two_tables_with_metadata.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_two_tables_with_metadata.json
@@ -12,7 +12,8 @@
                 "sensitivityLevel": "TOP_SECRET",
                 "rowCount": "1177"
             },
-            "name": "my_database.my_table",
+            "name": "my_table",
+            "qualifiedName": "my_database.my_table",
             "description": "bla bla",
             "tags": []
         }
@@ -171,7 +172,8 @@
                 "sensitivityLevel": "OFFICIAL",
                 "rowCount": "1177"
             },
-            "name": "my_database.my_table2",
+            "name": "my_table2",
+            "qualifiedName": "my_database.my_table2",
             "description": "this is a different table",
             "tags": []
         }

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_two_tables_with_metadata.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_two_tables_with_metadata.json
@@ -12,7 +12,7 @@
                 "sensitivityLevel": "TOP_SECRET",
                 "rowCount": "1177"
             },
-            "name": "my_table",
+            "name": "my_database.my_table",
             "description": "bla bla",
             "tags": []
         }
@@ -171,7 +171,7 @@
                 "sensitivityLevel": "OFFICIAL",
                 "rowCount": "1177"
             },
-            "name": "my_table2",
+            "name": "my_database.my_table2",
             "description": "this is a different table",
             "tags": []
         }

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -80,7 +80,7 @@ def test_upsert_test_hierarchy():
     )
     # check properties been loaded to datahub dataset
     assert dataset_properties.description == table.description
-    assert dataset_properties.name == table.name
+    assert dataset_properties.name == f"test_data_product_v2.{table.name}"
     assert (
         dataset_properties.customProperties["sourceDatasetName"]
         == table.source_dataset_name

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -80,7 +80,8 @@ def test_upsert_test_hierarchy():
     )
     # check properties been loaded to datahub dataset
     assert dataset_properties.description == table.description
-    assert dataset_properties.name == f"test_data_product_v2.{table.name}"
+    assert dataset_properties.qualifiedName == f"test_data_product_v2.{table.name}"
+    assert dataset_properties.name == table.name
     assert (
         dataset_properties.customProperties["sourceDatasetName"]
         == table.source_dataset_name


### PR DESCRIPTION
Fully qualified name is now loaded to datahub alongside the name property which is just the name of a table/dataset entity

This will allow us to better display fully qualified name on search results and just the simple table name on the data product details page