### PR TITLE
🚑 Revert Amazon Bedrock IAM policy description change

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -64,6 +64,6 @@ data "aws_iam_policy_document" "bedrock_integration" {
 }
 resource "aws_iam_policy" "bedrock_integration" {
   name        = "analytical-platform-bedrock-integration"
-  description = "Permissions to allow access to Bedrock in Frankfurt, Paris and Virginia from tooling."
+  description = "Permissions needed to allow access to Bedrock in Frankfurt from tooling."
   policy      = data.aws_iam_policy_document.bedrock_integration.json
 }


### PR DESCRIPTION
This pull request:

- Reverts the IAM policy description change made in https://github.com/ministryofjustice/data-platform/pull/4269


```
# aws_iam_policy.bedrock_integration must be replaced
-/+ resource "aws_iam_policy" "bedrock_integration" {
      ~ arn              = "arn:aws:iam::593291632749:policy/analytical-platform-bedrock-integration" -> (known after apply)
      ~ attachment_count = 3 -> (known after apply)
      ~ description      = "Permissions needed to allow access to Bedrock in Frankfurt from tooling." -> "Permissions to allow access to Bedrock in Frankfurt, Paris and Virginia from tooling." # forces replacement
      ~ id               = "arn:aws:iam::593291632749:policy/analytical-platform-bedrock-integration" -> (known after apply)
        name             = "analytical-platform-bedrock-integration"
      + name_prefix      = (known after apply)
      ~ policy           = jsonencode(
          ~ {
              ~ Statement = [
                  ~ {
                      ~ Condition = {
                          ~ StringEquals = {
                              ~ "aws:RequestedRegion" = [
                                    "eu-central-1",
                                  + "eu-west-3",
                                    "us-east-1",
                                ]
                            }
                        }
                        # (4 unchanged attributes hidden)
                    },
                ]
                # (1 unchanged attribute hidden)
            }
        )
      ~ policy_id        = "ANPAYUIXP4BWYVD6LK4XM" -> (known after apply)
      - tags             = {} -> null
        # (2 unchanged attributes hidden)
    }

Plan: 1 to add, 0 to change, 1 to destroy.
aws_iam_policy.bedrock_integration: Destroying... [id=arn:aws:iam::5932[91](https://github.com/ministryofjustice/data-platform/actions/runs/8984554346/job/24676691687#step:17:92)632749:policy/analytical-platform-bedrock-integration]
Error: Terraform exited with code 1.
Error: Process completed with exit code 1.
```

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 