### PR TITLE
🐛 Fixing Glue Policy Size

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/glue.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/glue.tf
@@ -43,16 +43,10 @@ data "aws_iam_policy_document" "glue_ireland" {
             data.aws_iam_role.glue_policy_role[role_arn].arn
           ]],
           [
-            data.aws_iam_role.aws_sso_modernisation_platform_data_eng.arn
+            data.aws_iam_role.aws_sso_modernisation_platform_data_eng.arn,
+            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
           ]
         ])
-      }
-      condition {
-        test     = "StringNotEquals"
-        variable = "aws:PrincipalAccount"
-        values = [
-          data.aws_caller_identity.current.account_id
-        ]
       }
     }
   }


### PR DESCRIPTION
### Pull Request Objective

This piece of work is being tracked in https://github.com/ministryofjustice/data-platform/issues/3765

The previous iteration of this policy was too long.

The policy as it was defined in the previous PR, exempted a list of roles and the entire account from database protection. After a closer examination of the original policy as well as [this](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_variables.html#principaltable) doc, it's more likely the intent was to specifically to exclude the account root user. The separate condition block exempting all account principals has been removed, and root account re-added

<!-- Please describe the purpose of this pull request. Detail the problem it addresses or the functionality it adds. Highlight how this contributes to the project goals, improves performance, or solves a specific issue. -->

### Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [X] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [X] All checks have passed (or override label applied, if I've used the `override-static-analysis` label, I've explained why)
- [X] I have self-reviewed my code
- [X] I have reviewed the checks and can attest they're as expected

