### PR TITLE
🛂 Add ACL permissions to `mojap-land` buckets

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -843,7 +843,9 @@ locals {
                 "s3:GetObject",
                 "s3:PutObject",
                 "s3:DeleteObject",
-                "s3:PutObjectTagging"
+                "s3:PutObjectTagging",
+                "s3:GetObjectAcl",
+                "s3:PutObjectAcl"
               ]
               Resource = [
                 "arn:aws:s3:::mojap-land",
@@ -1066,7 +1068,9 @@ locals {
                 "s3:GetObject",
                 "s3:PutObject",
                 "s3:DeleteObject",
-                "s3:PutObjectTagging"
+                "s3:PutObjectTagging",
+                "s3:GetObjectAcl",
+                "s3:PutObjectAcl"
               ]
               Resource = [
                 "arn:aws:s3:::mojap-land-dev",


### PR DESCRIPTION
This pull request:

is part of https://github.com/ministryofjustice/analytical-platform/issues/4320

- Adds `GetObjectAcl` and `PutObjectAcl` to `mojap-land` buckets

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 