### PR TITLE
Dc 175 add upsert athena methods

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `entities.TableMetadata` to have some optional properties to the class -
   `parent_database_name`, `domain`, `row_count`
+- `entities.SecurityClassification` to remove classicifation we will not be using.
 
 ## [0.19.2] 2024-03-07
 

--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,6 +7,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.20.0] 2024-03-15
+
+### Added
+
+- `upsert_athena_database` and `upsert_athena_table` methods to
+  `DataHubCatalogueClient` - to register/update databases or tables in
+  datahub. These methods do not create a domain if it does not exist.
+- `DatabaseMetadata` class to `entities.py` - for defining metadata for an
+  athena database
+  `DatabaseStatus` enum to `entities.py`
+- 2 custom exceptions in `datahub_client.py` for invalid domains and missing metadata.
+
+### Changed
+
+- `entities.TableMetadata` to have some optional properties to the class -
+  `parent_database_name`, `domain`, `row_count`
+
 ## [0.19.2] 2024-03-07
 
 ### Added

--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   datahub. These methods do not create a domain if it does not exist.
 - `DatabaseMetadata` class to `entities.py` - for defining metadata for an
   athena database
-  `DatabaseStatus` enum to `entities.py`
+- `DatabaseStatus` enum to `entities.py`
 - 2 custom exceptions in `datahub_client.py` for invalid domains and missing metadata.
 
 ### Changed

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/__init__.py
@@ -1,3 +1,8 @@
 from .client import CatalogueError, ReferencedEntityMissing  # noqa: F401
-from .entities import DataProductMetadata  # noqa: F401
-from .entities import CatalogueMetadata, DataLocation, TableMetadata  # noqa: F401
+from .entities import (  # noqa: F401
+    CatalogueMetadata,
+    DatabaseMetadata,
+    DataLocation,
+    DataProductMetadata,
+    TableMetadata,
+)

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -201,29 +201,17 @@ class DataHubCatalogueClient(BaseCatalogueClient):
                 f"{domain} does not exist in datahub - please align data to an existing domain"
             )
 
-        subdomain_urn = None
-        if metadata.subdomain:
-            subdomain = metadata_dict.pop("subdomain")
-            subdomain_urn = self.graph.get_domain_urn_by_name(domain_name=subdomain)
+        database_domain = DomainsClass(domains=[domain_urn])
 
-            if subdomain_urn is None:
-                logger.info(f"creating new subdomain {domain} for {name}")
-                domain_urn = self.create_domain(
-                    domain=subdomain, parentDomain=domain_urn
-                )
-
-        database_domain = DomainsClass(
-            domains=[subdomain_urn if subdomain_urn else domain_urn]
-        )
-
-        metadata_event = MetadataChangeProposalWrapper(
-            entityType="container",
-            changeType=ChangeTypeClass.UPSERT,
-            entityUrn=database_urn,
-            aspect=database_domain,
-        )
-        self.graph.emit(metadata_event)
-        logger.info(f"Database {name} associated with domain {domain}")
+        if domain_urn is not None:
+            metadata_event = MetadataChangeProposalWrapper(
+                entityType="container",
+                changeType=ChangeTypeClass.UPSERT,
+                entityUrn=database_urn,
+                aspect=database_domain,
+            )
+            self.graph.emit(metadata_event)
+            logger.info(f"Database {name} associated with domain {domain}")
 
         database_properties = ContainerPropertiesClass(
             customProperties={key: str(val) for key, val in metadata_dict.items()},
@@ -664,3 +652,6 @@ class DataHubCatalogueClient(BaseCatalogueClient):
             )
         except GraphError as e:
             raise Exception("Unable to execute getDataset query") from e
+
+    def _does_domain_exist(domain_name: str) -> bool:
+        pass

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -30,6 +30,7 @@ from datahub.metadata.schema_classes import (
 
 from ...entities import (
     CatalogueMetadata,
+    DatabaseMetadata,
     DataLocation,
     DataProductMetadata,
     TableMetadata,
@@ -174,7 +175,7 @@ class DataHubCatalogueClient(BaseCatalogueClient):
 
         return domain_urn
 
-    def upsert_athena_database(self, metadata: DataProductMetadata) -> str:
+    def upsert_athena_database(self, metadata: DatabaseMetadata) -> str:
         """
         Define a database. Must belong to a domain
         """

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -260,7 +260,7 @@ class DataHubCatalogueClient(BaseCatalogueClient):
         dataset_urn = mce_builder.make_dataset_urn(
             platform="athena", name=fully_qualified_name, env="PROD"
         )
-
+        # jscpd:ignore-start
         dataset_properties = DatasetPropertiesClass(
             name=metadata.name,
             qualifiedName=fully_qualified_name,
@@ -329,6 +329,7 @@ class DataHubCatalogueClient(BaseCatalogueClient):
                 aspect=tags_to_add,
             )
             self.graph.emit(event)
+        # jscpd:ignore-end
 
         database_urn = "urn:li:container:" + "".join(
             metadata.parent_database_name.split()
@@ -367,7 +368,7 @@ class DataHubCatalogueClient(BaseCatalogueClient):
             raise InvalidDomain(
                 f"{metadata.domain} does not exist in datahub - please align data to an existing domain"
             )
-        # domain_urn = f"urn:li:domain:{metadata.domain}"
+
         if domain_urn is not None:
             table_domain = DomainsClass(domains=[domain_urn])
             metadata_event = MetadataChangeProposalWrapper(
@@ -652,6 +653,3 @@ class DataHubCatalogueClient(BaseCatalogueClient):
             )
         except GraphError as e:
             raise Exception("Unable to execute getDataset query") from e
-
-    def _does_domain_exist(domain_name: str) -> bool:
-        pass

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -72,7 +72,8 @@ class InvalidDomain(Exception):
 
 class MissingDatabaseMetadata(Exception):
     """
-    Exception thrown when a database is attempted to be ingested without a given metadata specification
+    Exception thrown when a database is attempted to be ingested without
+    a given metadata specification
     """
 
 
@@ -261,7 +262,7 @@ class DataHubCatalogueClient(BaseCatalogueClient):
     def upsert_athena_table(
         self,
         metadata: TableMetadata,
-        database_metadata: DataProductMetadata | None = None,
+        database_metadata: DatabaseMetadata | None = None,
     ) -> str:
         if not metadata.parent_database_name:
             raise ValueError("parent_database_name needs to be set in TableMetadata")

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/datahub_client.py
@@ -7,8 +7,15 @@ from datahub.configuration.common import GraphError
 from datahub.emitter.mce_builder import make_data_platform_urn
 from datahub.emitter.mcp import MetadataChangeProposalWrapper
 from datahub.ingestion.graph.client import DatahubClientConfig, DataHubGraph
+from datahub.ingestion.source.common.subtypes import (
+    DatasetContainerSubTypes,
+    DatasetSubTypes,
+)
+from datahub.metadata.com.linkedin.pegasus2avro.common import DataPlatformInstance
 from datahub.metadata.schema_classes import (
     ChangeTypeClass,
+    ContainerClass,
+    ContainerPropertiesClass,
     DataProductAssociationClass,
     DataProductPropertiesClass,
     DatasetPropertiesClass,
@@ -18,6 +25,7 @@ from datahub.metadata.schema_classes import (
     SchemaFieldClass,
     SchemaFieldDataTypeClass,
     SchemaMetadataClass,
+    SubTypesClass,
 )
 
 from ...entities import (
@@ -53,6 +61,18 @@ DATAHUB_DATA_TYPE_MAPPING = {
     "date": schema_classes.DateTypeClass(),
     "timestamp": schema_classes.TimeTypeClass(),
 }
+
+
+class InvalidDomain(Exception):
+    """
+    Exception thrown when a domain does not exist
+    """
+
+
+class MissingDatabaseMetadata(Exception):
+    """
+    Exception thrown when a database is attempted to be ingested without a given metadata specification
+    """
 
 
 class DataHubCatalogueClient(BaseCatalogueClient):
@@ -96,6 +116,14 @@ class DataHubCatalogueClient(BaseCatalogueClient):
             .joinpath("getDatasetDetails.graphql")
             .read_text()
         )
+
+    def check_entity_exists_by_urn(self, urn: str | None):
+        if urn is not None:
+            exists = self.graph.exists(entity_urn=urn)
+        else:
+            exists = False
+
+        return exists
 
     def upsert_database_service(self, platform: str = "glue", *args, **kwargs) -> str:
         """
@@ -145,6 +173,223 @@ class DataHubCatalogueClient(BaseCatalogueClient):
         self.graph.emit(metadata_event)
 
         return domain_urn
+
+    def upsert_athena_database(self, metadata: DataProductMetadata) -> str:
+        """
+        Define a database. Must belong to a domain
+        """
+        metadata_dict = dict(metadata.__dict__)
+        metadata_dict.pop("version")
+        metadata_dict.pop("owner")
+        metadata_dict.pop("tags")
+
+        name = metadata_dict.pop("name")
+        description = metadata_dict.pop("description")
+
+        database_urn = "urn:li:container:" + "".join(name.split())
+
+        domain = metadata_dict.pop("domain")
+        domain_urn = self.graph.get_domain_urn_by_name(domain_name=domain)
+
+        # domains are to be controlled and limited so we dont want to create one
+        # when it doesn't exist
+        domain_exists = self.check_entity_exists_by_urn(domain_urn)
+        if not domain_exists:
+            raise InvalidDomain(
+                f"{domain} does not exist in datahub - please align data to an existing domain"
+            )
+
+        subdomain_urn = None
+        if metadata.subdomain:
+            subdomain = metadata_dict.pop("subdomain")
+            subdomain_urn = self.graph.get_domain_urn_by_name(domain_name=subdomain)
+
+            if subdomain_urn is None:
+                logger.info(f"creating new subdomain {domain} for {name}")
+                domain_urn = self.create_domain(
+                    domain=subdomain, parentDomain=domain_urn
+                )
+
+        database_domain = DomainsClass(
+            domains=[subdomain_urn if subdomain_urn else domain_urn]
+        )
+
+        metadata_event = MetadataChangeProposalWrapper(
+            entityType="container",
+            changeType=ChangeTypeClass.UPSERT,
+            entityUrn=database_urn,
+            aspect=database_domain,
+        )
+        self.graph.emit(metadata_event)
+        logger.info(f"Database {name} associated with domain {domain}")
+
+        database_properties = ContainerPropertiesClass(
+            customProperties={key: str(val) for key, val in metadata_dict.items()},
+            description=description,
+            name=name,
+        )
+        metadata_event = MetadataChangeProposalWrapper(
+            entityType="container",
+            changeType=ChangeTypeClass.UPSERT,
+            entityUrn=database_urn,
+            aspect=database_properties,
+        )
+        self.graph.emit(metadata_event)
+        logger.info(f"Properties updated for Database {name} ")
+
+        # set platform to athena
+        metadata_event = MetadataChangeProposalWrapper(
+            entityUrn=database_urn,
+            aspect=DataPlatformInstance(
+                platform="urn:li:dataPlatform:athena",
+            ),
+        )
+        self.graph.emit(metadata_event)
+        logger.info(f"Platform updated for Database {name} ")
+
+        # container type update
+        metadata_event = MetadataChangeProposalWrapper(
+            entityUrn=database_urn,
+            aspect=SubTypesClass(typeNames=[DatasetContainerSubTypes.DATABASE]),
+        )
+        self.graph.emit(metadata_event)
+        logger.info(f"Type updated for Database {name} ")
+
+        return database_urn
+
+    def upsert_athena_table(
+        self,
+        metadata: TableMetadata,
+        database_metadata: DataProductMetadata | None = None,
+    ) -> str:
+        if not metadata.parent_database_name:
+            raise ValueError("parent_database_name needs to be set in TableMetadata")
+
+        fully_qualified_name = f"{metadata.parent_database_name}.{metadata.name}"
+
+        dataset_urn = mce_builder.make_dataset_urn(
+            platform="athena", name=fully_qualified_name, env="PROD"
+        )
+
+        dataset_properties = DatasetPropertiesClass(
+            name=metadata.name,
+            qualifiedName=fully_qualified_name,
+            description=metadata.description,
+            customProperties={
+                "sourceDatasetName": metadata.source_dataset_name,
+                "whereToAccessDataset": metadata.where_to_access_dataset,
+                "sensitivityLevel": metadata.data_sensitivity_level.name,
+                **(
+                    {"rowCount": str(metadata.row_count)}
+                    if metadata.row_count is not None
+                    else {}
+                ),
+            },
+        )
+
+        metadata_event = MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=dataset_properties,
+        )
+        self.graph.emit(metadata_event)
+
+        dataset_schema_properties = SchemaMetadataClass(
+            schemaName=metadata.name,
+            platform="urn:li:dataPlatform:athena",
+            version=metadata.major_version,
+            hash="",
+            platformSchema=OtherSchemaClass(rawSchema=""),
+            fields=[
+                SchemaFieldClass(
+                    fieldPath=f"{column['name']}",
+                    type=SchemaFieldDataTypeClass(
+                        type=DATAHUB_DATA_TYPE_MAPPING[column["type"]]
+                    ),
+                    nativeDataType=column["type"],
+                    description=column["description"],
+                )
+                for column in metadata.column_details
+            ],
+        )
+
+        metadata_event = MetadataChangeProposalWrapper(
+            entityType="dataset",
+            changeType=ChangeTypeClass.UPSERT,
+            entityUrn=dataset_urn,
+            aspect=dataset_schema_properties,
+        )
+        self.graph.emit(metadata_event)
+
+        # set dataset type to table
+        metadata_event = MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=SubTypesClass(typeNames=[DatasetSubTypes.TABLE]),
+        )
+
+        self.graph.emit(metadata_event)
+
+        if metadata.tags:
+            tags_to_add = mce_builder.make_global_tag_aspect_with_tag_list(
+                tags=metadata.tags
+            )
+            event: MetadataChangeProposalWrapper = MetadataChangeProposalWrapper(
+                entityType="dataset",
+                changeType=ChangeTypeClass.UPSERT,
+                entityUrn=dataset_urn,
+                aspect=tags_to_add,
+            )
+            self.graph.emit(event)
+
+        database_urn = "urn:li:container:" + "".join(
+            metadata.parent_database_name.split()
+        )
+
+        database_exists = self.check_entity_exists_by_urn(urn=database_urn)
+
+        if not database_exists and database_metadata:
+            database_urn = self.upsert_athena_database(metadata=database_metadata)
+            domain_urn = self.graph.get_domain_urn_by_name(
+                domain_name=database_metadata.domain
+            )
+        elif not database_exists and not database_metadata:
+            raise MissingDatabaseMetadata(
+                "DatabaseMetadata object needs to be passed in to create a database"
+            )
+
+        # add dataset to database
+        metadata_event = MetadataChangeProposalWrapper(
+            entityUrn=dataset_urn,
+            aspect=ContainerClass(container=database_urn),
+        )
+
+        self.graph.emit(metadata_event)
+
+        # add domain to table - tables inherit the domain of parent database if not given
+        if metadata.domain:
+            domain_urn = self.graph.get_domain_urn_by_name(domain_name=metadata.domain)
+        else:
+            domain_urn = self.graph.get_aspect(
+                entity_urn=database_urn, aspect_type=DomainsClass
+            ).domains[0]
+
+        domain_exists = self.check_entity_exists_by_urn(domain_urn)
+        if not domain_exists:
+            raise InvalidDomain(
+                f"{metadata.domain} does not exist in datahub - please align data to an existing domain"
+            )
+        # domain_urn = f"urn:li:domain:{metadata.domain}"
+        if domain_urn is not None:
+            table_domain = DomainsClass(domains=[domain_urn])
+            metadata_event = MetadataChangeProposalWrapper(
+                entityType="dataset",
+                changeType=ChangeTypeClass.UPSERT,
+                entityUrn=dataset_urn,
+                aspect=table_domain,
+            )
+
+            self.graph.emit(metadata_event)
+
+        return dataset_urn
 
     def upsert_data_product(self, metadata: DataProductMetadata):
         """

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
@@ -98,8 +98,6 @@ class DataProductMetadata:
 
 class SecurityClassification(Enum):
     OFFICIAL = auto()
-    SECRET = auto()
-    TOP_SECRET = auto()
 
 
 @dataclass

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
@@ -147,6 +147,7 @@ class TableMetadata:
         return new_metadata
 
 
+# jscpd:ignore-start
 @dataclass
 class DatabaseMetadata:
     """
@@ -172,3 +173,6 @@ class DatabaseMetadata:
     s3_location: str | None
     status: DataProductStatus = DataProductStatus.DRAFT
     tags: list[str] = field(default_factory=list)
+
+
+# jscpd:ignore-end

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
@@ -32,6 +32,12 @@ class DataProductStatus(Enum):
     RETIRED = auto()
 
 
+class DatabaseStatus(Enum):
+    PROD = auto()
+    PREPROD = auto()
+    DEV = auto()
+
+
 @dataclass
 class DataProductMetadata:
     name: str
@@ -102,11 +108,14 @@ class TableMetadata:
     description: str
     column_details: list
     retention_period_in_days: int | None
+    domain: str | None = None
+    parent_database_name: str | None = None
     source_dataset_name: str = ""
     where_to_access_dataset: str = ""
     data_sensitivity_level: SecurityClassification = SecurityClassification.OFFICIAL
     tags: list[str] = field(default_factory=list)
     major_version: int = 1
+    row_count: int | None = None
 
     @staticmethod
     def from_data_product_schema_dict(
@@ -136,3 +145,30 @@ class TableMetadata:
         )
 
         return new_metadata
+
+
+@dataclass
+class DatabaseMetadata:
+    """
+    For source system databases - currently matches DataProductMetadata
+    but will need to be revisted and refined potentially
+    """
+
+    name: str
+    description: str
+    version: str
+    owner: str
+    owner_display_name: str
+    maintainer: str | None
+    maintainer_display_name: str | None
+    email: str
+    retention_period_in_days: int
+    domain: str
+    subdomain: str | None
+    dpia_required: bool
+    dpia_location: str | None
+    last_updated: datetime
+    creation_date: datetime
+    s3_location: str | None
+    status: DataProductStatus = DataProductStatus.DRAFT
+    tags: list[str] = field(default_factory=list)

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.19.2"
+version = "0.20.0"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -442,3 +442,9 @@ class TestCatalogueClientWithDatahub:
     def test_domain_does_not_exist_error(self, datahub_client, database):
         with pytest.raises(InvalidDomain):
             datahub_client.upsert_athena_database(metadata=database)
+
+    def test_database_not_exist_with_no_metadata_given_error(
+        self, datahub_client, table
+    ):
+        with pytest.raises(MissingDatabaseMetadata):
+            datahub_client.upsert_athena_table(metadata=table)

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -18,10 +18,7 @@ from data_platform_catalogue.entities import (
     SecurityClassification,
     TableMetadata,
 )
-from datahub.metadata.schema_classes import (
-    ContainerPropertiesClass,
-    DataProductPropertiesClass,
-)
+from datahub.metadata.schema_classes import DataProductPropertiesClass
 
 
 class TestCatalogueClientWithDatahub:

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -1,18 +1,27 @@
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
-from data_platform_catalogue.client.datahub.datahub_client import DataHubCatalogueClient
+from data_platform_catalogue.client.datahub.datahub_client import (
+    DataHubCatalogueClient,
+    InvalidDomain,
+    MissingDatabaseMetadata,
+)
 from data_platform_catalogue.entities import (
     CatalogueMetadata,
+    DatabaseMetadata,
+    DatabaseStatus,
     DataLocation,
     DataProductMetadata,
     DataProductStatus,
     SecurityClassification,
     TableMetadata,
 )
-from datahub.metadata.schema_classes import DataProductPropertiesClass
+from datahub.metadata.schema_classes import (
+    ContainerPropertiesClass,
+    DataProductPropertiesClass,
+)
 
 
 class TestCatalogueClientWithDatahub:
@@ -54,6 +63,29 @@ class TestCatalogueClientWithDatahub:
         )
 
     @pytest.fixture
+    def database(self):
+        return DatabaseMetadata(
+            name="my_database",
+            description="little test db",
+            version="v1.0.0",
+            owner="2e1fa91a-c607-49e4-9be2-6f072ebe27c7",
+            owner_display_name="April Gonzalez",
+            maintainer="j.shelvey@digital.justice.gov.uk",
+            maintainer_display_name="Jonjo Shelvey",
+            email="justice@justice.gov.uk",
+            status=DatabaseStatus.PROD.name,
+            retention_period_in_days=365,
+            domain="LAA",
+            subdomain="Legal Aid",
+            dpia_required=False,
+            dpia_location=None,
+            last_updated=datetime(2020, 5, 17),
+            creation_date=datetime(2020, 5, 17),
+            s3_location="s3://databucket/",
+            tags=["test"],
+        )
+
+    @pytest.fixture
     def table(self):
         return TableMetadata(
             name="my_table",
@@ -65,7 +97,9 @@ class TestCatalogueClientWithDatahub:
             retention_period_in_days=365,
             source_dataset_name="my_source_table",
             where_to_access_dataset="s3://databucket/table1",
-            data_sensitivity_level=SecurityClassification.TOP_SECRET,
+            data_sensitivity_level=SecurityClassification.OFFICIAL,
+            parent_database_name="my_database",
+            domain="LAA",
         )
 
     @pytest.fixture
@@ -90,9 +124,15 @@ class TestCatalogueClientWithDatahub:
         )
 
     @pytest.fixture
-    def golden_file_in(self):
+    def golden_file_in_dp(self):
         return Path(
             Path(__file__).parent / "../../test_resources/golden_data_product_in.json"
+        )
+
+    @pytest.fixture
+    def golden_file_in_db(self):
+        return Path(
+            Path(__file__).parent / "../../test_resources/golden_database_in.json"
         )
 
     def test_create_table_datahub(
@@ -102,13 +142,13 @@ class TestCatalogueClientWithDatahub:
         table,
         tmp_path,
         check_snapshot,
-        golden_file_in,
+        golden_file_in_dp,
     ):
         """
         Case where we just create a dataset (no data product)
         """
         mock_graph = base_mock_graph
-        mock_graph.import_file(golden_file_in)
+        mock_graph.import_file(golden_file_in_dp)
 
         fqn = datahub_client.upsert_table(
             metadata=table,
@@ -130,13 +170,13 @@ class TestCatalogueClientWithDatahub:
         base_mock_graph,
         tmp_path,
         check_snapshot,
-        golden_file_in,
+        golden_file_in_dp,
     ):
         """
         Case where we create a dataset, data product and domain
         """
         mock_graph = base_mock_graph
-        mock_graph.import_file(golden_file_in)
+        mock_graph.import_file(golden_file_in_dp)
 
         fqn = datahub_client.upsert_table(
             metadata=table,
@@ -166,14 +206,14 @@ class TestCatalogueClientWithDatahub:
         base_mock_graph,
         tmp_path,
         check_snapshot,
-        golden_file_in,
+        golden_file_in_dp,
     ):
         """
         Case where we create a dataset, data product and domain
         """
 
         mock_graph = base_mock_graph
-        mock_graph.import_file(golden_file_in)
+        mock_graph.import_file(golden_file_in_dp)
 
         fqn = datahub_client.upsert_table(
             metadata=table,
@@ -205,13 +245,13 @@ class TestCatalogueClientWithDatahub:
         base_mock_graph,
         tmp_path,
         check_snapshot,
-        golden_file_in,
+        golden_file_in_dp,
     ):
         """
         `create_table` should work even if the entities already exist in the metadata graph.
         """
         mock_graph = base_mock_graph
-        mock_graph.import_file(golden_file_in)
+        mock_graph.import_file(golden_file_in_dp)
 
         datahub_client.upsert_table(
             metadata=table,
@@ -329,3 +369,76 @@ class TestCatalogueClientWithDatahub:
             tags=[],
             major_version=1,
         )
+
+    def test_create_athena_database_and_table(
+        self,
+        datahub_client,
+        base_mock_graph,
+        database,
+        table,
+        tmp_path,
+        check_snapshot,
+        golden_file_in_db,
+    ):
+        """
+        Case where we create separate database and table
+        """
+        mock_graph = base_mock_graph
+        mock_graph.import_file(golden_file_in_db)
+        with patch(
+            "data_platform_catalogue.client.datahub.datahub_client.DataHubCatalogueClient.check_entity_exists_by_urn"
+        ) as mock_exists:
+            mock_exists.return_value = True
+            fqn_db = datahub_client.upsert_athena_database(metadata=database)
+            fqn_t = datahub_client.upsert_athena_table(metadata=table)
+
+        fqn_db_out = "urn:li:container:my_database"
+        assert fqn_db == fqn_db_out
+
+        fqn_t_out = (
+            "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)"
+        )
+        assert fqn_t == fqn_t_out
+
+        output_file = Path(tmp_path / "datahub_create_athena_table.json")
+        base_mock_graph.sink_to_file(output_file)
+        check_snapshot("datahub_create_athena_table.json", output_file)
+
+    def test_create_athena_table_with_metadata(
+        self,
+        datahub_client,
+        table,
+        database,
+        base_mock_graph,
+        tmp_path,
+        check_snapshot,
+        golden_file_in_db,
+    ):
+        """
+        Case where we create a dataset (athena table) and container (athena database)
+        via upsert_athena_table method
+        """
+        mock_graph = base_mock_graph
+        mock_graph.import_file(golden_file_in_db)
+
+        with patch(
+            "data_platform_catalogue.client.datahub.datahub_client.DataHubCatalogueClient.check_entity_exists_by_urn"
+        ) as mock_exists:
+            mock_exists.return_value = True
+            fqn = datahub_client.upsert_athena_table(
+                metadata=table,
+                database_metadata=database,
+            )
+        fqn_out = (
+            "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)"
+        )
+
+        assert fqn == fqn_out
+
+        output_file = Path(tmp_path / "datahub_create_athena_table_with_metadata.json")
+        base_mock_graph.sink_to_file(output_file)
+        check_snapshot("datahub_create_athena_table_with_metadata.json", output_file)
+
+    def test_domain_does_not_exist_error(self, datahub_client, database):
+        with pytest.raises(InvalidDomain):
+            datahub_client.upsert_athena_database(metadata=database)

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_athena_table.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_athena_table.json
@@ -1,0 +1,174 @@
+[
+{
+    "entityType": "domain",
+    "entityUrn": "urn:li:domain:Legal Aid",
+    "changeType": "UPSERT",
+    "aspectName": "domainProperties",
+    "aspect": {
+        "json": {
+            "name": "Legal Aid",
+            "description": ""
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:my_database",
+    "changeType": "UPSERT",
+    "aspectName": "domains",
+    "aspect": {
+        "json": {
+            "domains": [
+                "urn:li:domain:Legal Aid"
+            ]
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:my_database",
+    "changeType": "UPSERT",
+    "aspectName": "containerProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "owner_display_name": "April Gonzalez",
+                "maintainer": "j.shelvey@digital.justice.gov.uk",
+                "maintainer_display_name": "Jonjo Shelvey",
+                "email": "justice@justice.gov.uk",
+                "retention_period_in_days": "365",
+                "dpia_required": "False",
+                "dpia_location": "None",
+                "last_updated": "2020-05-17 00:00:00",
+                "creation_date": "2020-05-17 00:00:00",
+                "s3_location": "s3://databucket/",
+                "status": "PROD"
+            },
+            "name": "my_database",
+            "description": "little test db"
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:my_database",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Database"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "datasetProperties",
+    "aspect": {
+        "json": {
+            "customProperties": {
+                "sourceDatasetName": "my_source_table",
+                "whereToAccessDataset": "s3://databucket/table1",
+                "sensitivityLevel": "OFFICIAL"
+            },
+            "name": "my_table",
+            "qualifiedName": "my_database.my_table",
+            "description": "bla bla",
+            "tags": []
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "schemaMetadata",
+    "aspect": {
+        "json": {
+            "schemaName": "my_table",
+            "platform": "urn:li:dataPlatform:athena",
+            "version": 1,
+            "created": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "lastModified": {
+                "time": 0,
+                "actor": "urn:li:corpuser:unknown"
+            },
+            "hash": "",
+            "platformSchema": {
+                "com.linkedin.schema.OtherSchema": {
+                    "rawSchema": ""
+                }
+            },
+            "fields": [
+                {
+                    "fieldPath": "foo",
+                    "nullable": false,
+                    "description": "a",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.StringType": {}
+                        }
+                    },
+                    "nativeDataType": "string",
+                    "recursive": false,
+                    "isPartOfKey": false
+                },
+                {
+                    "fieldPath": "bar",
+                    "nullable": false,
+                    "description": "b",
+                    "type": {
+                        "type": {
+                            "com.linkedin.schema.NumberType": {}
+                        }
+                    },
+                    "nativeDataType": "int",
+                    "recursive": false,
+                    "isPartOfKey": false
+                }
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    }
+},
+{
+    "entityType": "container",
+    "entityUrn": "urn:li:container:my_database",
+    "changeType": "UPSERT",
+    "aspectName": "dataPlatformInstance",
+    "aspect": {
+        "json": {
+            "platform": "urn:li:dataPlatform:athena"
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:my_database"
+        }
+    }
+}
+]

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_athena_table.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_athena_table.json
@@ -1,30 +1,5 @@
 [
 {
-    "entityType": "domain",
-    "entityUrn": "urn:li:domain:Legal Aid",
-    "changeType": "UPSERT",
-    "aspectName": "domainProperties",
-    "aspect": {
-        "json": {
-            "name": "Legal Aid",
-            "description": ""
-        }
-    }
-},
-{
-    "entityType": "container",
-    "entityUrn": "urn:li:container:my_database",
-    "changeType": "UPSERT",
-    "aspectName": "domains",
-    "aspect": {
-        "json": {
-            "domains": [
-                "urn:li:domain:Legal Aid"
-            ]
-        }
-    }
-},
-{
     "entityType": "container",
     "entityUrn": "urn:li:container:my_database",
     "changeType": "UPSERT",
@@ -37,6 +12,7 @@
                 "maintainer_display_name": "Jonjo Shelvey",
                 "email": "justice@justice.gov.uk",
                 "retention_period_in_days": "365",
+                "subdomain": "Legal Aid",
                 "dpia_required": "False",
                 "dpia_location": "None",
                 "last_updated": "2020-05-17 00:00:00",

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_athena_table_with_metadata.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_athena_table_with_metadata.json
@@ -1,7 +1,7 @@
 [
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_database.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "datasetProperties",
     "aspect": {
@@ -9,8 +9,7 @@
             "customProperties": {
                 "sourceDatasetName": "my_source_table",
                 "whereToAccessDataset": "s3://databucket/table1",
-                "sensitivityLevel": "OFFICIAL",
-                "rowCount": "1177"
+                "sensitivityLevel": "OFFICIAL"
             },
             "name": "my_table",
             "qualifiedName": "my_database.my_table",
@@ -21,13 +20,13 @@
 },
 {
     "entityType": "dataset",
-    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:glue,my_database.my_table,PROD)",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)",
     "changeType": "UPSERT",
     "aspectName": "schemaMetadata",
     "aspect": {
         "json": {
             "schemaName": "my_table",
-            "platform": "urn:li:dataPlatform:glue",
+            "platform": "urn:li:dataPlatform:athena",
             "version": 1,
             "created": {
                 "time": 0,
@@ -71,6 +70,30 @@
                     "isPartOfKey": false
                 }
             ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "subTypes",
+    "aspect": {
+        "json": {
+            "typeNames": [
+                "Table"
+            ]
+        }
+    }
+},
+{
+    "entityType": "dataset",
+    "entityUrn": "urn:li:dataset:(urn:li:dataPlatform:athena,my_database.my_table,PROD)",
+    "changeType": "UPSERT",
+    "aspectName": "container",
+    "aspect": {
+        "json": {
+            "container": "urn:li:container:my_database"
         }
     }
 }

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table_with_metadata.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_table_with_metadata.json
@@ -9,7 +9,7 @@
             "customProperties": {
                 "sourceDatasetName": "my_source_table",
                 "whereToAccessDataset": "s3://databucket/table1",
-                "sensitivityLevel": "TOP_SECRET",
+                "sensitivityLevel": "OFFICIAL",
                 "rowCount": "1177"
             },
             "name": "my_table",

--- a/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_two_tables_with_metadata.json
+++ b/python-libraries/data-platform-catalogue/tests/snapshots/datahub_create_two_tables_with_metadata.json
@@ -9,7 +9,7 @@
             "customProperties": {
                 "sourceDatasetName": "my_source_table",
                 "whereToAccessDataset": "s3://databucket/table1",
-                "sensitivityLevel": "TOP_SECRET",
+                "sensitivityLevel": "OFFICIAL",
                 "rowCount": "1177"
             },
             "name": "my_table",

--- a/python-libraries/data-platform-catalogue/tests/test_resources/golden_database_in.json
+++ b/python-libraries/data-platform-catalogue/tests/test_resources/golden_database_in.json
@@ -1,0 +1,59 @@
+[
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "containerProperties",
+        "aspect": {
+            "json": {
+                "customProperties": {
+                    "version": "2.0",
+                    "dpia": "false"
+                },
+                "externalUrl": "https://github.com/datahub-project/datahub",
+                "name": "my_database",
+                "description": "little test db",
+                "assets": []
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "domains",
+        "aspect": {
+            "json": {
+                "domains": [
+                    "urn:li:domain:LAA"
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "globalTags",
+        "aspect": {
+            "json": {
+                "tags": [
+                    {
+                        "tag": "urn:li:tag:awesome"
+                    }
+                ]
+            }
+        }
+    },
+    {
+        "entityType": "container",
+        "entityUrn": "urn:li:container:my_database",
+        "changeType": "UPSERT",
+        "aspectName": "status",
+        "aspect": {
+            "json": {
+                "removed": false
+            }
+        }
+    }
+]


### PR DESCRIPTION
This PR adds two new upsert methods to the python datahub client to ingest metadata (in an expected format) as Athena databases and tables. 

Is part of the worked needed for https://github.com/ministryofjustice/find-moj-data/issues/175

### This PR adds
- `upsert_athena_database` and `upsert_athena_table` methods to `DataHubCatalogueClient` - to register/update databases or tables in datahub. These methods do not create a domain if it does not exist as we want doains to be a controlled entity.
- `DatabaseMetadata` class to `entities.py` - for defining metadata for an  athena database 
- `DatabaseStatus` enum to `entities.py`
- 2 custom exceptions in `datahub_client.py` for invalid domains and missing metadata.
- `parent_database_name`, `domain`, `row_count` optional properties to`entities.TableMetadata` class.

### What the PR doesn't do
This PR does not go as far as it potentially could go in the space of entities (as we have defined them).

I think there is some wider thought needed around what properties our metadata entities contain in light of our current focus and with what we know now. I'd suggest this could form another ticket as a task of itself and should be informed by discussion and agreement within the group after reflection on the initial user research results. 

Because of my thinking here i have not overhauled the metadata entity classes as much as i could've done