### PR TITLE
🛂 Create IAM role for Analytical Platform Compute Route53

### DIFF
--- a/terraform/aws/analytical-platform-production/route53/iam-polices.tf
+++ b/terraform/aws/analytical-platform-production/route53/iam-polices.tf
@@ -1,4 +1,6 @@
 data "aws_iam_policy_document" "analytical_platform_compute_route53_access" {
+  #checkov:skip=CKV_AWS_356:Wildcard is suggested from listing zones
+
   statement {
     sid    = "AllowRoute53List"
     effect = "Allow"

--- a/terraform/aws/analytical-platform-production/route53/iam-polices.tf
+++ b/terraform/aws/analytical-platform-production/route53/iam-polices.tf
@@ -1,3 +1,4 @@
+#trivy:ignore:avd-aws-0057:Wildcard is suggested from listing zones
 data "aws_iam_policy_document" "analytical_platform_compute_route53_access" {
   #checkov:skip=CKV_AWS_356:Wildcard is suggested from listing zones
 

--- a/terraform/aws/analytical-platform-production/route53/iam-polices.tf
+++ b/terraform/aws/analytical-platform-production/route53/iam-polices.tf
@@ -1,0 +1,32 @@
+data "aws_iam_policy_document" "analytical_platform_compute_route53_access" {
+  statement {
+    sid    = "AllowRoute53List"
+    effect = "Allow"
+    actions = [
+      "route53:ListHostedZones",
+      "route53:ListResourceRecordSets",
+      "route53:ListTagsForResource"
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "AllowRoute53ChangeResourceRecordSets"
+    effect = "Allow"
+    actions = [
+      "route53:ChangeResourceRecordSets"
+    ]
+    resources = [module.route53_zones.route53_zone_zone_arn["analytical-platform.service.justice.gov.uk"]]
+  }
+}
+
+module "analytical_platform_compute_route53_access_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.39.1"
+
+  name_prefix = "analytical-platform-compute-route53-access"
+
+  policy = data.aws_iam_policy_document.analytical_platform_compute_route53_access.json
+}

--- a/terraform/aws/analytical-platform-production/route53/iam-roles.tf
+++ b/terraform/aws/analytical-platform-production/route53/iam-roles.tf
@@ -1,0 +1,20 @@
+module "analytical_platform_compute_route53_access_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.39.1"
+
+  create_role = true
+
+  role_name         = "analytical-platform-compute-route53-access"
+  role_requires_mfa = false
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.account_ids["analytical-platform-compute-development"]}:root",
+    "arn:aws:iam::${var.account_ids["analytical-platform-compute-test"]}:root",
+    "arn:aws:iam::${var.account_ids["analytical-platform-compute-production"]}:root",
+  ]
+
+  custom_role_policy_arns = [module.analytical_platform_compute_route53_access_iam_policy.arn]
+}

--- a/terraform/aws/analytical-platform-production/route53/route53-records.tf
+++ b/terraform/aws/analytical-platform-production/route53/route53-records.tf
@@ -1,0 +1,45 @@
+module "route53_records" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/route53/aws//modules/records"
+  version = "2.11.1"
+
+  zone_id = module.route53_zones.route53_zone_zone_id["analytical-platform.service.justice.gov.uk"]
+
+  records = [
+    {
+      name = "compute.development"
+      type = "NS"
+      ttl  = 300
+      records = [
+        "ns-676.awsdns-20.net.",
+        "ns-492.awsdns-61.com.",
+        "ns-1979.awsdns-55.co.uk.",
+        "ns-1364.awsdns-42.org."
+      ]
+    },
+    {
+      name = "compute.test"
+      type = "NS"
+      ttl  = 300
+      records = [
+        "ns-329.awsdns-41.com.",
+        "ns-736.awsdns-28.net.",
+        "ns-1094.awsdns-08.org.",
+        "ns-1604.awsdns-08.co.uk."
+      ]
+    },
+    {
+      name = "compute"
+      type = "NS"
+      ttl  = 300
+      records = [
+        "ns-1143.awsdns-14.org.",
+        "ns-121.awsdns-15.com.",
+        "ns-633.awsdns-15.net.",
+        "ns-1852.awsdns-39.co.uk."
+      ]
+    }
+  ]
+}

--- a/terraform/aws/analytical-platform-production/route53/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/route53/terraform.tfvars
@@ -1,4 +1,7 @@
 account_ids = {
+  analytical-platform-compute-development   = "381491960855"
+  analytical-platform-compute-test          = "767397661611"
+  analytical-platform-compute-production    = "992382429243"
   analytical-platform-management-production = "042130406152"
   analytical-platform-production            = "312423030077"
 }


### PR DESCRIPTION
This pull request:

Is part of https://github.com/ministryofjustice/analytical-platform/issues/3555

- Adds a role that can be assumed by `analytical-platform-compute` environments, to make changes to `analytical-platform.service.justice.gov.uk` zone

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 