### PR TITLE
Add ec2:DescribeLaunchTemplateVersions permission

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/iam-policies.tf
@@ -120,6 +120,7 @@ data "aws_iam_policy_document" "airflow_dev_cluster_autoscaler_policy" {
     effect = "Allow"
     actions = [
       "ec2:DescribeInstanceTypes",
+      "ec2:DescribeLaunchTemplateVersions",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
       "autoscaling:SetDesiredCapacity",
       "autoscaling:DescribeTags",


### PR DESCRIPTION
### Pull Request Objective

As part of the remediation of an earlier Airflow incident, a new version of `cluster-autoscaler` was deployed into development cluster. This version required an additional permission to function: `"ec2:DescribeLaunchTemplateVersions"` This PR ports the manual change into code.

`override-static-analysis` applied because it flagged up a few issues in the component so resolving it should be handled in a ticket.

<!-- Please describe the purpose of this pull request. Detail the problem it addresses or the functionality it adds. Highlight how this contributes to the project goals, improves performance, or solves a specific issue. -->

### Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
