### PR TITLE
Bumping runner chart version

### DIFF
--- a/terraform/dpat-eks/production/actions-runners/create-a-derived-table.tf
+++ b/terraform/dpat-eks/production/actions-runners/create-a-derived-table.tf
@@ -13,7 +13,7 @@ data "aws_secretsmanager_secret_version" "github_actions_self_hosted_runner_crea
 resource "helm_release" "create_a_derived_table" {
   name       = "actions-runner-mojas-create-a-derived-table"
   repository = "oci://ghcr.io/ministryofjustice/data-platform-charts"
-  version    = "2.1.0"
+  version    = "2.316.1"
   chart      = "actions-runner"
   namespace  = "actions-runners"
 


### PR DESCRIPTION
### Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/data-platform-support/issues/595) GitHub Issue.

The message on runner bootup is that the runner version has been deprecated and is unable to receive comms. This PR bumps the helm chart which makes use of the new runner image. 

### Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
