### PR TITLE
amend .github/codeowners in caluma barnett abscence

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,4 +5,5 @@
 /scripts/simulated-data-producer/ @ministryofjustice/data-platform-labs
 /terraform/ @ministryofjustice/data-platform-apps-and-tools
 /python-libraries/data-platform-catalogue/ @ministryofjustice/data-platform-labs
-/terraform/github/configuration/data-engineering-access.json @calumabarnett
+#/terraform/github/configuration/data-engineering-access.json @calumabarnett
+/terraform/github/configuration/data-engineering-access.json @ministryofjustice/data-platform-apps-and-tools

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -6,4 +6,3 @@
 /terraform/ @ministryofjustice/data-platform-apps-and-tools
 /python-libraries/data-platform-catalogue/ @ministryofjustice/data-platform-labs
 #/terraform/github/configuration/data-engineering-access.json @calumabarnett
-/terraform/github/configuration/data-engineering-access.json @ministryofjustice/data-platform-apps-and-tools


### PR DESCRIPTION
## What does this PR achieve?

caluma barnett is currently out of the office and is set as code oner for /terraform/github/configuration/data-engineering-access.json - this is a temporary change to the  .github/codeowners file 

from /terraform/github/configuration/data-engineering-access.json @calumabarnett
to /terraform/github/configuration/data-engineering-access.json @ministryofjustice/data-platform-apps-and-tools

to allow approval of data-engineering-access requests

- [ x] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [x] All checks have passed (or override label applied)
- [x ] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected


