### PR TITLE
Amend documentation to change data-platform to analytical-platform for ghcr

### DIFF
--- a/docs/source/documentation/platform/infrastructure/containers.html.md.erb
+++ b/docs/source/documentation/platform/infrastructure/containers.html.md.erb
@@ -35,7 +35,7 @@ To create a new container, you will need to:
 
       ```json
       {
-        "name": "example-application", # this will be appended to ghcr.io/ministryofjustice/data-platform-${name}
+        "name": "example-application", # this will be appended to ghcr.io/ministryofjustice/analytical-platform-${name}
         "version": "1.0.0",            # this is the tag that will be applied to the image
         "registry": "ghcr"
       }


### PR DESCRIPTION
Amend one occurrence in the documentation from  data-platform to analytical-platform for ghcr in instruction for creating an image

this is part of the work for this [ticket](https://github.com/ministryofjustice/data-platform/issues/4004)