### PR TITLE
🫂 Remove Murad from PagerDuty/Team/Rota

### DIFF
--- a/terraform/pagerduty/schedules.tf
+++ b/terraform/pagerduty/schedules.tf
@@ -17,7 +17,6 @@ locals {
             module.users["michael.collins@digital.justice.gov.uk"].id,
             module.users["gary.henderson@digital.justice.gov.uk"].id,
             module.users["jacob.hamblin-pyke@digital.justice.gov.uk"].id,
-            module.users["murad.ali@digital.justice.gov.uk"].id,
             module.users["thomas.webber@digital.justice.gov.uk"].id,
             module.users["james.stott@digital.justice.gov.uk"].id,
             module.users["anthony.fitzroy@digital.justice.gov.uk"].id,

--- a/terraform/pagerduty/teams.tf
+++ b/terraform/pagerduty/teams.tf
@@ -14,7 +14,6 @@ locals {
         module.users["gary.henderson@digital.justice.gov.uk"].id,
         module.users["jacob.hamblin-pyke@digital.justice.gov.uk"].id,
         module.users["thomas.webber@digital.justice.gov.uk"].id,
-        module.users["murad.ali@digital.justice.gov.uk"].id,
         module.users["james.stott@digital.justice.gov.uk"].id,
         module.users["anthony.fitzroy@digital.justice.gov.uk"].id,
       ]

--- a/terraform/pagerduty/users.tf
+++ b/terraform/pagerduty/users.tf
@@ -37,10 +37,6 @@ locals {
       email = "thomas.webber@digital.justice.gov.uk"
     },
     {
-      name  = "Murad Ali"
-      email = "murad.ali@digital.justice.gov.uk"
-    },
-    {
       name  = "James Stott"
       email = "james.stott@digital.justice.gov.uk"
     },


### PR DESCRIPTION
Remove's Murad from PagerDuty, and naturally the team and the rota.