### PR TITLE
Reverting Glue Ireland Policy back to Unique IDs

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/glue.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/glue.tf
@@ -1,9 +1,7 @@
-#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "glue_ireland" {
   policy_id = "protect-deployed-dbs"
 
   dynamic "statement" {
-    #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
     for_each = local.protected_dbs
 
     content {
@@ -37,14 +35,16 @@ data "aws_iam_policy_document" "glue_ireland" {
       }
       condition {
         test     = "StringNotLike"
-        variable = "aws:PrincipalArn"
+        variable = "aws:userId"
         values = flatten([
-          [for role_arn in statement.value.role_names_to_exempt : [
-            data.aws_iam_role.glue_policy_role[role_arn].arn
+          [for user_id in statement.value.role_names_to_exempt : [
+            data.aws_iam_role.glue_policy_role[user_id].unique_id,
+            "${data.aws_iam_role.glue_policy_role[user_id].unique_id}:*"
           ]],
           [
-            data.aws_iam_role.aws_sso_modernisation_platform_data_eng.arn,
-            "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+            data.aws_caller_identity.current.account_id,
+            data.aws_iam_role.aws_sso_modernisation_platform_data_eng.unique_id,
+            "${data.aws_iam_role.aws_sso_modernisation_platform_data_eng.unique_id}:*" // data engineering role protection bypass
           ]
         ])
       }


### PR DESCRIPTION
### Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/data-platform/issues/3765) GitHub Issue.

<!-- Please describe the purpose of this pull request. Detail the problem it addresses or the functionality it adds. Highlight how this contributes to the project goals, improves performance, or solves a specific issue. -->

Reverting #4015 and #4013 due to arns push policy size above quota.

### Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

