### PR TITLE
Add find-moj-data repo

### DIFF
--- a/terraform/github/data-platform-repositories.tf
+++ b/terraform/github/data-platform-repositories.tf
@@ -35,6 +35,20 @@ locals {
         pushers     = [module.data_platform_team.id]
       }
     }
+
+    "find-moj-data" = {
+      name            = "find-moj-data"
+      description     = "Django frontend app for Find MOJ Data"
+      topics          = ["ministryofjustice", "data-platform"]
+      has_projects    = true
+      has_discussions = true
+      use_template    = false
+      access = {
+        admins  = [module.data_platform_teams["data-platform-labs"].id]
+        pushers = [module.data_platform_team.id]
+      }
+    }
+
     "data-platform-support" = {
       name                                   = "data-platform-support"
       description                            = "Data Platform Support"


### PR DESCRIPTION
This adds https://github.com/ministryofjustice/find-moj-data to the list of repos controlled by terraform.

Questions:

1. Is data-platform/terraform still the correct place for this?
2. How come the terraform plan says a new repository will be created? https://github.com/ministryofjustice/data-platform/actions/runs/8093781369/job/22117116011?pr=3489#step:13:933