### PR TITLE
😭 Remove noisy linters

### DIFF
--- a/.github/workflows/repository-super-linter.yml
+++ b/.github/workflows/repository-super-linter.yml
@@ -47,3 +47,5 @@ jobs:
           VALIDATE_OPENAPI: false
           VALIDATE_KUBERNETES_KUBECONFORM: false
           VALIDATE_TERRAFORM_TERRASCAN: false
+          VALIDATE_CHECKOV: false
+          VALIDATE_JSCPD: false


### PR DESCRIPTION
This pull request:

- Removes Checkov, it loads everything even when `VALIDATE_ALL_CODEBASE: false`
- Removes JSCPD, since upgrading to Super-Linter v6, it processes everything, which makes sense given its looking for code duplication

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 