### PR TITLE
Update rshiny-open-source-base image to rocker:4.3.2

### DIFF
--- a/containers/rshiny-open-source-base/CHANGELOG.md
+++ b/containers/rshiny-open-source-base/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0]
+
+- Update to use rocker/r-ver:4.3.2
+
 ## [1.0.3]
 
 - Add packages installed by previous base shiny image

--- a/containers/rshiny-open-source-base/Dockerfile
+++ b/containers/rshiny-open-source-base/Dockerfile
@@ -1,6 +1,6 @@
 # hadolint global ignore=DL3008
 
-ARG r=4.1.3
+ARG r=4.3.2
 FROM rocker/r-ver:${r}
 
 ARG shinyserver=1.5.20.1002

--- a/containers/rshiny-open-source-base/config.json
+++ b/containers/rshiny-open-source-base/config.json
@@ -1,5 +1,5 @@
 {
   "name": "rshiny-open-source-base",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "registry": "ghcr"
 }


### PR DESCRIPTION
### Pull Request Objective

This piece of work is being tracked in this [support ticket](https://github.com/ministryofjustice/data-platform-support/issues/515)

<!-- Please describe the purpose of this pull request. Detail the problem it addresses or the functionality it adds. Highlight how this contributes to the project goals, improves performance, or solves a specific issue. -->
This PR update the rshiny-open-source-base image to `rocker:4.3.2` in 1.1.0 release.

### Checklist

- [x] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

