### PR TITLE
update instances of `lastModified` property in data-platform-catalogue

### DIFF
--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -7,6 +7,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.24.2] 2024-04-16
+
+### Changed
+
+- `lastModified` updated for getDatasetDetails, getChartDetails, listDataProductAssets
+
 ## [0.24.1] 2024-04-11
 
 ### Changed

--- a/python-libraries/data-platform-catalogue/CHANGELOG.md
+++ b/python-libraries/data-platform-catalogue/CHANGELOG.md
@@ -11,7 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- `lastModified` updated for getDatasetDetails, getChartDetails, listDataProductAssets
+- `lastModified` syntax updated for getDatasetDetails, getChartDetails,
+  listDataProductAssets, as per `0.24.0`
 
 ## [0.24.1] 2024-04-11
 

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/getChartDetails.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/getChartDetails.graphql
@@ -35,6 +35,7 @@ query getChartDetails($urn: String!) {
       }
       lastModified {
         time
+        actor
       }
     }
   }

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/getDatasetDetails.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/getDatasetDetails.graphql
@@ -77,7 +77,10 @@ query getDatasetDetails($urn: String!) {
         value
       }
       created
-      lastModified
+      lastModified {
+        time
+        actor
+      }
     }
     editableProperties {
       description

--- a/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/listDataProductAssets.graphql
+++ b/python-libraries/data-platform-catalogue/data_platform_catalogue/client/datahub/graphql/listDataProductAssets.graphql
@@ -1,7 +1,12 @@
-query dataProductDetails($urn: String!, $query: String!, $count: Int!, $start: Int!) {
+query dataProductDetails(
+  $urn: String!
+  $query: String!
+  $count: Int!
+  $start: Int!
+) {
   listDataProductAssets(
     urn: $urn
-    input: {query: $query, start: $start, count: $count}
+    input: { query: $query, start: $start, count: $count }
   ) {
     start
     count
@@ -16,7 +21,11 @@ query dataProductDetails($urn: String!, $query: String!, $count: Int!, $start: I
             name
           }
           relationships(
-            input: {types: ["DataProductContains"], direction: INCOMING, count: 10}
+            input: {
+              types: ["DataProductContains"]
+              direction: INCOMING
+              count: 10
+            }
           ) {
             total
             relationships {
@@ -60,7 +69,10 @@ query dataProductDetails($urn: String!, $query: String!, $count: Int!, $start: I
               value
             }
             created
-            lastModified
+            lastModified {
+              time
+              actor
+            }
           }
           editableProperties {
             description

--- a/python-libraries/data-platform-catalogue/pyproject.toml
+++ b/python-libraries/data-platform-catalogue/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "ministryofjustice-data-platform-catalogue"
-version = "0.24.1"
+version = "0.24.2"
 description = "Library to integrate the MoJ data platform with the catalogue component."
 authors = ["MoJ Data Platform Team <data-platform-tech@digital.justice.gov.uk>"]
 license = "MIT"


### PR DESCRIPTION
### Pull Request Objective

This piece of work is related to the ministryofjustice/data-catalogue#25 DataHub upgrade breaking changes.

It resolves an error due to a breaking change in the `0.12.1` that has [already been resolved for search](https://github.com/ministryofjustice/data-platform/pull/4063).

### Checklist


- [x] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

