### PR TITLE
Fix none fqn data catalogue

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.18.1] 2024-03-05
+
+### Changed
+
+- `SearchResult.fully_qualified_name` now returns `name` if datahub metadata
+  property `qualifiedName` has a value of `None`, which it can do in the
+  case of dbt ingestions.
+
 ## [0.18.0] 2024-03-04
 
 ### Added

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -282,12 +282,18 @@ class SearchClient:
         metadata.update(self._parse_domain(entity))
         metadata.update(custom_properties)
 
+        fqn = (
+            properties.get("qualifiedName", name)
+            if properties.get("qualifiedName") is not None
+            else name
+        )
+
         return SearchResult(
             id=entity["urn"],
             result_type=ResultType.TABLE,
             matches=matches,
             name=properties.get("name", name),
-            fully_qualified_name=properties.get("qualifiedName", name),
+            fully_qualified_name=fqn,
             description=properties.get("description", ""),
             metadata=metadata,
             tags=tags,
@@ -310,12 +316,18 @@ class SearchClient:
         metadata.update(self._parse_domain(entity))
         metadata.update(custom_properties)
 
+        fqn = (
+            properties.get("qualifiedName", properties["name"])
+            if properties.get("qualifiedName") is not None
+            else properties["name"]
+        )
+
         return SearchResult(
             id=entity["urn"],
             result_type=ResultType.DATA_PRODUCT,
             matches=matches,
             name=properties["name"],
-            fully_qualified_name=properties.get("qualifiedName", properties["name"]),
+            fully_qualified_name=fqn,
             description=properties.get("description", ""),
             metadata=metadata,
             tags=tags,

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.18.0"
+version = "0.18.1"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"

--- a/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
+++ b/python-libraries/data-platform-catalogue/tests/test_datahub_search.py
@@ -217,9 +217,7 @@ def test_full_page(mock_graph, searcher):
                         "type": "DATASET",
                         "urn": "urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers2,PROD)",  # noqa E501
                         "name": "calm-pagoda-323403.jaffle_shop.customers2",
-                        "properties": {
-                            "name": "customers2",
-                        },
+                        "properties": {"name": "customers2", "qualifiedName": None},
                     },
                 },
                 {


### PR DESCRIPTION
Fixes the scenario where a `qualifiedName` key exists in the metadata but with a value of `None` as is the case with data ingested via `create-a-derived-table`