### PR TITLE
Fmd-149-charts

### DIFF
--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
@@ -116,3 +116,10 @@ class BaseCatalogueClient(ABC):
         returns the schema and detailed information about a table
         """
         pass
+
+    @abstractmethod
+    def get_chart_details(self, urn) -> TableMetadata:
+        """
+        returns detailed information about a chart
+        """
+        pass

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/base.py
@@ -4,6 +4,7 @@ from typing import Sequence
 
 from ..entities import (
     CatalogueMetadata,
+    ChartMetadata,
     DataLocation,
     DataProductMetadata,
     TableMetadata,
@@ -118,7 +119,7 @@ class BaseCatalogueClient(ABC):
         pass
 
     @abstractmethod
-    def get_chart_details(self, urn) -> TableMetadata:
+    def get_chart_details(self, urn) -> ChartMetadata:
         """
         returns detailed information about a chart
         """

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/getChartDetails.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/getChartDetails.graphql
@@ -1,0 +1,41 @@
+query getChartDetails($urn: String!) {
+  chart(urn: $urn) {
+    urn
+    type
+    platform {
+      name
+    }
+    ownership {
+      owners {
+        owner {
+          ... on CorpUser {
+            urn
+            properties {
+              fullName
+              email
+            }
+          }
+          ... on CorpGroup {
+            urn
+            properties {
+              displayName
+              email
+            }
+          }
+        }
+      }
+    }
+    properties {
+      name
+      description
+      externalUrl
+      customProperties {
+        key
+        value
+      }
+      lastModified {
+        time
+      }
+    }
+  }
+}

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
@@ -54,6 +54,42 @@ query Search(
       }
       entity {
         type
+        ... on Chart {
+          urn
+          type
+          platform {
+            name
+          }
+          ownership {
+            owners {
+              owner {
+                ... on CorpUser {
+                  urn
+                  properties {
+                    fullName
+                    email
+                  }
+                }
+                ... on CorpGroup {
+                  urn
+                  properties {
+                    displayName
+                    email
+                  }
+                }
+              }
+            }
+          }
+          properties {
+            name
+            description
+            externalUrl
+            customProperties {
+              key
+              value
+            }
+          }
+        }
         ... on Dataset {
           urn
           type

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/search.py
@@ -59,6 +59,7 @@ class SearchClient:
         result_types: Sequence[ResultType] = (
             ResultType.DATA_PRODUCT,
             ResultType.TABLE,
+            ResultType.CHART,
         ),
         filters: Sequence[MultiSelectFilter] = (),
         sort: SortOption | None = None,
@@ -105,6 +106,8 @@ class SearchClient:
                 page_results.append(self._parse_data_product(entity, matched_fields))
             elif entity_type == "DATASET":
                 page_results.append(self._parse_dataset(entity, matched_fields))
+            elif entity_type == "CHART":
+                page_results.append(self._parse_chart(entity, matched_fields))
             else:
                 raise ValueError(f"Unexpected entity type: {entity_type}")
 
@@ -198,6 +201,9 @@ class SearchClient:
             types.append("DATASET")
         if ResultType.GLOSSARY_TERM in result_types:
             types.append("GLOSSARY_TERM")
+        if ResultType.CHART in result_types:
+            types.append("CHART")
+
         return types
 
     def _map_filters(self, filters: Sequence[MultiSelectFilter]):
@@ -283,6 +289,21 @@ class SearchClient:
             description=properties.get("description", ""),
             metadata=metadata,
             tags=tags,
+            last_updated=last_updated,
+        )
+
+    def _parse_chart(self, entity: dict[str, Any], matches) -> SearchResult:
+        properties, custom_properties = parse_properties(entity)
+        last_updated = parse_last_updated(entity)
+
+        return SearchResult(
+            id=entity["urn"],
+            result_type=ResultType.CHART,
+            matches=matches,
+            name=properties["name"],
+            fully_qualified_name=properties["name"],
+            description=properties.get("description", ""),
+            metadata=custom_properties,
             last_updated=last_updated,
         )
 

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
@@ -174,3 +174,10 @@ class DatabaseMetadata:
 
 
 # jscpd:ignore-end
+
+@dataclass
+class ChartMetadata:
+    name: str
+    description: str
+    external_url: str
+    tags: list[str] = field(default_factory=list)

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/entities.py
@@ -175,6 +175,7 @@ class DatabaseMetadata:
 
 # jscpd:ignore-end
 
+
 @dataclass
 class ChartMetadata:
     name: str

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/search_types.py
@@ -8,6 +8,7 @@ class ResultType(Enum):
     DATA_PRODUCT = auto()
     TABLE = auto()
     GLOSSARY_TERM = auto()
+    CHART = auto()
 
 
 @dataclass

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -10,6 +10,7 @@ from data_platform_catalogue.client.datahub.datahub_client import (
 )
 from data_platform_catalogue.entities import (
     CatalogueMetadata,
+    ChartMetadata,
     DatabaseMetadata,
     DatabaseStatus,
     DataLocation,
@@ -17,7 +18,6 @@ from data_platform_catalogue.entities import (
     DataProductStatus,
     SecurityClassification,
     TableMetadata,
-    ChartMetadata,
 )
 from datahub.metadata.schema_classes import DataProductPropertiesClass
 
@@ -374,25 +374,18 @@ class TestCatalogueClientWithDatahub:
             "chart": {
                 "urn": "urn:li:chart:(justice-data,absconds)",
                 "type": "CHART",
-                "platform": {
-                    "name": "justice-data"
-                },
-                "relationships": {
-                    "total": 0,
-                    "relationships": []
-                },
+                "platform": {"name": "justice-data"},
+                "relationships": {"total": 0, "relationships": []},
                 "ownership": None,
                 "properties": {
                     "name": "Absconds",
                     "externalUrl": "https://data.justice.gov.uk/prisons/public-protection/absconds",
                     "description": "a test description",
                     "customProperties": [],
-                    "lastModified": {
-                    "time": 0
-                    }
-                }
+                    "lastModified": {"time": 0},
+                },
             },
-            "extensions": {}
+            "extensions": {},
         }
         base_mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
 

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -390,7 +390,6 @@ class TestCatalogueClientWithDatahub:
         base_mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
 
         chart = datahub_client.get_chart_details(urn)
-        print(chart)
         assert chart == ChartMetadata(
             name="Absconds",
             description="a test description",

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_datahub_client.py
@@ -17,6 +17,7 @@ from data_platform_catalogue.entities import (
     DataProductStatus,
     SecurityClassification,
     TableMetadata,
+    ChartMetadata,
 )
 from datahub.metadata.schema_classes import DataProductPropertiesClass
 
@@ -365,6 +366,42 @@ class TestCatalogueClientWithDatahub:
             data_sensitivity_level=SecurityClassification.OFFICIAL,
             tags=[],
             major_version=1,
+        )
+
+    def test_get_chart_details(self, datahub_client, base_mock_graph):
+        urn = "urn:li:chart:(justice-data,absconds)"
+        datahub_response = {
+            "chart": {
+                "urn": "urn:li:chart:(justice-data,absconds)",
+                "type": "CHART",
+                "platform": {
+                    "name": "justice-data"
+                },
+                "relationships": {
+                    "total": 0,
+                    "relationships": []
+                },
+                "ownership": None,
+                "properties": {
+                    "name": "Absconds",
+                    "externalUrl": "https://data.justice.gov.uk/prisons/public-protection/absconds",
+                    "description": "a test description",
+                    "customProperties": [],
+                    "lastModified": {
+                    "time": 0
+                    }
+                }
+            },
+            "extensions": {}
+        }
+        base_mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+        chart = datahub_client.get_chart_details(urn)
+        print(chart)
+        assert chart == ChartMetadata(
+            name="Absconds",
+            description="a test description",
+            external_url="https://data.justice.gov.uk/prisons/public-protection/absconds",
         )
 
     def test_create_athena_database_and_table(

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_search.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_search.py
@@ -828,3 +828,64 @@ def test_get_glossary_terms(mock_graph, searcher):
             ),
         ],
     )
+
+
+def test_search_for_charts(mock_graph, searcher):
+    datahub_response = {
+        "searchAcrossEntities": {
+            "start": 0,
+            "count": 1,
+            "total": 1,
+            "searchResults": [
+                {
+                    "insights": [],
+                    "matchedFields": [
+                        {
+                            "name": "urn",
+                            "value": "urn:li:chart:(justice-data,absconds)",
+                        },
+                        {
+                            "name": "description",
+                            "value": "test",
+                        },
+                        {"name": "title", "value": "absconds"},
+                        {"name": "title", "value": "Absconds"},
+                    ],
+                    "entity": {
+                        "type": "CHART",
+                        "urn": "urn:li:chart:(justice-data,absconds)",
+                        "platform": {"name": "justice-data"},
+                        "ownership": None,
+                        "properties": {
+                            "name": "Absconds",
+                            "description": "test",
+                            "externalUrl": "https://data.justice.gov.uk/prisons/public-protection/absconds",
+                            "customProperties": [],
+                        },
+                    },
+                }
+            ],
+        }
+    }
+
+    mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
+
+    response = searcher.search()
+    print(response)
+    assert response == SearchResponse(
+        total_results=1,
+        page_results=[
+            SearchResult(
+                id="urn:li:chart:(justice-data,absconds)",
+                name="Absconds",
+                fully_qualified_name="Absconds",
+                description="test",
+                matches={
+                    "urn": "urn:li:chart:(justice-data,absconds)",
+                    "description": "test",
+                    "title": "Absconds",
+                },
+                result_type=ResultType.CHART,
+            )
+        ],
+    )

--- a/python-libraries/data-platform-catalogue/tests/client/datahub/test_search.py
+++ b/python-libraries/data-platform-catalogue/tests/client/datahub/test_search.py
@@ -871,7 +871,6 @@ def test_search_for_charts(mock_graph, searcher):
     mock_graph.execute_graphql = MagicMock(return_value=datahub_response)
 
     response = searcher.search()
-    print(response)
     assert response == SearchResponse(
         total_results=1,
         page_results=[

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -292,6 +292,15 @@ def test_get_glossary_terms_returns():
 
 
 @runs_on_development_server
+def test_get_chart():
+    client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
+    table = client.get_chart_details(
+        urn="urn:li:chart:(justice-data,absconds)"
+    )
+    assert table
+
+
+@runs_on_development_server
 def test_get_dataset():
     client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
     table = client.get_table_details(

--- a/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
+++ b/python-libraries/data-platform-catalogue/tests/test_integration_with_datahub_server.py
@@ -294,9 +294,7 @@ def test_get_glossary_terms_returns():
 @runs_on_development_server
 def test_get_chart():
     client = DataHubCatalogueClient(jwt_token=jwt_token, api_url=api_url)
-    table = client.get_chart_details(
-        urn="urn:li:chart:(justice-data,absconds)"
-    )
+    table = client.get_chart_details(urn="urn:li:chart:(justice-data,absconds)")
     assert table
 
 


### PR DESCRIPTION
From https://github.com/ministryofjustice/find-moj-data/issues/149

* Added a `ChartMetadata` class with very limited attributes
* Added `ResultType.CHART`
* Added a graphQL query for chart details (I'm pulling back a load of empty information we won't use)
* Altered graphQL search query to include chart parsing
* Added `SearchClient._parse_chart` and incorporated chart parsing into the normal search method
* Added `DataHubCatalogueClient.get_chart_details` for the chart display page
* I have followed what seems to be the precedent for the table page in adding `get_chart_details` to the `DataHubCatalogueClient` and not to the `SearchClient`