### PR TITLE
Replace data-catalogue with a new repo

### DIFF
--- a/terraform/github/analytical-platform-repositories.tf
+++ b/terraform/github/analytical-platform-repositories.tf
@@ -59,16 +59,17 @@ locals {
     },
     /* Old World */
     "analytics-platform-infrastructure" = {
-      name                                   = "analytics-platform-infrastructure"
-      description                            = "Analytical Platform Infrastructure"
-      topics                                 = ["ministryofjustice", "analytical-platform"]
-      visibility                             = "internal"
-      archived                               = true
-      use_template                           = false
-      vulnerability_alerts                   = false
-      advanced_security_status               = "disabled"
-      secret_scanning_status                 = "disabled"
-      secret_scanning_push_protection_status = "disabled"
+      name                                     = "analytics-platform-infrastructure"
+      description                              = "Analytical Platform Infrastructure"
+      topics                                   = ["ministryofjustice", "analytical-platform"]
+      visibility                               = "internal"
+      archived                                 = true
+      use_template                             = false
+      vulnerability_alerts                     = false
+      advanced_security_status                 = "disabled"
+      secret_scanning_status                   = "disabled"
+      secret_scanning_push_protection_status   = "disabled"
+      branch_protection_require_signed_commits = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]
@@ -113,15 +114,16 @@ locals {
       }
     }
     "analytics-platform-control-panel-public" = {
-      name                                   = "analytics-platform-control-panel-public"
-      description                            = "Analytical Platform Control Panel Public"
-      topics                                 = ["ministryofjustice", "analytical-platform"]
-      archived                               = true
-      use_template                           = false
-      vulnerability_alerts                   = false
-      advanced_security_status               = "disabled"
-      secret_scanning_status                 = "enabled"
-      secret_scanning_push_protection_status = "disabled"
+      name                                     = "analytics-platform-control-panel-public"
+      description                              = "Analytical Platform Control Panel Public"
+      topics                                   = ["ministryofjustice", "analytical-platform"]
+      archived                                 = true
+      use_template                             = false
+      vulnerability_alerts                     = false
+      advanced_security_status                 = "disabled"
+      secret_scanning_status                   = "enabled"
+      secret_scanning_push_protection_status   = "disabled"
+      branch_protection_require_signed_commits = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]
@@ -142,15 +144,16 @@ locals {
       }
     },
     "analytics-platform-ops" = {
-      name                                   = "analytics-platform-ops"
-      description                            = "Analytical Platform Ops"
-      topics                                 = ["ministryofjustice", "analytical-platform"]
-      archived                               = true
-      use_template                           = false
-      vulnerability_alerts                   = false
-      advanced_security_status               = "disabled"
-      secret_scanning_status                 = "disabled"
-      secret_scanning_push_protection_status = "disabled"
+      name                                     = "analytics-platform-ops"
+      description                              = "Analytical Platform Ops"
+      topics                                   = ["ministryofjustice", "analytical-platform"]
+      archived                                 = true
+      use_template                             = false
+      vulnerability_alerts                     = false
+      advanced_security_status                 = "disabled"
+      secret_scanning_status                   = "disabled"
+      secret_scanning_push_protection_status   = "disabled"
+      branch_protection_require_signed_commits = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]
@@ -181,16 +184,17 @@ locals {
       }
     },
     "analytical-platform-iam" = {
-      name                                   = "analytical-platform-iam"
-      description                            = "Analytical Platform IAM"
-      topics                                 = ["ministryofjustice", "analytical-platform"]
-      archived                               = true
-      use_template                           = false
-      visibility                             = "internal"
-      vulnerability_alerts                   = false
-      advanced_security_status               = "disabled"
-      secret_scanning_status                 = "disabled"
-      secret_scanning_push_protection_status = "disabled"
+      name                                     = "analytical-platform-iam"
+      description                              = "Analytical Platform IAM"
+      topics                                   = ["ministryofjustice", "analytical-platform"]
+      archived                                 = true
+      use_template                             = false
+      visibility                               = "internal"
+      vulnerability_alerts                     = false
+      advanced_security_status                 = "disabled"
+      secret_scanning_status                   = "disabled"
+      secret_scanning_push_protection_status   = "disabled"
+      branch_protection_require_signed_commits = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]
@@ -304,32 +308,34 @@ locals {
       }
     },
     "ap-terraform-module-template" = {
-      name                                   = "ap-terraform-module-template"
-      description                            = "Analytical Platform Terraform Module Template"
-      topics                                 = ["ministryofjustice", "analytical-platform"]
-      is_template                            = true
-      use_template                           = false
-      archived                               = true
-      vulnerability_alerts                   = false
-      advanced_security_status               = "disabled"
-      secret_scanning_status                 = "disabled"
-      secret_scanning_push_protection_status = "disabled"
+      name                                     = "ap-terraform-module-template"
+      description                              = "Analytical Platform Terraform Module Template"
+      topics                                   = ["ministryofjustice", "analytical-platform"]
+      is_template                              = true
+      use_template                             = false
+      archived                                 = true
+      vulnerability_alerts                     = false
+      advanced_security_status                 = "disabled"
+      secret_scanning_status                   = "disabled"
+      secret_scanning_push_protection_status   = "disabled"
+      branch_protection_require_signed_commits = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]
       }
     },
     "ap-test-github-workflow" = {
-      name                                   = "ap-test-github-workflow"
-      description                            = "Analytical Platform Test Github Workflow"
-      topics                                 = ["ministryofjustice", "analytical-platform"]
-      visibility                             = "internal"
-      archived                               = true
-      use_template                           = false
-      vulnerability_alerts                   = false
-      advanced_security_status               = "disabled"
-      secret_scanning_status                 = "disabled"
-      secret_scanning_push_protection_status = "disabled"
+      name                                     = "ap-test-github-workflow"
+      description                              = "Analytical Platform Test Github Workflow"
+      topics                                   = ["ministryofjustice", "analytical-platform"]
+      visibility                               = "internal"
+      archived                                 = true
+      use_template                             = false
+      vulnerability_alerts                     = false
+      advanced_security_status                 = "disabled"
+      secret_scanning_status                   = "disabled"
+      secret_scanning_push_protection_status   = "disabled"
+      branch_protection_require_signed_commits = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]
@@ -423,42 +429,45 @@ locals {
       }
     },
     "ap-terraform-ecr-repository" = {
-      name                                   = "ap-terraform-ecr-repository"
-      description                            = "Analytical Platform Terraform ECR Repository"
-      topics                                 = ["ministryofjustice", "analytical-platform"]
-      use_template                           = true
-      template_repository                    = "ap-terraform-module-template"
-      archived                               = true
-      vulnerability_alerts                   = false
-      secret_scanning_push_protection_status = "disabled"
+      name                                     = "ap-terraform-ecr-repository"
+      description                              = "Analytical Platform Terraform ECR Repository"
+      topics                                   = ["ministryofjustice", "analytical-platform"]
+      use_template                             = true
+      template_repository                      = "ap-terraform-module-template"
+      archived                                 = true
+      vulnerability_alerts                     = false
+      secret_scanning_push_protection_status   = "disabled"
+      branch_protection_require_signed_commits = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]
       }
     },
     "ap-terraform-github-id-provider-config" = {
-      name                            = "ap-terraform-github-id-provider-config"
-      description                     = "Analytical Platform Terraform Github ID Provider Config"
-      topics                          = ["ministryofjustice", "analytical-platform"]
-      use_template                    = true
-      archived                        = true
-      vulnerability_alerts            = false
-      secret_scanning_push_protection = "disabled"
-      template_repository             = "ap-terraform-module-template"
+      name                                     = "ap-terraform-github-id-provider-config"
+      description                              = "Analytical Platform Terraform Github ID Provider Config"
+      topics                                   = ["ministryofjustice", "analytical-platform"]
+      use_template                             = true
+      archived                                 = true
+      vulnerability_alerts                     = false
+      secret_scanning_push_protection          = "disabled"
+      template_repository                      = "ap-terraform-module-template"
+      branch_protection_require_signed_commits = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]
       }
     },
     "ap-terraform-aws-oidc-provider" = {
-      name                            = "ap-terraform-aws-oidc-provider"
-      description                     = "Analytical Platform Terraform AWS OIDC Provider"
-      topics                          = ["ministryofjustice", "analytical-platform"]
-      use_template                    = true
-      archived                        = true
-      vulnerability_alerts            = false
-      secret_scanning_push_protection = "disabled"
-      template_repository             = "ap-terraform-module-template"
+      name                                     = "ap-terraform-aws-oidc-provider"
+      description                              = "Analytical Platform Terraform AWS OIDC Provider"
+      topics                                   = ["ministryofjustice", "analytical-platform"]
+      use_template                             = true
+      archived                                 = true
+      vulnerability_alerts                     = false
+      secret_scanning_push_protection          = "disabled"
+      template_repository                      = "ap-terraform-module-template"
+      branch_protection_require_signed_commits = false
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
         pushers = [module.data_platform_team.id]

--- a/terraform/github/data-catalogue.tf
+++ b/terraform/github/data-catalogue.tf
@@ -16,21 +16,21 @@ module "data_catalogue_team" {
   ]
 }
 
-# module "data_catalogue_parent_repository" {
-#   source = "./modules/repository"
+module "data_catalogue_repository" {
+  source = "./modules/repository"
 
-#   name        = "data-catalogue"
-#   description = "Data catalogue"
-#   topics      = ["data-catalogue"]
+  name        = "data-catalogue"
+  description = "Data catalogue"
+  topics      = ["data-catalogue"]
 
-#   use_template = true
-#   has_projects = "true"
-#   homepage_url = null
+  use_template = true
+  has_projects = "true"
+  homepage_url = null
 
-#   access = {
-#     admins = [module.data_catalogue_team.id]
-#   }
-# }
+  access = {
+    admins = [module.data_catalogue_team.id]
+  }
+}
 
 module "find_moj_data_repository" {
   source = "./modules/repository"
@@ -46,11 +46,6 @@ module "find_moj_data_repository" {
   access = {
     admins = [module.data_catalogue_team.id]
   }
-}
-
-moved {
-  from = module.data_catalogue_repository
-  to   = module.find_moj_data_repository
 }
 
 module "datahub_custom_api_source_repository" {

--- a/terraform/github/data-catalogue.tf
+++ b/terraform/github/data-catalogue.tf
@@ -39,9 +39,10 @@ module "find_moj_data_repository" {
   description = "Find MOJ data service"
   topics      = ["data-catalogue"]
 
-  use_template = true
-  has_projects = "true"
-  homepage_url = null
+  use_template        = true
+  template_repository = "data-platform-app-template"
+  has_projects        = "true"
+  homepage_url        = null
 
   access = {
     admins = [module.data_catalogue_team.id]

--- a/terraform/github/data-catalogue.tf
+++ b/terraform/github/data-catalogue.tf
@@ -16,21 +16,41 @@ module "data_catalogue_team" {
   ]
 }
 
-module "data_catalogue_repository" {
+# module "data_catalogue_parent_repository" {
+#   source = "./modules/repository"
+
+#   name        = "data-catalogue"
+#   description = "Data catalogue"
+#   topics      = ["data-catalogue"]
+
+#   use_template = true
+#   has_projects = "true"
+#   homepage_url = null
+
+#   access = {
+#     admins = [module.data_catalogue_team.id]
+#   }
+# }
+
+module "find_moj_data_repository" {
   source = "./modules/repository"
 
-  name        = "data-catalogue"
-  description = "Data Catalogue"
+  name        = "find-moj-data"
+  description = "Find MOJ data service"
   topics      = ["data-catalogue"]
 
-  use_template        = true
-  template_repository = "data-platform-app-template"
-  has_projects        = "true"
-  homepage_url        = null
+  use_template = true
+  has_projects = "true"
+  homepage_url = null
 
   access = {
     admins = [module.data_catalogue_team.id]
   }
+}
+
+moved {
+  from = module.data_catalogue_repository
+  to   = module.find_moj_data_repository
 }
 
 module "datahub_custom_api_source_repository" {


### PR DESCRIPTION
The goal of this PR is to:
- Rename `data-catalogue` back to `find-moj-data`
- Create a *new* `data-catalogue` repo

Since find-moj-data creates a build artefact, we've decided to manage it in its own separate repo. We are expecting this will make deployment easier because
- we won't need workflow logic to conditionally execute stuff depending on subdirectory
- deployments of the same artefact type will follow the same basic template
- we can diff versions of an artefact in source without seeing unrelated changes from other components

However we also want a "top level" repo that links out to the various artefacts. It is this repo that would take over the repository terraforming if we completely decouple our work from the analytical platform. Right now, we will use it for the helm deployment of datahub itself, and any documentation or tickets related to the overall data catalogue project.

## What we are aiming for
![Screenshot 2024-03-04 at 11 54 06](https://github.com/ministryofjustice/data-platform/assets/87579/23856061-1c6e-48c5-8265-7d164f547ff6)

## Consequences
- After merging this, we should partially revert https://github.com/ministryofjustice/cloud-platform-environments/pull/21391