### PR TITLE
Add missing metadata when fetching datasets

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,6 +7,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.23.0] 2024-03-26
+
+### Changed
+
+- Use timezone aware timestamps when returning last updated values, and source
+  the information from `lastModified` in Datahub, not `lastIngested`.
+- Prefer native data types to Datahub's type when returning schemas for datasets
+
+### Added
+
+- Return qualifiedName and tags for datasets if available
+
 ## [0.22.0] 2023-03-19
 
 ### Added
@@ -37,7 +49,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - A ChartMetadata class with very limited attributes
 - ResultType.CHART
 - A GraphQL query for chart details
-- SearchClient._parse_chart, incorporated chart parsing into the normal search method
+- SearchClient.\_parse_chart, incorporated chart parsing into the normal search method
 - DataHubCatalogueClient.get_chart_details for the chart display page
 
 ### Changed

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -665,7 +665,7 @@ class DataHubCatalogueClient(BaseCatalogueClient):
             domain = parse_domain(response)
             owner, owner_email = parse_owner(response)
             tags = parse_tags(response)
-            name = properties["name"]
+            name = properties.get("name", response.get("name"))
             created, modified = parse_created_and_modified(properties)
 
             # A dataset can't have both a container and data product parent, but if we did
@@ -678,6 +678,8 @@ class DataHubCatalogueClient(BaseCatalogueClient):
                 relations = parse_relations(
                     RelationshipType.PARENT, response["data_product_relations"]
                 )
+            else:
+                relations = {}
             return TableMetadata(
                 name=name,
                 fully_qualified_name=properties.get("qualifiedName") or name,

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -664,6 +664,7 @@ class DataHubCatalogueClient(BaseCatalogueClient):
             domain = parse_domain(response)
             owner, owner_email = parse_owner(response)
             tags = parse_tags(response)
+            name = properties["name"]
 
             # A dataset can't have both a container and data product parent, but if we did
             # start to use in that we'd need to change this
@@ -676,7 +677,8 @@ class DataHubCatalogueClient(BaseCatalogueClient):
                     RelationshipType.PARENT, response["data_product_relations"]
                 )
             return TableMetadata(
-                name=properties["name"],
+                name=name,
+                fully_qualified_name=properties.get("qualifiedName") or name,
                 description=properties.get("description", ""),
                 column_details=columns,
                 retention_period_in_days=custom_properties.get("retentionPeriodInDays"),

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -47,6 +47,7 @@ from ...search_types import (
 from ..base import BaseCatalogueClient, CatalogueError, logger
 from .graphql_helpers import (
     parse_columns,
+    parse_created_and_modified,
     parse_domain,
     parse_owner,
     parse_properties,
@@ -665,6 +666,7 @@ class DataHubCatalogueClient(BaseCatalogueClient):
             owner, owner_email = parse_owner(response)
             tags = parse_tags(response)
             name = properties["name"]
+            created, modified = parse_created_and_modified(properties)
 
             # A dataset can't have both a container and data product parent, but if we did
             # start to use in that we'd need to change this
@@ -685,9 +687,10 @@ class DataHubCatalogueClient(BaseCatalogueClient):
                 relationships=relations,
                 domain=domain["domain_name"],
                 tags=tags,
-                last_updated=None,  # we are not populating this and i think wouldn't refer to lastIngested
                 owner=owner,
                 owner_email=owner_email,
+                first_created=created,
+                last_updated=modified,
             )
         except GraphError as e:
             raise Exception("Unable to execute getDataset query") from e

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/getDatasetDetails.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/getDatasetDetails.graphql
@@ -3,6 +3,7 @@ query getDatasetDetails($urn: String!) {
     platform {
       name
     }
+    name # Deprecated - prefer properties.name
     domain {
       domain {
         urn
@@ -16,12 +17,8 @@ query getDatasetDetails($urn: String!) {
     subTypes {
       typeNames
     }
-    container_relations:relationships(
-      input: {
-        types: ["IsPartOf"]
-        direction: OUTGOING
-        count: 10
-      }
+    container_relations: relationships(
+      input: { types: ["IsPartOf"], direction: OUTGOING, count: 10 }
     ) {
       total
       relationships {
@@ -35,12 +32,8 @@ query getDatasetDetails($urn: String!) {
         }
       }
     }
-    data_product_relations:relationships(
-      input: {
-        types: ["DataProductContains"]
-        direction: INCOMING
-        count: 10
-      }
+    data_product_relations: relationships(
+      input: { types: ["DataProductContains"], direction: INCOMING, count: 10 }
     ) {
       total
       relationships {

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql_helpers.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql_helpers.py
@@ -35,7 +35,6 @@ def parse_last_updated(entity: dict[str, Any]) -> datetime | None:
 def parse_created_and_modified(
     properties: dict[str, Any]
 ) -> Tuple[datetime | None, datetime | None]:
-
     created = properties.get("created")
     modified = properties.get("lastModified")
 

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql_helpers.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql_helpers.py
@@ -127,7 +127,7 @@ def parse_columns(entity: dict[str, Any]) -> list[dict[str, Any]]:
             {
                 "name": field["fieldPath"],
                 "description": field["description"],
-                "type": field["type"],
+                "type": field.get("nativeDataType", field["type"]),
                 "nullable": field["nullable"],
                 "isPrimaryKey": is_primary_key,
                 "foreignKeys": foreign_keys_for_field,

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql_helpers.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql_helpers.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Tuple
 
 from data_platform_catalogue.entities import RelatedEntity, RelationshipType
@@ -29,7 +29,22 @@ def parse_last_updated(entity: dict[str, Any]) -> datetime | None:
     timestamp = entity.get("lastIngested")
     if timestamp is None:
         return None
-    return datetime.utcfromtimestamp(timestamp / 1000)
+    return datetime.fromtimestamp(timestamp / 1000, timezone.utc)
+
+
+def parse_created_and_modified(
+    properties: dict[str, Any]
+) -> Tuple[datetime | None, datetime | None]:
+
+    created = properties.get("created")
+    modified = properties.get("lastModified")
+
+    if created is not None:
+        created = datetime.fromtimestamp(created / 1000, timezone.utc)
+    if modified is not None:
+        modified = datetime.fromtimestamp(modified / 1000, timezone.utc)
+
+    return created, modified
 
 
 def parse_tags(entity: dict[str, Any]) -> list[str]:

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -17,6 +17,7 @@ from ...search_types import (
     SortOption,
 )
 from .graphql_helpers import (
+    parse_created_and_modified,
     parse_domain,
     parse_last_updated,
     parse_owner,
@@ -288,6 +289,8 @@ class SearchClient:
 
         fqn = self._get_fully_qualified_name(properties, name)
 
+        created, modified = parse_created_and_modified(properties)
+
         return SearchResult(
             id=entity["urn"],
             result_type=ResultType.TABLE,
@@ -297,7 +300,8 @@ class SearchClient:
             description=properties.get("description", ""),
             metadata=metadata,
             tags=tags,
-            last_updated=last_updated,
+            last_updated=modified or last_updated,
+            first_created=created,
         )
 
     def _parse_data_product(self, entity: dict[str, Any], matches) -> SearchResult:

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
@@ -126,9 +126,10 @@ class TableMetadata:
     tags: list[str] = field(default_factory=list)
     major_version: int = 1
     row_count: int | None = None
-    last_updated: datetime | None = None
     owner: str = ""
     owner_email: str = ""
+    last_updated: datetime | None = None
+    first_created: datetime | None = None
 
     @staticmethod
     def from_data_product_schema_dict(

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
@@ -121,6 +121,7 @@ class TableMetadata:
     relationships: dict[RelationshipType, list[RelatedEntity]] | None = None
     source_dataset_name: str = ""
     where_to_access_dataset: str = ""
+    fully_qualified_name: str | None = None
     data_sensitivity_level: SecurityClassification = SecurityClassification.OFFICIAL
     tags: list[str] = field(default_factory=list)
     major_version: int = 1

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
@@ -60,6 +60,7 @@ class SearchResult:
     metadata: dict[str, Any] = field(default_factory=dict)
     tags: list[str] = field(default_factory=list)
     last_updated: datetime | None = None
+    first_created: datetime | None = None
 
 
 @dataclass

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.22.0"
+version = "0.23.0"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -303,6 +303,7 @@ class TestCatalogueClientWithDatahub:
                     "customProperties": [
                         {"key": "sensitivityLevel", "value": "OFFICIAL-SENSITIVE"}
                     ],
+                    "lastModified": 1709619407814,
                 },
                 "editableProperties": None,
                 "tags": {
@@ -398,6 +399,7 @@ class TestCatalogueClientWithDatahub:
                 ]
             },
             domain="",
+            last_updated=datetime(2024, 3, 5, 6, 16, 47, 814000, tzinfo=timezone.utc),
         )
 
     def test_get_chart_details(self, datahub_client, base_mock_graph):

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -402,6 +402,44 @@ class TestCatalogueClientWithDatahub:
             last_updated=datetime(2024, 3, 5, 6, 16, 47, 814000, tzinfo=timezone.utc),
         )
 
+    def test_get_dataset_minimal_properties(
+        self,
+        datahub_client,
+        base_mock_graph,
+    ):
+        urn = "abc"
+        datahub_response = {
+            "dataset": {
+                "platform": {"name": "datahub"},
+                "name": "notinproperties",
+                "properties": {},
+                "container_relations": {
+                    "total": 0,
+                },
+                "data_product_relations": {"total": 0, "relationships": []},
+                "schemaMetadata": {"fields": []},
+            }
+        }
+        base_mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+        dataset = datahub_client.get_table_details(urn)
+
+        assert dataset == TableMetadata(
+            name="notinproperties",
+            fully_qualified_name="notinproperties",
+            description="",
+            column_details=[],
+            retention_period_in_days=None,
+            source_dataset_name="",
+            where_to_access_dataset="",
+            data_sensitivity_level=SecurityClassification.OFFICIAL,
+            tags=[],
+            major_version=1,
+            relationships={},
+            domain="",
+            last_updated=None,
+        )
+
     def test_get_chart_details(self, datahub_client, base_mock_graph):
         urn = "urn:li:chart:(justice-data,absconds)"
         datahub_response = {

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -364,7 +364,7 @@ class TestCatalogueClientWithDatahub:
             column_details=[
                 {
                     "name": "urn",
-                    "type": "STRING",
+                    "type": "string",
                     "description": "The primary identifier for the dataset entity.",
                     "isPrimaryKey": True,
                     "foreignKeys": [],
@@ -372,7 +372,7 @@ class TestCatalogueClientWithDatahub:
                 },
                 {
                     "name": "upstreamLineage",
-                    "type": "STRUCT",
+                    "type": "upstreamLineage",
                     "description": "Upstream lineage of a dataset",
                     "foreignKeys": [
                         {

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -300,10 +300,20 @@ class TestCatalogueClientWithDatahub:
                     "name": "Dataset",
                     "qualifiedName": None,
                     "description": "Dataset",
+                    "customProperties": [
+                        {"key": "sensitivityLevel", "value": "OFFICIAL-SENSITIVE"}
+                    ],
                 },
                 "editableProperties": None,
                 "tags": {
-                    "tags": [{"tag": {"urn": "urn:li:tag:Entity", "properties": None}}]
+                    "tags": [
+                        {
+                            "tag": {
+                                "urn": "urn:li:tag:Entity",
+                                "properties": {"name": "some-tag"},
+                            }
+                        }
+                    ]
                 },
                 "lastIngested": 1709619407814,
                 "domain": None,
@@ -379,7 +389,7 @@ class TestCatalogueClientWithDatahub:
             source_dataset_name="",
             where_to_access_dataset="",
             data_sensitivity_level=SecurityClassification.OFFICIAL,
-            tags=[],
+            tags=["some-tag"],
             major_version=1,
             relationships={
                 RelationshipType.PARENT: [

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -298,7 +298,7 @@ class TestCatalogueClientWithDatahub:
                 "name": "Dataset",
                 "properties": {
                     "name": "Dataset",
-                    "qualifiedName": None,
+                    "qualifiedName": "Foo.Dataset",
                     "description": "Dataset",
                     "customProperties": [
                         {"key": "sensitivityLevel", "value": "OFFICIAL-SENSITIVE"}
@@ -361,6 +361,7 @@ class TestCatalogueClientWithDatahub:
         assert dataset == TableMetadata(
             name="Dataset",
             description="Dataset",
+            fully_qualified_name="Foo.Dataset",
             column_details=[
                 {
                     "name": "urn",

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_graphql_helpers.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_graphql_helpers.py
@@ -48,7 +48,7 @@ def test_parse_columns_with_primary_key_and_foreign_key():
     assert parse_columns(entity) == [
         {
             "name": "urn",
-            "type": "STRING",
+            "type": "string",
             "isPrimaryKey": True,
             "foreignKeys": [],
             "nullable": False,
@@ -56,7 +56,7 @@ def test_parse_columns_with_primary_key_and_foreign_key():
         },
         {
             "name": "[version=2.0].[type=dataset].[type=UpstreamLineage].upstreamLineage",
-            "type": "STRUCT",
+            "type": "upstreamLineage",
             "description": "Upstream lineage of a dataset",
             "nullable": False,
             "isPrimaryKey": False,
@@ -100,7 +100,7 @@ def test_parse_columns_with_no_keys():
     assert parse_columns(entity) == [
         {
             "name": "[version=2.0].[type=dataset].[type=UpstreamLineage].upstreamLineage",
-            "type": "STRUCT",
+            "type": "upstreamLineage",
             "description": "Upstream lineage of a dataset",
             "nullable": False,
             "isPrimaryKey": False,
@@ -108,7 +108,7 @@ def test_parse_columns_with_no_keys():
         },
         {
             "name": "urn",
-            "type": "STRING",
+            "type": "string",
             "isPrimaryKey": False,
             "foreignKeys": [],
             "nullable": False,

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_graphql_helpers.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_graphql_helpers.py
@@ -1,5 +1,8 @@
+from datetime import datetime, timezone
+
 from data_platform_catalogue.client.datahub.graphql_helpers import (
     parse_columns,
+    parse_created_and_modified,
     parse_relations,
 )
 from data_platform_catalogue.entities import RelatedEntity, RelationshipType
@@ -150,3 +153,12 @@ def test_parse_relations_blank():
     relations = {"relationships": {"total": 0, "relationships": []}}
     result = parse_relations(RelationshipType.PARENT, relations["relationships"])
     assert result == {RelationshipType.PARENT: []}
+
+
+def test_parse_created_and_modified():
+    properties = {"created": 1710426920000, "lastModified": 1710426921000}
+
+    created, modified = parse_created_and_modified(properties)
+
+    assert created == datetime(2024, 3, 14, 14, 35, 20, tzinfo=timezone.utc)
+    assert modified == datetime(2024, 3, 14, 14, 35, 21, tzinfo=timezone.utc)

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_search.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_search.py
@@ -1,4 +1,4 @@
-from datetime import datetime
+from datetime import datetime, timezone
 from unittest.mock import MagicMock
 
 import pytest
@@ -266,7 +266,9 @@ def test_full_page(mock_graph, searcher):
                     },
                 },
                 tags=[],
-                last_updated=datetime(2024, 1, 23, 6, 15, 2, 353000),
+                last_updated=datetime(
+                    2024, 1, 23, 6, 15, 2, 353000, tzinfo=timezone.utc
+                ),
             ),
             SearchResult(
                 id="urn:li:dataset:(urn:li:dataPlatform:bigquery,calm-pagoda-323403.jaffle_shop.customers2,PROD)",


### PR DESCRIPTION
I noticed a few bits of metadata are not being passed through to the frontend correctly, so we render some missing values on the details page. This PR adds those in.

We are still missing some attributes we've previously defined like `source_dataset`, `where_to_access_dataset`, but we don't have that in the catalogue yet, so we'll have to handle that in another ticket (either populating or removing these fields).

### Added

- Return `qualifiedName` and `tags` for datasets if available

### Changed

- Use timezone aware timestamps when returning last updated values, and source
  the information from `lastModified` in Datahub, not `lastIngested`.
- Prefer native data types to Datahub's type when returning schemas for datasets

