### PR TITLE
🔒 Set Control Panel Development RDS CA to `rds-ca-rsa2048-g1`

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/rds.tf
+++ b/terraform/aws/analytical-platform-development/cluster/rds.tf
@@ -20,6 +20,7 @@ module "rds" {
   snapshot_identifier = var.rds_snapshot_identifier
   maintenance_window  = var.rds_maintenance_window
   backup_window       = var.rds_backup_window
+  ca_cert_identifier  = var.rds_ca_cert_identifier
 
   subnet_ids             = module.vpc.database_subnets
   vpc_security_group_ids = [module.eks.worker_security_group_id]

--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -62,6 +62,7 @@ rds_db_name              = "controlpanel"
 rds_snapshot_identifier  = "newly-encrypted-dev-cp-psg-05012023"
 rds_maintenance_window   = "Mon:00:00-Mon:03:00"
 rds_backup_window        = "03:00-06:00"
+rds_ca_cert_identifier   = "rds-ca-rsa2048-g1"
 rds_monitoring_interval  = 30
 rds_monitoring_role_name = "ControlPanelRDSMonitoringRole-psgdb-encrypted"
 rds_paramaters = [

--- a/terraform/aws/analytical-platform-development/cluster/variables.tf
+++ b/terraform/aws/analytical-platform-development/cluster/variables.tf
@@ -134,6 +134,11 @@ variable "rds_backup_window" {
   description = "Backup window for the RDS instance"
 }
 
+variable "rds_ca_cert_identifier" {
+  type        = string
+  description = "CA certificate for the RDS instance"
+}
+
 variable "rds_monitoring_interval" {
   type        = number
   description = "Monitoring interval for the RDS instance"


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/4247
- Adds `ca_cert_identifier` and sets to `rds-ca-rsa2048-g1`

Note:

<img width="603" alt="Screenshot of RDS console showing no restart required" src="https://github.com/ministryofjustice/analytical-platform/assets/15148673/dbf47718-b862-46df-97d8-495df20b1580">

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 