### PR TITLE
✨ Stream Auth0 Logs to Operations Engineering Account

### DIFF
--- a/terraform/auth0/alpha-analytics-moj/auth0-log-streams.tf
+++ b/terraform/auth0/alpha-analytics-moj/auth0-log-streams.tf
@@ -19,3 +19,14 @@ resource "auth0_log_stream" "aws_eventbridge_analytical_platform_development" {
     aws_region     = "eu-west-2"
   }
 }
+
+resource "auth0_log_stream" "aws_eventbridge_operations_engineering_development" {
+  name   = "operations-engineering-development"
+  type   = "eventbridge"
+  status = "active"
+
+  sink {
+    aws_account_id = "211125434264"
+    aws_region     = "eu-west-2"
+  }
+}


### PR DESCRIPTION
This commit enables streaming to the Operations Engineering AWS account in Mod Platform. By enabling this streaming, we are allowing Operations Engineering to identify users who only use GitHub to auth to various services, avoiding unnecessary account removal due to inactivity.