### PR TITLE
🛂 Add APC OIDC to CaDeT

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
@@ -96,7 +96,7 @@ module "create_a_derived_table_iam_policy" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "5.39.0"
+  version = "5.39.1"
 
   name_prefix = "create-a-derived-table"
 

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-roles.tf
@@ -2,7 +2,7 @@ module "create_a_derived_table_iam_role" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
-  version = "5.39.0"
+  version = "5.39.1"
 
   role_name = "create-a-derived-table"
 
@@ -13,6 +13,10 @@ module "create_a_derived_table_iam_role" {
   }
 
   oidc_providers = {
+    analytical-platform-compute-production = {
+      provider_arn               = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/801920EDEF91E3CAB03E04C03A2DE2BB"
+      namespace_service_accounts = ["actions-runners:actions-runner-mojas-create-a-derived-table"]
+    }
     cloud-platform = {
       provider_arn               = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/DF366E49809688A3B16EEC29707D8C09"
       namespace_service_accounts = ["data-platform-production:actions-runner-mojas-create-a-derived-table"]


### PR DESCRIPTION
This pull request:

- Adds APC production's OIDC provider to CaDeT role
  - OIDC provider was created with ✨ _ClickOps_ ✨
- Updates IAM module 

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 