### PR TITLE
♻️ Rename Data Platform Control Panel to Analytical Platform Dashboard

### DIFF
--- a/terraform/github/analytical-platform-repositories.tf
+++ b/terraform/github/analytical-platform-repositories.tf
@@ -1,6 +1,7 @@
 locals {
   /* New World */
   analytical_platform_repositories = {
+    /* New World */
     "analytical-platform" = {
       name         = "analytical-platform"
       description  = "Analytical Platform"
@@ -42,6 +43,16 @@ locals {
           path   = "/"
         }
       }
+      access = {
+        admins = [module.analytical_platform_team.id]
+      }
+    },
+    "analytical-platform-dashboard" = {
+      name         = "analytical-platform-dashboard"
+      description  = "Analytical Platform Dashboard"
+      topics       = ["ministryofjustice", "analytical-platform"]
+      has_issues   = true
+      homepage_url = "https://user-guide.analytical-platform.service.justice.gov.uk"
       access = {
         admins = [module.analytical_platform_team.id]
       }

--- a/terraform/github/data-platform-repositories.tf
+++ b/terraform/github/data-platform-repositories.tf
@@ -79,18 +79,6 @@ locals {
         pushers = [module.data_platform_team.id]
       }
     },
-    "data-platform-control-panel" = {
-      name                                              = "data-platform-control-panel"
-      description                                       = "Data Platform Control Panel"
-      topics                                            = ["ministryofjustice", "data-platform"]
-      has_projects                                      = false
-      has_issues                                        = false
-      branch_protection_required_status_checks_contexts = ["Super-Linter"]
-      access = {
-        admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
-        pushers = [module.data_platform_team.id]
-      }
-    },
     "data-platform-new-app-runthrough" = {
       name                                   = "data-platform-new-app-runthrough"
       description                            = "A lovely new application"


### PR DESCRIPTION
This pull request:

- Renames Data Platform Control Panel to Analytical Platform Dashboard
- Enables issues so it doesn't break Ops Eng report

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 