### PR TITLE
:dependabot: Dependabot multi-directory configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,370 +12,62 @@ updates:
       time: "09:00"
       timezone: "Europe/London"
     commit-message:
-      prefix: "github-actions"
+      prefix: ":dependabot: github-actions"
       include: "scope"
     reviewers:
       - "ministryofjustice/analytical-platform"
   - package-ecosystem: "pip"
-    directory: "scripts/pagerduty/rota-to-slack"
     schedule:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
     commit-message:
-      prefix: "pip"
+      prefix: ":dependabot: pip"
       include: "scope"
     reviewers:
       - "ministryofjustice/analytical-platform"
+    directories:
+      - "scripts/pagerduty/rota-to-slack"
   - package-ecosystem: "terraform"
-    directory: "terraform/auth0/alpha-analytics-moj"
     schedule:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
     commit-message:
-      prefix: "terraform"
+      prefix: ":dependabot: terraform"
       include: "scope"
     reviewers:
       - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/auth0/dev-analytics-moj"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/auth0/ministryofjustice-data-platform"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/auth0/ministryofjustice-data-platform-development"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform/baseline"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-engineering-production/10ds"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-engineering-sandbox-a/airflow-hmcts-sdp-load"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/airflow"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/artifact-repos"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/athena"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/cjs-dashboard-app"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/control-panel-message-broker"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/create-a-derived-table"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/data-engineering-pipelines"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/github-airflow-cjs-dashboard-data"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/ingestion-egress"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/openmetadata"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/powerbi-gateway"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/rds-s3-exports"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/s3-glue-crawler"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-data-production/tooling-iam"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-development/auth0-log-streams"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-development/cluster"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-development/control-panel-message-broker"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-development/sagemaker"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-management-production/cluster"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform/oidc"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/aws/analytical-platform-production/cluster"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/cloud-platform/live/data-platform-development/static-assets"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/cloud-platform/live/data-platform-production/actions-runners"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/dpat-eks/production/actions-runners"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
-  - package-ecosystem: "terraform"
-    directory: "terraform/pagerduty"
-    schedule:
-      interval: "daily"
-      time: "09:00"
-      timezone: "Europe/London"
-    commit-message:
-      prefix: "terraform"
-      include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
+    directories:
+      - "terraform/auth0/alpha-analytics-moj"
+      - "terraform/auth0/dev-analytics-moj"
+      - "terraform/auth0/ministryofjustice-data-platform"
+      - "terraform/auth0/ministryofjustice-data-platform-development"
+      - "terraform/aws/analytical-platform/baseline"
+      - "terraform/aws/analytical-platform-data-engineering-production/10ds"
+      - "terraform/aws/analytical-platform-data-engineering-sandbox-a/airflow-hmcts-sdp-load"
+      - "terraform/aws/analytical-platform-data-production/airflow"
+      - "terraform/aws/analytical-platform-data-production/artifact-repos"
+      - "terraform/aws/analytical-platform-data-production/athena"
+      - "terraform/aws/analytical-platform-data-production/cjs-dashboard-app"
+      - "terraform/aws/analytical-platform-data-production/control-panel-message-broker"
+      - "terraform/aws/analytical-platform-data-production/create-a-derived-table"
+      - "terraform/aws/analytical-platform-data-production/data-engineering-pipelines"
+      - "terraform/aws/analytical-platform-data-production/github-airflow-cjs-dashboard-data"
+      - "terraform/aws/analytical-platform-data-production/ingestion-egress"
+      - "terraform/aws/analytical-platform-data-production/openmetadata"
+      - "terraform/aws/analytical-platform-data-production/powerbi-gateway"
+      - "terraform/aws/analytical-platform-data-production/rds-s3-exports"
+      - "terraform/aws/analytical-platform-data-production/s3-glue-crawler"
+      - "terraform/aws/analytical-platform-data-production/tooling-iam"
+      - "terraform/aws/analytical-platform-development/auth0-log-streams"
+      - "terraform/aws/analytical-platform-development/cluster"
+      - "terraform/aws/analytical-platform-development/control-panel-message-broker"
+      - "terraform/aws/analytical-platform-development/sagemaker"
+      - "terraform/aws/analytical-platform-management-production/cluster"
+      - "terraform/aws/analytical-platform/oidc"
+      - "terraform/aws/analytical-platform-production/cluster"
+      - "terraform/cloud-platform/live/data-platform-development/static-assets"
+      - "terraform/cloud-platform/live/data-platform-production/actions-runners"
+      - "terraform/dpat-eks/production/actions-runners"
+      - "terraform/pagerduty"

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -18,17 +18,17 @@ updates:
       time: "09:00"
       timezone: "Europe/London"
     commit-message:
-      prefix: "github-actions"
+      prefix: ":dependabot: github-actions"
       include: "scope"
     reviewers:
       - "ministryofjustice/analytical-platform"
 EOL
 
-for ecosystem in pip terraform; do
+for package_ecosystem in pip terraform; do
 
-  echo "=== Ecosystem: ${ecosystem} ==="
+  echo "=== Ecosystem: ${package_ecosystem} ==="
 
-  case ${ecosystem} in
+  case ${package_ecosystem} in
     pip)
       SEARCH_PATTERN="*requirements*.txt"
       SKIP_FILE=".dependabot-pip-ignore"
@@ -38,6 +38,19 @@ for ecosystem in pip terraform; do
       SKIP_FILE=".dependabot-terraform-ignore"
     ;;
   esac
+
+  printf "  - package-ecosystem: \"%s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    schedule:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "      interval: \"daily\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "      time: \"09:00\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "      timezone: \"Europe/London\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    commit-message:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "      prefix: \":dependabot: %s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "      include: \"scope\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    reviewers:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "      - \"ministryofjustice/analytical-platform\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    directories:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+
 
   folders=$(find . -type f -name "${SEARCH_PATTERN}" -exec dirname {} \; | sort -h | uniq | cut -c 3-)
   export folders
@@ -51,18 +64,7 @@ for ecosystem in pip terraform; do
     echo "Ignoring ${folder}"
     continue
   fi
-    printf "  - package-ecosystem: \"%s\"\n" "${ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "    directory: \"%s\"\n" "${folder}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "    schedule:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "      interval: \"daily\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "      time: \"09:00\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "      timezone: \"Europe/London\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "    commit-message:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "      prefix: \"%s\"\n" "${ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "      include: \"scope\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "    reviewers:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-    printf "      - \"ministryofjustice/analytical-platform\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-
+    printf "      - \"${folder}\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   done
 
 done


### PR DESCRIPTION
This pull request:

- Updates `scripts/dependabot/configuration-generator.sh` to use [Dependabot's new multi-directory configuration](https://github.blog/changelog/2024-04-29-dependabot-multi-directory-configuration-public-beta-now-available/)

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 