### PR TITLE
🌐 Set BOLD egress KMS keys to multi region

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-egress/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-egress/kms-keys.tf
@@ -7,6 +7,7 @@ module "development_kms" {
   aliases               = ["s3/mojap-data-production-bold-egress-development"]
   description           = "MoJ AP BOLD Egress - Development"
   enable_default_policy = true
+  multi_region          = true
 
   deletion_window_in_days = 7
 }
@@ -20,6 +21,7 @@ module "production_kms" {
   aliases               = ["s3/mojap-data-production-bold-egress-production"]
   description           = "MoJ AP BOLD Egress - Production"
   enable_default_policy = true
+  multi_region          = true
 
   deletion_window_in_days = 7
 }


### PR DESCRIPTION
This pull request:

- Sets `s3/mojap-data-production-bold-egress-*` to multi region, this is required because Airflow runs in `eu-west-1` but Analytical Platform new resources run in `eu-west-2`

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 