### PR TITLE
Updated github-airflow-cjs-dashboard-data policy

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-airflow-cjs-dashboard-data/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/github-airflow-cjs-dashboard-data/iam-policies.tf
@@ -5,12 +5,15 @@ data "aws_iam_policy_document" "github_airflow_cjs_dashboard_data" {
     actions = [
       "s3:ListBucket",
       "s3:GetObject",
+      "s3:GetBucketLocation",
       "s3:PutObject",
       "s3:DeleteObject"
     ]
     resources = [
       "arn:aws:s3:::alpha-cjs-scorecard",
-      "arn:aws:s3:::alpha-cjs-scorecard/*"
+      "arn:aws:s3:::alpha-cjs-scorecard/*",
+      "arn:aws:s3:::mojap-athena-query-dump",
+      "arn:aws:s3:::mojap-athena-query-dump/*"
     ]
   }
 


### PR DESCRIPTION
### Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/data-platform/issues/3942) GitHub Issue.

This PR adds the `s3:GetBucketLocation` permission and an additional S3 bucket to the the github-airflow-cjs-dashboard-data IAM policy.

**Note**: `terraform apply` has already been run locally.