### PR TITLE
🌐 Import `analytical-platform.service.justice.gov.uk`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -65,6 +65,7 @@ updates:
       - "terraform/aws/analytical-platform-development/sagemaker"
       - "terraform/aws/analytical-platform-management-production/cluster"
       - "terraform/aws/analytical-platform-production/cluster"
+      - "terraform/aws/analytical-platform-production/route53"
       - "terraform/aws/analytical-platform/baseline"
       - "terraform/aws/analytical-platform/oidc"
       - "terraform/cloud-platform/live/data-platform-development/static-assets"

--- a/terraform/aws/analytical-platform-production/route53/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-production/route53/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.50.0"
+  constraints = "5.50.0"
+  hashes = [
+    "h1:WL4SfIhP8jI5CksUGSgkOFrXvAfbcGnOw0gVrzZZ4rw=",
+    "zh:19be42f5a545d6712dee4bdb704b018d23bacf5d902ac3cb061eb1750dfe6a20",
+    "zh:1d880bdba95ce96efde37e5bcf457a57df2c1effa9b47bc67fa29c1a264ae53b",
+    "zh:1e9c78e324d7492be5e7744436ed71d66fe4eca3fb6af07a28efd0d1e3bf7640",
+    "zh:27ac672aa61b3795931561fdbe4a306ad1132af517d7711c14569429b2cc694f",
+    "zh:3b978423dead02f9a98d25de118adf264a2331acdc4550ea93bed01feabc12e7",
+    "zh:490d7eb4b922ba1b57e0ab8dec1a08df6517485febcab1e091fd6011281c3472",
+    "zh:64e7c84e18dac1af5778d6f516e01a46f9c91d710867c39fbc7efa3cd972dc62",
+    "zh:73867ac2956dcdd377121b3aa8fe2e1085e77fae9b61d018f56a863277ea4b6e",
+    "zh:7ed899d0d5c49f009b445d7816e4bf702d9c48205c24cf884cd2ae0247160455",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b93784b3fb13d08cf95a4131c49b56bf7e1cd35daad6156b3658a89ce6fb58f",
+    "zh:b29d77eb75de474e46eb47e539c48916628d85599bcf14e5cc500b14a4578e75",
+    "zh:bbd9cec8ca705452e4a3d21d56474eacb8cc7b1b74b7f310fdea4bdcffebab32",
+    "zh:c352eb3169efa0e27a29b99a2630e8298710a084453c519caa39e5972ff6d1fc",
+    "zh:e32f4744b43be1708b309a734e0ac10b5c0f9f92e5849298cf1a90f2b906f6f3",
+  ]
+}

--- a/terraform/aws/analytical-platform-production/route53/data.tf
+++ b/terraform/aws/analytical-platform-production/route53/data.tf
@@ -1,0 +1,9 @@
+data "aws_caller_identity" "session" {
+  provider = aws.session
+}
+
+data "aws_iam_session_context" "session" {
+  provider = aws.session
+
+  arn = data.aws_caller_identity.session.arn
+}

--- a/terraform/aws/analytical-platform-production/route53/route53-zones.tf
+++ b/terraform/aws/analytical-platform-production/route53/route53-zones.tf
@@ -1,0 +1,18 @@
+module "route53_zones" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/route53/aws//modules/zones"
+  version = "2.11.1"
+
+  zones = {
+    "analytical-platform.service.justice.gov.uk" = {
+      comment = "Managed by Terraform"
+    }
+  }
+}
+
+import {
+  to = module.route53_zones.aws_route53_zone.this["analytical-platform.service.justice.gov.uk"]
+  id = "Z2TGLAURT6S808"
+}

--- a/terraform/aws/analytical-platform-production/route53/route53-zones.tf
+++ b/terraform/aws/analytical-platform-production/route53/route53-zones.tf
@@ -1,6 +1,8 @@
 module "route53_zones" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  #checkov:skip=CKV2_AWS_38:Will address in the future, this is just an import of the zone
+  #checkov:skip=CKV2_AWS_39:Will address in the future, this is just an import of the zone
 
   source  = "terraform-aws-modules/route53/aws//modules/zones"
   version = "2.11.1"

--- a/terraform/aws/analytical-platform-production/route53/terraform.tf
+++ b/terraform/aws/analytical-platform-production/route53/terraform.tf
@@ -1,0 +1,43 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-production/route53/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.50.0"
+    }
+  }
+  required_version = "~> 1.5"
+}
+
+provider "aws" {
+  alias = "session"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+

--- a/terraform/aws/analytical-platform-production/route53/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/route53/terraform.tfvars
@@ -1,0 +1,15 @@
+account_ids = {
+  analytical-platform-management-production = "042130406152"
+  analytical-platform-production            = "312423030077"
+}
+
+tags = {
+  business-unit          = "Platforms"
+  application            = "Analytical Platform"
+  component              = "route53"
+  environment            = "production"
+  is-production          = "true"
+  owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/analytical-platform/terraform/aws/analytical-platform-production/route53"
+}

--- a/terraform/aws/analytical-platform-production/route53/variables.tf
+++ b/terraform/aws/analytical-platform-production/route53/variables.tf
@@ -1,0 +1,9 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}


### PR DESCRIPTION
This pull request:

Is part of https://github.com/ministryofjustice/analytical-platform/issues/3555

- Imports `analytical-platform.service.justice.gov.uk` into code so we can create records programatically instead of ClickOps 🙅 I need to create some NSs from the compute environments

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 