### PR TITLE
Removing PenTester from cluster-masters.

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/data.tf
+++ b/terraform/aws/analytical-platform-development/cluster/data.tf
@@ -32,11 +32,6 @@ data "aws_iam_roles" "aws_sso_administrator_access" {
   path_prefix = "/aws-reserved/sso.amazonaws.com/"
 }
 
-data "aws_iam_roles" "aws_pentester_access" {
-  name_regex  = "PenTester"
-  path_prefix = "/"
-}
-
 data "aws_secretsmanager_secret_version" "auth0_credentials" {
   secret_id = "${var.environment}/auth0-terraform/auth0-creds"
 }

--- a/terraform/aws/analytical-platform-development/cluster/eks-cluster.tf
+++ b/terraform/aws/analytical-platform-development/cluster/eks-cluster.tf
@@ -37,10 +37,6 @@ module "eks" {
         "system:bootstrappers",
         "system:nodes",
       ]
-      }, {
-      groups   = ["system:masters"]
-      username = "restricted-admin"
-      rolearn  = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${one(data.aws_iam_roles.aws_pentester_access.names)}"
     }],
     var.eks_role_mappings
   )


### PR DESCRIPTION
As part of this story #3700, removing PenTester role as a cluster-master for the dev cluster.