### PR TITLE
Add gpu-compute node pool in ap-development cluster

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-development/cluster/.terraform.lock.hcl
@@ -56,6 +56,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.3"
   constraints = ">= 2.0.0"
   hashes = [
+    "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
     "h1:ZmQ97fIcPW7hj/vynRB4zbtObK0Z/LVJPvCwlNd78zA=",
     "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
     "zh:3055ad0dcc98de1d4e45b72c5889ae91b62f4ae4e54dbc56c4821be0fdfbed91",
@@ -99,6 +100,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.4.1"
   constraints = ">= 1.4.0"
   hashes = [
+    "h1:FzraUapGrJoH3ZOWiUT2m6QpZAD+HmU+JmqZgM4/o2Y=",
     "h1:V2G4qygMV0uHy+QTMlrjSyYgzpYmYyB6gWuE09+5CPI=",
     "zh:244b445bf34ddbd167731cc6c6b95bbed231dc4493f8cc34bd6850cfe1f78528",
     "zh:3c330bdb626123228a0d1b1daa6c741b4d5d484ab1c7ae5d2f48d4c9885cc5e9",

--- a/terraform/aws/analytical-platform-development/cluster/eks-cluster.tf
+++ b/terraform/aws/analytical-platform-development/cluster/eks-cluster.tf
@@ -59,6 +59,37 @@ module "eks" {
       metadata_http_tokens                 = "required"
       metadata_http_put_response_hop_limit = 1
     }
+    gpu_node_pool = {
+      name_prefix            = var.eks_node_group_name_prefix
+      create_launch_template = true
+
+      ami_type       = var.eks_node_group_ami_type_gpu_node
+      instance_types = var.eks_node_group_instance_types_gpu_node
+
+      desired_capacity = var.eks_node_group_capacities_gpu_node["desired"]
+      max_capacity     = var.eks_node_group_capacities_gpu_node["max"]
+      min_capacity     = var.eks_node_group_capacities_gpu_node["min"]
+
+      metadata_http_endpoint               = "enabled"
+      metadata_http_tokens                 = "required"
+      metadata_http_put_response_hop_limit = 1
+
+      update_config = {
+        max_unavailable = 1
+
+      }
+      taints = [
+        {
+          key    = "gpu-compute"
+          value  = "true"
+          effect = "NO_SCHEDULE"
+        }
+      ]
+
+      k8s_labels = {
+        gpu-compute = "true"
+      }
+    }
   }
 
   workers_additional_policies          = ["arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"]

--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -184,6 +184,16 @@ eks_node_group_ami_type       = "AL2_x86_64"
 eks_node_group_disk_size      = 250
 eks_node_group_instance_types = ["r5.2xlarge"]
 
+### GPU-enable node group
+eks_node_group_instance_types_gpu_node = ["p3.2xlarge"]
+eks_node_group_ami_type_gpu_node       = "AL2_x86_64_GPU"
+
+eks_node_group_capacities_gpu_node = {
+  desired = 0
+  max     = 2
+  min     = 0
+}
+
 ##################################################
 # Control Panel
 ##################################################

--- a/terraform/aws/analytical-platform-development/cluster/variables.tf
+++ b/terraform/aws/analytical-platform-development/cluster/variables.tf
@@ -319,6 +319,21 @@ variable "eks_node_group_capacities" {
   description = "The desired capacities for the EKS node group"
 }
 
+variable "eks_node_group_capacities_gpu_node" {
+  type        = map(number)
+  description = "The desired capacities for the EKS GPU node group"
+}
+
+variable "eks_node_group_instance_types_gpu_node" {
+  type        = list(string)
+  description = "The instance types for the EKS GPU node group"
+}
+
+variable "eks_node_group_ami_type_gpu_node" {
+  type        = string
+  description = "The type of AMI to use for the EKS GPU node group"
+}
+
 ##################################################
 # AWS SSO
 ##################################################


### PR DESCRIPTION
Pull Request Objective
This piece of work is being tracked in https://github.com/ministryofjustice/data-platform/issues/4120 GitHub Issue.

The changes in this PR add a GPU-enable node group to the cluster in analytical-platform-development.

**Note**: Static analysis has been overridden as the issues flagged in the development cluster are historic and not arising from the changes made in this PR.