### PR TITLE
🐛 Fixing condition block so that assumed roles are excluded as well

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/glue.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/glue.tf
@@ -43,7 +43,8 @@ data "aws_iam_policy_document" "glue_ireland" {
           ]],
           [
             data.aws_caller_identity.current.account_id,
-            data.aws_iam_role.aws_sso_modernisation_platform_data_eng.unique_id // data engineering role protection bypass
+            data.aws_iam_role.aws_sso_modernisation_platform_data_eng.unique_id,
+            "${data.aws_iam_role.aws_sso_modernisation_platform_data_eng.unique_id}:*" // data engineering role protection bypass
           ]
         ])
       }


### PR DESCRIPTION
## If this work is being tracked by an issue, please link it below

https://github.com/ministryofjustice/data-platform-support/issues/487
https://github.com/ministryofjustice/data-platform/issues/3765

## What does this PR achieve?

Adds the `data-eng` SSO role assumed roles form as being excluded from Glue database/table protection rules

## If you're adding the `override-static-analysis` label, please explain why

This is again a bug fix not a final solution. Further refinement incoming.

## Checklist (check `x` in `[ ]` of list items)

> **_NOTE:_** Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [x] All checks have passed (or override label applied)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

## Additional comments (if any)

{Please write here}
