### PR TITLE
Analytical Platform Bedrock Policy

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -1,0 +1,62 @@
+#tfsec:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "bedrock_integration" {
+  #checkov:skip=CKV_AWS_111: This is a service policy
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+  statement {
+    sid    = "AnalyticalPlatformBedrockIntegrtion"
+    effect = "Allow"
+
+    actions = [
+      "bedrock:ListFoundationModels",
+      "bedrock:GetFoundationModel",
+      "bedrock:InvokeModel",
+      "bedrock:InvokeModelWithResponseStream",
+      "bedrock:CreateModelCustomizationJob",
+      "bedrock:GetModelCustomizationJob",
+      "bedrock:GetFoundationModelAvailability",
+      "bedrock:ListModelCustomizationJobs",
+      "bedrock:StopModelCustomizationJob",
+      "bedrock:GetCustomModel",
+      "bedrock:ListCustomModels",
+      "bedrock:DeleteCustomModel",
+      "bedrock:CreateProvisionedModelThroughput",
+      "bedrock:UpdateProvisionedModelThroughput",
+      "bedrock:GetProvisionedModelThroughput",
+      "bedrock:DeleteProvisionedModelThroughput",
+      "bedrock:ListProvisionedModelThroughputs",
+      "bedrock:ListTagsForResource",
+      "bedrock:UntagResource",
+      "bedrock:TagResource",
+      "bedrock:CreateAgent",
+      "bedrock:UpdateAgent",
+      "bedrock:GetAgent",
+      "bedrock:ListAgents",
+      "bedrock:CreateActionGroup",
+      "bedrock:UpdateActionGroup",
+      "bedrock:GetActionGroup",
+      "bedrock:ListActionGroups",
+      "bedrock:CreateAgentDraftSnapshot",
+      "bedrock:GetAgentVersion",
+      "bedrock:ListAgentVersions",
+      "bedrock:CreateAgentAlias",
+      "bedrock:UpdateAgentAlias",
+      "bedrock:GetAgentAlias",
+      "bedrock:ListAgentAliases",
+      "bedrock:InvokeAgent",
+      "bedrock:PutFoundationModelEntitlement",
+      "bedrock:GetModelInvocationLoggingConfiguration",
+      "bedrock:PutModelInvocationLoggingConfiguration",
+      "bedrock:CreateFoundationModelAgreement",
+      "bedrock:DeleteFoundationModelAgreement",
+      "bedrock:ListFoundationModelAgreementOffers",
+      "bedrock:GetUseCaseForModelAccess"
+    ]
+
+    resources = ["*"]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:RequestedRegion"
+      values   = ["eu-central-1"]
+    }
+  }
+}

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -60,3 +60,8 @@ data "aws_iam_policy_document" "bedrock_integration" {
     }
   }
 }
+resource "aws_iam_policy" "bedrock_integration" {
+  name        = "anaytial-platform-bedrock-integration"
+  description = "Permissions needed to allow access to Bedrock in Frankfurt from tooling."
+  policy      = data.aws_iam_policy_document.bedrock_integration.json
+}


### PR DESCRIPTION
#3456 

Adding Bedrock policy to Analytical Platform dev, to support AWS hackathon activities. 