### PR TITLE
📌 Update deployed Actions Runners to 2.1.0

### DIFF
--- a/terraform/cloud-platform/live/data-platform-production/actions-runners/create-a-derived-table.tf
+++ b/terraform/cloud-platform/live/data-platform-production/actions-runners/create-a-derived-table.tf
@@ -13,7 +13,7 @@ data "aws_secretsmanager_secret_version" "github_actions_self_hosted_runner_crea
 resource "helm_release" "create_a_derived_table" {
   name       = "actions-runner-mojas-create-a-derived-table"
   repository = "oci://ghcr.io/ministryofjustice/data-platform-charts"
-  version    = "2.0.0"
+  version    = "2.1.0"
   chart      = "actions-runner"
   namespace  = "data-platform-production"
 

--- a/terraform/dpat-eks/production/actions-runners/create-a-derived-table.tf
+++ b/terraform/dpat-eks/production/actions-runners/create-a-derived-table.tf
@@ -13,7 +13,7 @@ data "aws_secretsmanager_secret_version" "github_actions_self_hosted_runner_crea
 resource "helm_release" "create_a_derived_table" {
   name       = "actions-runner-mojas-create-a-derived-table"
   repository = "oci://ghcr.io/ministryofjustice/data-platform-charts"
-  version    = "2.0.0"
+  version    = "2.1.0"
   chart      = "actions-runner"
   namespace  = "actions-runners"
 


### PR DESCRIPTION
This pull request:

- Follow on from #3484 
- Bumps deployed charts to 2.1.0

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 