### PR TITLE
🦪 Add ingestion scanner repository

### DIFF
--- a/terraform/github/analytical-platform-repositories.tf
+++ b/terraform/github/analytical-platform-repositories.tf
@@ -57,6 +57,23 @@ locals {
         admins = [module.analytical_platform_team.id]
       }
     },
+    "analytical-platform-visual-studio-code" = {
+      name        = "analytical-platform-visual-studio-code"
+      description = "Analytical Platform Visual Studio Code"
+      topics      = ["ministryofjustice", "analytical-platform"]
+      access = {
+        admins  = [module.analytical_platform_team.id]
+        pushers = [module.data_platform_team.id]
+      }
+    },
+    "analytical-platform-ingestion-scanner" = {
+      name        = "analytical-platform-ingestion-scanner"
+      description = "Analytical Platform Ingestion Scanner"
+      topics      = ["ministryofjustice", "analytical-platform"]
+      access = {
+        admins = [module.analytical_platform_team.id]
+      }
+    },
     /* Old World */
     "analytics-platform-infrastructure" = {
       name                                     = "analytics-platform-infrastructure"
@@ -295,15 +312,6 @@ locals {
       secret_scanning_push_protection_status = "disabled"
       access = {
         admins  = [module.data_platform_teams["data-platform-apps-and-tools"].id]
-        pushers = [module.data_platform_team.id]
-      }
-    },
-    "analytical-platform-visual-studio-code" = {
-      name        = "analytical-platform-visual-studio-code"
-      description = "Analytical Platform Visual Studio Code"
-      topics      = ["ministryofjustice", "analytical-platform"]
-      access = {
-        admins  = [module.analytical_platform_team.id]
         pushers = [module.data_platform_team.id]
       }
     },


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/data-platform/issues/3501
- Creates a new repository called `analytical-platform-ingestion-scanner`
- Moves `analytical-platform-visual-studio-code` into New World section

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 