### PR TITLE
Revert "⏪ Revert enabling of `eu-west-3`"

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -56,6 +56,7 @@ data "aws_iam_policy_document" "bedrock_integration" {
       variable = "aws:RequestedRegion"
       values = [
         "eu-central-1",
+        "eu-west-3",
         "us-east-1"
       ]
     }


### PR DESCRIPTION
Reverts ministryofjustice/data-platform#4274 and reenables Bedrock in 🇫🇷 

Context:
https://github.com/ministryofjustice/data-platform/issues/4222