### PR TITLE
Add a new repo for spiking a custom ingestion source

### DIFF
--- a/terraform/github/data-catalogue.tf
+++ b/terraform/github/data-catalogue.tf
@@ -33,6 +33,23 @@ module "data_catalogue_repository" {
   }
 }
 
+module "datahub_custom_api_source" {
+  source = "./modules/repository"
+
+  name        = "data-catalogue"
+  description = "Custom ingestion source for Datahub to consume from https://data.justice.gov.uk/api"
+  topics      = ["data-catalogue"]
+
+  use_template        = true
+  template_repository = "data-platform-app-template"
+  has_projects        = "true"
+  homepage_url        = null
+
+  access = {
+    admins = [module.data_catalogue_team.id]
+  }
+}
+
 module "data_catalogue_metadata_repository" {
   source = "./modules/repository"
 
@@ -53,4 +70,3 @@ module "data_catalogue_metadata_repository" {
     admins = [module.data_catalogue_team.id]
   }
 }
-

--- a/terraform/github/data-catalogue.tf
+++ b/terraform/github/data-catalogue.tf
@@ -33,17 +33,16 @@ module "data_catalogue_repository" {
   }
 }
 
-module "datahub_custom_api_source" {
+module "datahub_custom_api_source_repository" {
   source = "./modules/repository"
 
-  name        = "data-catalogue"
+  name        = "datahub-custom-api-source"
   description = "Custom ingestion source for Datahub to consume from https://data.justice.gov.uk/api"
   topics      = ["data-catalogue"]
 
-  use_template        = true
-  template_repository = "data-platform-app-template"
-  has_projects        = "true"
-  homepage_url        = null
+  use_template = true
+  has_projects = "true"
+  homepage_url = null
 
   access = {
     admins = [module.data_catalogue_team.id]


### PR DESCRIPTION
We have a spike to investigate ingesting dashboards into the data catalogue.

As part of this I want to try and write a custom ingestion source that pulls chart metadata from the Justice Data API.