### PR TITLE
 🔧 Update Airflow Node group name

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -83,7 +83,7 @@ output "kubeconfig_certificate_authority_data" {
 
 resource "aws_eks_node_group" "new_dev_node_group_standard" {
   cluster_name    = aws_eks_cluster.airflow_dev_eks_cluster.name
-  node_group_name = "new-standard"
+  node_group_name = "standard"
   node_role_arn   = aws_iam_role.airflow_dev_node_instance_role.arn
   subnet_ids      = aws_subnet.dev_private_subnet[*].id
 
@@ -110,7 +110,7 @@ resource "aws_eks_node_group" "new_dev_node_group_standard" {
 
 resource "aws_eks_node_group" "new_dev_node_group_high_memory" {
   cluster_name    = aws_eks_cluster.airflow_dev_eks_cluster.name
-  node_group_name = "new-high-memory"
+  node_group_name = "high-memory"
   node_role_arn   = aws_iam_role.airflow_dev_node_instance_role.arn
   subnet_ids      = aws_subnet.dev_private_subnet[*].id
 

--- a/terraform/aws/analytical-platform-data-production/airflow/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/iam-policies.tf
@@ -119,14 +119,17 @@ data "aws_iam_policy_document" "airflow_dev_cluster_autoscaler_policy" {
     sid    = ""
     effect = "Allow"
     actions = [
-      "ec2:DescribeInstanceTypes",
-      "ec2:DescribeLaunchTemplateVersions",
-      "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:SetDesiredCapacity",
-      "autoscaling:DescribeTags",
-      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
-      "autoscaling:DescribeAutoScalingGroups"
+      "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeScalingActivities",
+      "autoscaling:DescribeTags",
+      "autoscaling:SetDesiredCapacity",
+      "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeImages",
+      "ec2:GetInstanceTypesFromInstanceRequirements",
+      "eks:DescribeNodegroup"
     ]
     resources = ["*"]
   }


### PR DESCRIPTION
Additionally add a permission required to scale up the `high-memory` node group in dev. The prod role has not been imported into terraform.

Created as part of [this](https://github.com/ministryofjustice/analytical-platform/issues/4389) ticket.