### PR TITLE
update lastModified property in data-platform-catalogue

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,6 +7,14 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.0] 2024-04-11
+
+### Changed
+
+- `search.graphql` query to be compatible with Datahub v0.12.1, where the property
+  `lastModified` has changed type from `Long` to `AuditStamp` a nested structure
+  which contains a time (long) and an actor (string).
+
 ## [0.23.0] 2024-03-26
 
 ### Changed

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
@@ -148,7 +148,7 @@ query Search(
               value
             }
             created
-            lastModified{
+            lastModified {
               time
               actor
             }

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/search.graphql
@@ -148,7 +148,10 @@ query Search(
               value
             }
             created
-            lastModified
+            lastModified{
+              time
+              actor
+            }
           }
           editableProperties {
             description

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.23.0"
+version = "0.24.0"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
fix for the latest update to 0.12.1 datahub which broke our search query by introducing a more complex `lastModified` property