### PR TITLE
update HMCTS github role to allow access to athena query results

### DIFF
--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/airflow-hmcts-sdp-load/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/airflow-hmcts-sdp-load/iam-policies.tf
@@ -20,7 +20,8 @@ data "aws_iam_policy_document" "airflow_hmcts_sdp_load" {
       "s3:PutObject"
     ]
     resources = [
-      "arn:aws:s3:::aws-athena-query-results-684969100054-eu-west-1"
+      "arn:aws:s3:::aws-athena-query-results-684969100054-eu-west-1",
+      "arn:aws:s3:::aws-athena-query-results-684969100054-eu-west-1/*"
     ]
   }
   #tfsec:ignore:avd-aws-0057:needs to access multiple resources


### PR DESCRIPTION
Amend access to sandbox s3 bucket `aws-athena-query-results-684969100054-eu-west-1` to allow get and put operations on any object - this is necessary for the role performing end-to-end test for hmcts pipeline