### PR TITLE
create datahub assumable role in ap prod

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -147,7 +147,7 @@ resource "aws_iam_policy" "datahub_ingest_glue_jobs" {
 
 module "datahub_ingestion_roles" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  source  = "terraform-aws-modules/iam/aws/modules/iam-assumable-role"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5.0"
 
   for_each = var.datahub_cp_irsa_arns

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -1,7 +1,7 @@
 #trivy:ignore:aws-iam-no-policy-wildcards
 
 locals {
-  ingest_athena_nonS3 = [
+  ingest_athena_nons3 = [
     "arn:aws:athena::${var.account_ids["cloud-platform"]}:datacatalog/*",
     "arn:aws:athena::${var.account_ids["cloud-platform"]}:workgroup/*",
     "arn:aws:glue::${var.account_ids["cloud-platform"]}:tableVersion/*/*/*",
@@ -9,7 +9,7 @@ locals {
     "arn:aws:glue::${var.account_ids["cloud-platform"]}:catalog",
     "arn:aws:glue::${var.account_ids["cloud-platform"]}:database/*"
   ]
-  ingest_athena_S3 = formatlist("arn:aws:s3:::%s", var.data_buckets)
+  ingest_athena_s3 = formatlist("arn:aws:s3:::%s", var.data_buckets)
 }
 
 data "aws_iam_policy_document" "datahub_ingest_athena_datasets" {
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "datahub_ingest_athena_datasets" {
       "s3:ListBucket",
       "s3:GetBucketLocation",
     ]
-    resources = concat(local.ingest_athena_nonS3, local.ingest_athena_S3)
+    resources = concat(local.ingest_athena_nons3, local.ingest_athena_s3)
   }
 }
 
@@ -92,7 +92,7 @@ data "aws_iam_policy_document" "datahub_assume_ingestion_policy" {
   }
 }
 
-data "aws_iam_policy_document" "datahub_read_CaDeT_bucket" {
+data "aws_iam_policy_document" "datahub_read_cadet_bucket" {
   statement {
     sid    = "datahubReadCaDeTBucket"
     effect = "Allow"
@@ -105,9 +105,9 @@ data "aws_iam_policy_document" "datahub_read_CaDeT_bucket" {
   }
 }
 
-resource "aws_iam_policy" "datahub_ingest_CaDeT_bucket" {
+resource "aws_iam_policy" "datahub_ingest_cadet_bucket" {
   name   = "datahub_ingest_CaDeT_bucket"
-  policy = data.aws_iam_policy_document.datahub_ingest_CaDeT_bucket.json
+  policy = data.aws_iam_policy_document.datahub_ingest_cadet_bucket.json
 }
 
 #trivy:ignore:avd-aws-0057:sensitive action 'glue:GetDatabases' on wildcarded resource
@@ -154,7 +154,7 @@ resource "aws_iam_role" "datahub_ingestion" {
   name               = "datahub_ingestion"
   assume_role_policy = data.aws_iam_policy_document.datahub_assume_ingestion_policy.json
   managed_policy_arns = [
-    aws_iam_policy.datahub_read_CaDeT_bucket.arn,
+    aws_iam_policy.datahub_read_cadet_bucket.arn,
     aws_iam_policy.datahub_ingest_athena_datasets.arn,
     aws_iam_policy.datahub_ingest_athena_query_results.arn,
     aws_iam_policy.datahub_ingest_glue_datasets.arn,

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -149,14 +149,12 @@ resource "aws_iam_role" "datahub_ingestion_roles" {
   for_each = var.datahub_cp_irsa_arns
   name     = "datahub_ingestion_${each.key}"
   assume_role_policy = jsonencode({
-    version = "2012-10-17"
-    statement = {
-      effects = "Allow"
-      actions = ["sts:AssumeRole", "sts:TagSession"]
-
-      principals = {
-        type        = "AWS"
-        identifiers = each.value
+    Version = "2012-10-17"
+    Statement = {
+      Action = ["sts:AssumeRole", "sts:TagSession"]
+      Effect = "Allow"
+      Principal = {
+        AWS = each.value
       }
     }
   })

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -105,9 +105,9 @@ data "aws_iam_policy_document" "datahub_read_cadet_bucket" {
   }
 }
 
-resource "aws_iam_policy" "datahub_ingest_cadet_bucket" {
-  name   = "datahub_ingest_CaDeT_bucket"
-  policy = data.aws_iam_policy_document.datahub_ingest_cadet_bucket.json
+resource "aws_iam_policy" "datahub_read_cadet_bucket" {
+  name   = "datahub_read_CaDeT_bucket"
+  policy = data.aws_iam_policy_document.datahub_read_cadet_bucket.json
 }
 
 #trivy:ignore:avd-aws-0057:sensitive action 'glue:GetDatabases' on wildcarded resource

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -1,20 +1,3 @@
-#trivy:ignore:aws-iam-no-policy-wildcards
-
-locals {
-  ingest_athena_nons3 = [
-    "arn:aws:athena::${var.account_ids["analytical-platform-data-production"]}:datacatalog/*",
-    "arn:aws:athena::${var.account_ids["analytical-platform-data-production"]}:workgroup/*",
-    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:tableVersion/*/*/*",
-    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:table/*/*",
-    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:catalog",
-    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:database/*"
-  ]
-  ingest_athena_s3 = concat(
-    formatlist("arn:aws:s3:::%s/*", var.data_buckets),
-    formatlist("arn:aws:s3:::%s", var.data_buckets)
-  )
-}
-
 data "aws_iam_policy_document" "datahub_ingest_athena_datasets" {
   statement {
     sid    = "datahubIngestAthenaDatasets"
@@ -81,7 +64,6 @@ resource "aws_iam_policy" "datahub_ingest_athena_query_results" {
   policy = data.aws_iam_policy_document.datahub_ingest_athena_query_results.json
 }
 
-
 #trivy:ignore:avd-aws-0057:sensitive action 's3:*' on wildcarded resource
 data "aws_iam_policy_document" "datahub_read_cadet_bucket" {
   statement {
@@ -126,7 +108,7 @@ resource "aws_iam_policy" "datahub_ingest_glue_datasets" {
   policy = data.aws_iam_policy_document.datahub_ingest_glue_datasets.json
 }
 
-
+#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "datahub_ingest_glue_jobs" {
   statement {
     sid    = "datahubIngestGlueJobs"
@@ -143,7 +125,6 @@ resource "aws_iam_policy" "datahub_ingest_glue_jobs" {
   name   = "datahub_ingest_glue_jobs"
   policy = data.aws_iam_policy_document.datahub_ingest_glue_jobs.json
 }
-
 
 module "datahub_ingestion_roles" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -154,7 +154,7 @@ module "datahub_ingestion_roles" {
 
   create_role = true
 
-  role_name     = "datahub_ingestion_${each.key}"
+  role_name = "datahub_ingestion_${each.key}"
 
   role_requires_mfa = false
 

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -1,0 +1,163 @@
+#trivy:ignore:aws-iam-no-policy-wildcards
+
+locals {
+  ingest_athena_nonS3 = [
+        "arn:aws:athena::${var.account_ids["cloud-platform"]}:datacatalog/*",
+        "arn:aws:athena::${var.account_ids["cloud-platform"]}:workgroup/*",
+        "arn:aws:glue::${var.account_ids["cloud-platform"]}:tableVersion/*/*/*",
+        "arn:aws:glue::${var.account_ids["cloud-platform"]}:table/*/*",
+        "arn:aws:glue::${var.account_ids["cloud-platform"]}:catalog",
+        "arn:aws:glue::${var.account_ids["cloud-platform"]}:database/*"
+      ]
+  ingest_athena_S3 = formatlist("arn:aws:s3:::%s", var.data_buckets)
+}
+
+data "aws_iam_policy_document" "datahub_ingest_athena_datasets" {
+   statement {
+    sid    = "datahubIngestAthenaDatasets"
+    effect = "Allow"
+    actions = [
+        "athena:GetTableMetadata",
+        "athena:StartQueryExecution",
+        "athena:GetQueryResults",
+        "athena:GetDatabase",
+        "athena:ListDataCatalogs",
+        "athena:GetDataCatalog",
+        "athena:ListQueryExecutions",
+        "athena:GetWorkGroup",
+        "athena:StopQueryExecution",
+        "athena:GetQueryResultsStream",
+        "athena:ListDatabases",
+        "athena:GetQueryExecution",
+        "athena:ListTableMetadata",
+        "athena:BatchGetQueryExecution",
+        "glue:GetTables",
+        "glue:GetDatabases",
+        "glue:GetTable",
+        "glue:GetDatabase",
+        "glue:SearchTables",
+        "glue:GetTableVersions",
+        "glue:GetTableVersion",
+        "glue:GetPartition",
+        "glue:GetPartitions",
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+      ]
+      resources = concat(local.ingest_athena_nonS3, local.ingest_athena_S3)
+  }
+}
+
+resource "aws_iam_policy" "datahub_ingest_athena_datasets" {
+  name = datahub_ingest_athena_datasets
+  policy = data.aws_iam_policy_document.datahub_ingest_athena_datasets.json
+}
+
+data "aws_iam_policy_document" "datahub_ingest_athena_query_results" {
+   statement {
+    sid    = "datahubIngestAthenaQueryResults"
+    effect = "Allow"
+    actions = [
+        "s3:PutObject",
+        "s3:GetObject",
+        "s3:ListBucketMultipartUploads",
+        "s3:AbortMultipartUpload",
+        "s3:ListBucket",
+        "s3:GetBucketLocation",
+        "s3:ListMultipartUploadParts"
+      ]
+    resources = concat(
+      formatlist("arn:aws:s3:::%s/*", var.athena_query_result_buckets),
+      formatlist("arn:aws:s3:::%s", var.athena_query_result_buckets)
+    )
+  }
+}
+
+resource "aws_iam_policy" "datahub_ingest_athena_query_results" {
+  name = datahub_ingest_athena_query_results
+  policy = data.aws_iam_policy_document.datahub_ingest_athena_query_results.json
+}
+
+data "aws_iam_policy_document" "datahub_assume_ingestion_policy" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole", "sts:TagSession"]
+
+    principals {
+      type = "AWS"
+      identifiers = var.datahub_cp_irsa_arns.values
+    }
+  }
+}
+
+data "aws_iam_policy_document" "datahub_read_CaDeT_bucket" {
+  statement {
+    sid    = "datahubReadCaDeTBucket"
+    effect = "Allow"
+    actions = [
+      "s3:Get*",
+      "s3:List*",
+      "s3:Describe*"
+    ]
+    resources = ["arn:aws:s3:::mojap-derived-tables/*"]
+  }
+}
+
+resource "aws_iam_policy" "datahub_ingest_CaDeT_bucket" {
+  name = datahub_ingest_CaDeT_bucket
+  policy = data.aws_iam_policy_document.datahub_ingest_CaDeT_bucket.json
+}
+
+
+data "aws_iam_policy_document" "datahub_ingest_glue_datasets" {
+   statement {
+    sid    = "datahubIngestGlueDatasets"
+    effect = "Allow"
+    actions = [
+      "glue:GetDatabases",
+      "glue:GetTables"
+    ]
+    resources = [
+      "arn:aws:glue:$region-id:$account-id:catalog",
+      "arn:aws:glue:$region-id:$account-id:database/*",
+      "arn:aws:glue:$region-id:$account-id:table/*"
+      ]
+  }
+}
+
+resource "aws_iam_policy" "datahub_ingest_glue_datasets" {
+  name = datahub_ingest_glue_datasets
+  policy = data.aws_iam_policy_document.datahub_ingest_glue_datasets.json
+}
+
+
+data "aws_iam_policy_document" "datahub_ingest_glue_jobs" {
+   statement {
+    sid    = "datahubIngestGlueJobs"
+    effect = "Allow"
+    actions = [
+      "glue:GetDataflowGraph",
+      "glue:GetJobs",
+    ]
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "datahub_ingest_glue_jobs" {
+  name = datahub_ingest_glue_jobs
+  policy = data.aws_iam_policy_document.datahub_ingest_glue_jobs.json
+}
+
+resource "aws_iam_role" "datahub_ingestion" {
+  name = "datahub_ingestion"
+  assume_role_policy = data.aws_iam_policy_document.datahub_assume_ingestion_policy.json
+  managed_policy_arns = [
+    aws_iam_policy.datahub_read_CaDeT_bucket.arn,
+    aws_iam_policy.datahub_ingest_athena_datasets.arn,
+    aws_iam_policy.datahub_ingest_athena_query_results.arn,
+    aws_iam_policy.datahub_ingest_glue_datasets.arn,
+    aws_iam_policy.datahub_ingest_glue_jobs.arn
+    ]
+}

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -9,7 +9,10 @@ locals {
     "arn:aws:glue::${var.account_ids["cloud-platform"]}:catalog",
     "arn:aws:glue::${var.account_ids["cloud-platform"]}:database/*"
   ]
-  ingest_athena_s3 = formatlist("arn:aws:s3:::%s", var.data_buckets)
+  ingest_athena_s3 = concat(
+    formatlist("arn:aws:s3:::%s/*", var.data_buckets),
+    formatlist("arn:aws:s3:::%s", var.data_buckets)
+    )
 }
 
 data "aws_iam_policy_document" "datahub_ingest_athena_datasets" {
@@ -92,6 +95,7 @@ data "aws_iam_policy_document" "datahub_assume_ingestion_policy" {
   }
 }
 
+#trivy:ignore:avd-aws-0057:sensitive action 's3:*' on wildcarded resource
 data "aws_iam_policy_document" "datahub_read_cadet_bucket" {
   statement {
     sid    = "datahubReadCaDeTBucket"
@@ -101,7 +105,10 @@ data "aws_iam_policy_document" "datahub_read_cadet_bucket" {
       "s3:List*",
       "s3:Describe*"
     ]
-    resources = ["arn:aws:s3:::mojap-derived-tables/*"]
+    resources = [
+      "arn:aws:s3:::mojap-derived-tables/*",
+      "arn:aws:s3:::mojap-derived-tables"
+      ]
   }
 }
 

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -12,7 +12,7 @@ locals {
   ingest_athena_s3 = concat(
     formatlist("arn:aws:s3:::%s/*", var.data_buckets),
     formatlist("arn:aws:s3:::%s", var.data_buckets)
-    )
+  )
 }
 
 data "aws_iam_policy_document" "datahub_ingest_athena_datasets" {
@@ -108,7 +108,7 @@ data "aws_iam_policy_document" "datahub_read_cadet_bucket" {
     resources = [
       "arn:aws:s3:::mojap-derived-tables/*",
       "arn:aws:s3:::mojap-derived-tables"
-      ]
+    ]
   }
 }
 

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -150,7 +150,7 @@ module "datahub_ingestion_roles" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
   version = "~> 5.0"
 
-  for_each = var.datahub_cp_irsa_arns
+  for_each = local.datahub_cp_irsa_role_arns
 
   create_role = true
 

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -49,7 +49,7 @@ data "aws_iam_policy_document" "datahub_ingest_athena_datasets" {
 }
 
 resource "aws_iam_policy" "datahub_ingest_athena_datasets" {
-  name   = datahub_ingest_athena_datasets
+  name   = "datahub_ingest_athena_datasets"
   policy = data.aws_iam_policy_document.datahub_ingest_athena_datasets.json
 }
 
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "datahub_ingest_athena_query_results" {
 }
 
 resource "aws_iam_policy" "datahub_ingest_athena_query_results" {
-  name   = datahub_ingest_athena_query_results
+  name   = "datahub_ingest_athena_query_results"
   policy = data.aws_iam_policy_document.datahub_ingest_athena_query_results.json
 }
 
@@ -87,7 +87,7 @@ data "aws_iam_policy_document" "datahub_assume_ingestion_policy" {
 
     principals {
       type        = "AWS"
-      identifiers = var.datahub_cp_irsa_arns.values
+      identifiers = values(var.datahub_cp_irsa_arns)
     }
   }
 }
@@ -106,11 +106,11 @@ data "aws_iam_policy_document" "datahub_read_CaDeT_bucket" {
 }
 
 resource "aws_iam_policy" "datahub_ingest_CaDeT_bucket" {
-  name   = datahub_ingest_CaDeT_bucket
+  name   = "datahub_ingest_CaDeT_bucket"
   policy = data.aws_iam_policy_document.datahub_ingest_CaDeT_bucket.json
 }
 
-
+#trivy:ignore:avd-aws-0057:sensitive action 'glue:GetDatabases' on wildcarded resource
 data "aws_iam_policy_document" "datahub_ingest_glue_datasets" {
   statement {
     sid    = "datahubIngestGlueDatasets"
@@ -128,7 +128,7 @@ data "aws_iam_policy_document" "datahub_ingest_glue_datasets" {
 }
 
 resource "aws_iam_policy" "datahub_ingest_glue_datasets" {
-  name   = datahub_ingest_glue_datasets
+  name   = "datahub_ingest_glue_datasets"
   policy = data.aws_iam_policy_document.datahub_ingest_glue_datasets.json
 }
 
@@ -146,7 +146,7 @@ data "aws_iam_policy_document" "datahub_ingest_glue_jobs" {
 }
 
 resource "aws_iam_policy" "datahub_ingest_glue_jobs" {
-  name   = datahub_ingest_glue_jobs
+  name   = "datahub_ingest_glue_jobs"
   policy = data.aws_iam_policy_document.datahub_ingest_glue_jobs.json
 }
 

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -2,12 +2,12 @@
 
 locals {
   ingest_athena_nons3 = [
-    "arn:aws:athena::${var.account_ids["cloud-platform"]}:datacatalog/*",
-    "arn:aws:athena::${var.account_ids["cloud-platform"]}:workgroup/*",
-    "arn:aws:glue::${var.account_ids["cloud-platform"]}:tableVersion/*/*/*",
-    "arn:aws:glue::${var.account_ids["cloud-platform"]}:table/*/*",
-    "arn:aws:glue::${var.account_ids["cloud-platform"]}:catalog",
-    "arn:aws:glue::${var.account_ids["cloud-platform"]}:database/*"
+    "arn:aws:athena::${var.account_ids["analytical-platform-data-production"]}:datacatalog/*",
+    "arn:aws:athena::${var.account_ids["analytical-platform-data-production"]}:workgroup/*",
+    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:tableVersion/*/*/*",
+    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:table/*/*",
+    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:catalog",
+    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:database/*"
   ]
   ingest_athena_s3 = concat(
     formatlist("arn:aws:s3:::%s/*", var.data_buckets),
@@ -81,6 +81,7 @@ resource "aws_iam_policy" "datahub_ingest_athena_query_results" {
   policy = data.aws_iam_policy_document.datahub_ingest_athena_query_results.json
 }
 
+
 #trivy:ignore:avd-aws-0057:sensitive action 's3:*' on wildcarded resource
 data "aws_iam_policy_document" "datahub_read_cadet_bucket" {
   statement {
@@ -113,9 +114,9 @@ data "aws_iam_policy_document" "datahub_ingest_glue_datasets" {
       "glue:GetTables"
     ]
     resources = [
-      "arn:aws:glue:$region-id:$account-id:catalog",
-      "arn:aws:glue:$region-id:$account-id:database/*",
-      "arn:aws:glue:$region-id:$account-id:table/*"
+      "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:catalog",
+      "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:database/*",
+      "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:table/*"
     ]
   }
 }
@@ -147,7 +148,7 @@ resource "aws_iam_policy" "datahub_ingest_glue_jobs" {
 resource "aws_iam_role" "datahub_ingestion_roles" {
   for_each = var.datahub_cp_irsa_arns
   name     = "datahub_ingestion_${each.key}"
-  assume_role_policy = jsondecode({
+  assume_role_policy = jsonencode({
     version = "2012-10-17"
     statement = {
       effects = "Allow"

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -2,70 +2,70 @@
 
 locals {
   ingest_athena_nonS3 = [
-        "arn:aws:athena::${var.account_ids["cloud-platform"]}:datacatalog/*",
-        "arn:aws:athena::${var.account_ids["cloud-platform"]}:workgroup/*",
-        "arn:aws:glue::${var.account_ids["cloud-platform"]}:tableVersion/*/*/*",
-        "arn:aws:glue::${var.account_ids["cloud-platform"]}:table/*/*",
-        "arn:aws:glue::${var.account_ids["cloud-platform"]}:catalog",
-        "arn:aws:glue::${var.account_ids["cloud-platform"]}:database/*"
-      ]
+    "arn:aws:athena::${var.account_ids["cloud-platform"]}:datacatalog/*",
+    "arn:aws:athena::${var.account_ids["cloud-platform"]}:workgroup/*",
+    "arn:aws:glue::${var.account_ids["cloud-platform"]}:tableVersion/*/*/*",
+    "arn:aws:glue::${var.account_ids["cloud-platform"]}:table/*/*",
+    "arn:aws:glue::${var.account_ids["cloud-platform"]}:catalog",
+    "arn:aws:glue::${var.account_ids["cloud-platform"]}:database/*"
+  ]
   ingest_athena_S3 = formatlist("arn:aws:s3:::%s", var.data_buckets)
 }
 
 data "aws_iam_policy_document" "datahub_ingest_athena_datasets" {
-   statement {
+  statement {
     sid    = "datahubIngestAthenaDatasets"
     effect = "Allow"
     actions = [
-        "athena:GetTableMetadata",
-        "athena:StartQueryExecution",
-        "athena:GetQueryResults",
-        "athena:GetDatabase",
-        "athena:ListDataCatalogs",
-        "athena:GetDataCatalog",
-        "athena:ListQueryExecutions",
-        "athena:GetWorkGroup",
-        "athena:StopQueryExecution",
-        "athena:GetQueryResultsStream",
-        "athena:ListDatabases",
-        "athena:GetQueryExecution",
-        "athena:ListTableMetadata",
-        "athena:BatchGetQueryExecution",
-        "glue:GetTables",
-        "glue:GetDatabases",
-        "glue:GetTable",
-        "glue:GetDatabase",
-        "glue:SearchTables",
-        "glue:GetTableVersions",
-        "glue:GetTableVersion",
-        "glue:GetPartition",
-        "glue:GetPartitions",
-        "s3:GetObject",
-        "s3:ListBucket",
-        "s3:GetBucketLocation",
-      ]
-      resources = concat(local.ingest_athena_nonS3, local.ingest_athena_S3)
+      "athena:GetTableMetadata",
+      "athena:StartQueryExecution",
+      "athena:GetQueryResults",
+      "athena:GetDatabase",
+      "athena:ListDataCatalogs",
+      "athena:GetDataCatalog",
+      "athena:ListQueryExecutions",
+      "athena:GetWorkGroup",
+      "athena:StopQueryExecution",
+      "athena:GetQueryResultsStream",
+      "athena:ListDatabases",
+      "athena:GetQueryExecution",
+      "athena:ListTableMetadata",
+      "athena:BatchGetQueryExecution",
+      "glue:GetTables",
+      "glue:GetDatabases",
+      "glue:GetTable",
+      "glue:GetDatabase",
+      "glue:SearchTables",
+      "glue:GetTableVersions",
+      "glue:GetTableVersion",
+      "glue:GetPartition",
+      "glue:GetPartitions",
+      "s3:GetObject",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+    ]
+    resources = concat(local.ingest_athena_nonS3, local.ingest_athena_S3)
   }
 }
 
 resource "aws_iam_policy" "datahub_ingest_athena_datasets" {
-  name = datahub_ingest_athena_datasets
+  name   = datahub_ingest_athena_datasets
   policy = data.aws_iam_policy_document.datahub_ingest_athena_datasets.json
 }
 
 data "aws_iam_policy_document" "datahub_ingest_athena_query_results" {
-   statement {
+  statement {
     sid    = "datahubIngestAthenaQueryResults"
     effect = "Allow"
     actions = [
-        "s3:PutObject",
-        "s3:GetObject",
-        "s3:ListBucketMultipartUploads",
-        "s3:AbortMultipartUpload",
-        "s3:ListBucket",
-        "s3:GetBucketLocation",
-        "s3:ListMultipartUploadParts"
-      ]
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:ListBucketMultipartUploads",
+      "s3:AbortMultipartUpload",
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:ListMultipartUploadParts"
+    ]
     resources = concat(
       formatlist("arn:aws:s3:::%s/*", var.athena_query_result_buckets),
       formatlist("arn:aws:s3:::%s", var.athena_query_result_buckets)
@@ -74,7 +74,7 @@ data "aws_iam_policy_document" "datahub_ingest_athena_query_results" {
 }
 
 resource "aws_iam_policy" "datahub_ingest_athena_query_results" {
-  name = datahub_ingest_athena_query_results
+  name   = datahub_ingest_athena_query_results
   policy = data.aws_iam_policy_document.datahub_ingest_athena_query_results.json
 }
 
@@ -86,7 +86,7 @@ data "aws_iam_policy_document" "datahub_assume_ingestion_policy" {
     actions = ["sts:AssumeRole", "sts:TagSession"]
 
     principals {
-      type = "AWS"
+      type        = "AWS"
       identifiers = var.datahub_cp_irsa_arns.values
     }
   }
@@ -106,13 +106,13 @@ data "aws_iam_policy_document" "datahub_read_CaDeT_bucket" {
 }
 
 resource "aws_iam_policy" "datahub_ingest_CaDeT_bucket" {
-  name = datahub_ingest_CaDeT_bucket
+  name   = datahub_ingest_CaDeT_bucket
   policy = data.aws_iam_policy_document.datahub_ingest_CaDeT_bucket.json
 }
 
 
 data "aws_iam_policy_document" "datahub_ingest_glue_datasets" {
-   statement {
+  statement {
     sid    = "datahubIngestGlueDatasets"
     effect = "Allow"
     actions = [
@@ -123,18 +123,18 @@ data "aws_iam_policy_document" "datahub_ingest_glue_datasets" {
       "arn:aws:glue:$region-id:$account-id:catalog",
       "arn:aws:glue:$region-id:$account-id:database/*",
       "arn:aws:glue:$region-id:$account-id:table/*"
-      ]
+    ]
   }
 }
 
 resource "aws_iam_policy" "datahub_ingest_glue_datasets" {
-  name = datahub_ingest_glue_datasets
+  name   = datahub_ingest_glue_datasets
   policy = data.aws_iam_policy_document.datahub_ingest_glue_datasets.json
 }
 
 
 data "aws_iam_policy_document" "datahub_ingest_glue_jobs" {
-   statement {
+  statement {
     sid    = "datahubIngestGlueJobs"
     effect = "Allow"
     actions = [
@@ -146,12 +146,12 @@ data "aws_iam_policy_document" "datahub_ingest_glue_jobs" {
 }
 
 resource "aws_iam_policy" "datahub_ingest_glue_jobs" {
-  name = datahub_ingest_glue_jobs
+  name   = datahub_ingest_glue_jobs
   policy = data.aws_iam_policy_document.datahub_ingest_glue_jobs.json
 }
 
 resource "aws_iam_role" "datahub_ingestion" {
-  name = "datahub_ingestion"
+  name               = "datahub_ingestion"
   assume_role_policy = data.aws_iam_policy_document.datahub_assume_ingestion_policy.json
   managed_policy_arns = [
     aws_iam_policy.datahub_read_CaDeT_bucket.arn,
@@ -159,5 +159,5 @@ resource "aws_iam_role" "datahub_ingestion" {
     aws_iam_policy.datahub_ingest_athena_query_results.arn,
     aws_iam_policy.datahub_ingest_glue_datasets.arn,
     aws_iam_policy.datahub_ingest_glue_jobs.arn
-    ]
+  ]
 }

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  datahub_cp_irsa_role_arns = flatten(
+    [
+      for env, role_name in var.datahub_cp_irsa_role_names :
+      { (env) = "arn:aws:iam::${var.account_ids["cloud-platform"]}:role/${role_name}" }
+    ]
+  )
+}

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/locals.tf
@@ -1,8 +1,6 @@
 locals {
-  datahub_cp_irsa_role_arns = flatten(
-    [
-      for env, role_name in var.datahub_cp_irsa_role_names :
-      { (env) = "arn:aws:iam::${var.account_ids["cloud-platform"]}:role/${role_name}" }
-    ]
-  )
+  datahub_cp_irsa_role_arns = {
+    for env, role_name in var.datahub_cp_irsa_role_names :
+    env => "arn:aws:iam::${var.account_ids["cloud-platform"]}:role/${role_name}"
+  }
 }

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/locals.tf
@@ -3,4 +3,18 @@ locals {
     for env, role_name in var.datahub_cp_irsa_role_names :
     env => "arn:aws:iam::${var.account_ids["cloud-platform"]}:role/${role_name}"
   }
+
+  ingest_athena_nons3 = [
+    "arn:aws:athena::${var.account_ids["analytical-platform-data-production"]}:datacatalog/*",
+    "arn:aws:athena::${var.account_ids["analytical-platform-data-production"]}:workgroup/*",
+    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:tableVersion/*/*/*",
+    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:table/*/*",
+    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:catalog",
+    "arn:aws:glue::${var.account_ids["analytical-platform-data-production"]}:database/*"
+  ]
+
+  ingest_athena_s3 = concat(
+    formatlist("arn:aws:s3:::%s/*", var.data_buckets),
+    formatlist("arn:aws:s3:::%s", var.data_buckets)
+  )
 }

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/terraform.tfvars
@@ -9,17 +9,17 @@ account_ids = {
 }
 
 data_buckets = [
-    "moj-reg-dev-curated",
-    "moj-reg-preprod-curated",
-    "moj-reg-prod-curated"
-    ]
+  "moj-reg-dev-curated",
+  "moj-reg-preprod-curated",
+  "moj-reg-prod-curated"
+]
 
 athena_query_result_buckets = ["aws-athena-query-results-593291632749-eu-west-1"]
 
 datahub_cp_irsa_arns = {
-    dev = "arn:aws:iam::754256621582:role/cloud-platform-irsa-33e75989394c3a08-live"
-    test = "arn:aws:iam::754256621582:role/cloud-platform-irsa-fdce67955f41b322-live"
-    preprod = "arn:aws:iam::754256621582:role/cloud-platform-irsa-fe098636951cc219-live"
+  dev     = "arn:aws:iam::754256621582:role/cloud-platform-irsa-33e75989394c3a08-live"
+  test    = "arn:aws:iam::754256621582:role/cloud-platform-irsa-fdce67955f41b322-live"
+  preprod = "arn:aws:iam::754256621582:role/cloud-platform-irsa-fe098636951cc219-live"
 }
 
 tags = {

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/terraform.tfvars
@@ -16,10 +16,10 @@ data_buckets = [
 
 athena_query_result_buckets = ["aws-athena-query-results-593291632749-eu-west-1"]
 
-datahub_cp_irsa_arns = {
-  dev     = "arn:aws:iam::754256621582:role/cloud-platform-irsa-33e75989394c3a08-live"
-  test    = "arn:aws:iam::754256621582:role/cloud-platform-irsa-fdce67955f41b322-live"
-  preprod = "arn:aws:iam::754256621582:role/cloud-platform-irsa-fe098636951cc219-live"
+datahub_cp_irsa_role_names = {
+  dev     = "cloud-platform-irsa-33e75989394c3a08-live",
+  test    = "cloud-platform-irsa-fdce67955f41b322-live",
+  preprod = "cloud-platform-irsa-fe098636951cc219-live"
 }
 
 tags = {

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/terraform.tfvars
@@ -5,6 +5,21 @@
 account_ids = {
   analytical-platform-data-production       = "593291632749"
   analytical-platform-management-production = "042130406152"
+  cloud-platform                            = "754256621582"
+}
+
+data_buckets = [
+    "moj-reg-dev-curated",
+    "moj-reg-preprod-curated",
+    "moj-reg-prod-curated"
+    ]
+
+athena_query_result_buckets = ["aws-athena-query-results-593291632749-eu-west-1"]
+
+datahub_cp_irsa_arns = {
+    dev = "arn:aws:iam::754256621582:role/cloud-platform-irsa-33e75989394c3a08-live"
+    test = "arn:aws:iam::754256621582:role/cloud-platform-irsa-fdce67955f41b322-live"
+    preprod = "arn:aws:iam::754256621582:role/cloud-platform-irsa-fe098636951cc219-live"
 }
 
 tags = {

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/variables.tf
@@ -7,6 +7,21 @@ variable "account_ids" {
   description = "Map of account names to account IDs"
 }
 
+variable "data_buckets" {
+  type        = list(string)
+  description = "List of data buckets containing Athena databases"
+}
+
+variable "athena_query_result_buckets" {
+  type        = list(string)
+  description = "Athena query dump buckets"
+}
+
+variable "datahub_cp_irsa_arns" {
+  type        = map(string)
+  description = "Map of DataHub environments and their IRSA role arns"
+}
+
 variable "tags" {
   type        = map(string)
   description = "Map of tags to apply to resources"

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/variables.tf
@@ -17,9 +17,9 @@ variable "athena_query_result_buckets" {
   description = "Athena query dump buckets"
 }
 
-variable "datahub_cp_irsa_arns" {
+variable "datahub_cp_irsa_role_names" {
   type        = map(string)
-  description = "Map of DataHub environments and their IRSA role arns"
+  description = "Map of DataHub environments and their IRSA role names"
 }
 
 variable "tags" {


### PR DESCRIPTION
Creates a role for DataHub to assume to allow metadata ingestion via dbt (CaDeT), Glue, and Athena ingestion sources from AP prod account.
- add minimal set of datahub glue + athena ingestion policies 
- athena datasets & query results access 
- CaDeT bucket read access 
- glue dataset & job read access 
- specify register-my-data buckets for athena locations 
- specify all environments irsa arns for role assumption

### Of note
The Glue permissions are broad, but read-only, so we can grab metadata for all items in the catalogue. 
