### PR TITLE
add athena permission fir cjs dashoboard

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-airflow-cjs-dashboard-data/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/github-airflow-cjs-dashboard-data/iam-policies.tf
@@ -36,7 +36,8 @@ data "aws_iam_policy_document" "github_airflow_cjs_dashboard_data" {
       "athena:GetTable",
       "athena:GetTables",
       "athena:StartQueryExecution",
-      "athena:StopQueryExecution"
+      "athena:StopQueryExecution",
+      "athena:GetTableMetadata"
     ]
     resources = [
       "arn:aws:athena:*:${var.account_ids["analytical-platform-data-production"]}:datacatalog/AwsDataCatalog",


### PR DESCRIPTION
this pr adds an additional athena permission needed for testing
-is tracked in this support issue #[ministryofjustice/data-platform-support#619](https://github.com/ministryofjustice/data-platform-support/issues/619)