### PR TITLE
Remove redundant OPG roles

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -435,12 +435,8 @@ locals {
               Effect = "Allow"
               Principal = {
                 AWS = [
-                  "arn:aws:iam::649098267436:role/GlueJobRole20200409082701607800000004",
-                  "arn:aws:iam::492687888235:role/GlueJobRole20200409082023850700000002",
                   "arn:aws:iam::649098267436:role/glue-crawler-production",
                   "arn:aws:iam::649098267436:role/glue-job-production",
-                  "arn:aws:iam::492687888235:role/GlueServiceRole-preproduction20200409082023848800000001",
-                  "arn:aws:iam::649098267436:role/GlueServiceRole-production20200409082701606000000001",
                 ]
               }
               Resource = "arn:aws:s3:::mojap-land/opg/sirius/*"
@@ -456,12 +452,8 @@ locals {
               Effect = "Deny"
               Principal = {
                 AWS = [
-                  "arn:aws:iam::649098267436:role/GlueJobRole20200409082701607800000004",
-                  "arn:aws:iam::492687888235:role/GlueJobRole20200409082023850700000002",
                   "arn:aws:iam::649098267436:role/glue-crawler-production",
                   "arn:aws:iam::649098267436:role/glue-job-production",
-                  "arn:aws:iam::492687888235:role/GlueServiceRole-preproduction20200409082023848800000001",
-                  "arn:aws:iam::649098267436:role/GlueServiceRole-production20200409082701606000000001",
                 ]
               }
               Resource = "arn:aws:s3:::mojap-land/opg/sirius/*"
@@ -477,12 +469,8 @@ locals {
               Effect = "Deny"
               Principal = {
                 AWS = [
-                  "arn:aws:iam::649098267436:role/GlueJobRole20200409082701607800000004",
-                  "arn:aws:iam::492687888235:role/GlueJobRole20200409082023850700000002",
                   "arn:aws:iam::649098267436:role/glue-crawler-production",
                   "arn:aws:iam::649098267436:role/glue-job-production",
-                  "arn:aws:iam::492687888235:role/GlueServiceRole-preproduction20200409082023848800000001",
-                  "arn:aws:iam::649098267436:role/GlueServiceRole-production20200409082701606000000001",
                 ]
               }
               Resource = "arn:aws:s3:::mojap-land/opg/sirius/*"
@@ -498,13 +486,8 @@ locals {
               Effect = "Deny"
               Principal = {
                 AWS = [
-                  "arn:aws:iam::649098267436:role/GlueServiceRole-production20200409082701606000000001",
-                  "arn:aws:iam::492687888235:role/GlueJobRole20200409082023850700000002",
-                  "arn:aws:iam::492687888235:role/GlueServiceRole-preproduction20200409082023848800000001",
                   "arn:aws:iam::649098267436:role/glue-crawler-production",
                   "arn:aws:iam::649098267436:role/glue-job-production",
-                  "arn:aws:iam::649098267436:role/GlueJobRole20200409082701607800000004",
-                  "arn:aws:iam::492687888235:role/GlueJobRole20200409082023850700000002",
                 ]
               }
               Resource = "arn:aws:s3:::mojap-land/opg/sirius/*"


### PR DESCRIPTION
Remove redundant OPG roles from `mojap-land` S3 bucket policy

### Pull Request Objective

Removes roles from OPG account which are going to be deleted as per these slack conversations ([here](https://mojdt.slack.com/archives/CEBNH64PN/p1712935231011439) and [here](https://mojdt.slack.com/archives/CEBNH64PN/p1716298445876779)).

### Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

NA
