### PR TITLE
⏪ Revert enabling of `eu-west-3`

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -56,7 +56,6 @@ data "aws_iam_policy_document" "bedrock_integration" {
       variable = "aws:RequestedRegion"
       values = [
         "eu-central-1",
-        "eu-west-3",
         "us-east-1"
       ]
     }


### PR DESCRIPTION
This pull request:

- Backs out the change https://github.com/ministryofjustice/data-platform/pull/4269

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 