### PR TITLE
Add policy to allow quicksight author access

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -63,6 +63,7 @@ updates:
       - "terraform/aws/analytical-platform-development/cluster"
       - "terraform/aws/analytical-platform-development/control-panel-message-broker"
       - "terraform/aws/analytical-platform-development/sagemaker"
+      - "terraform/aws/analytical-platform-development/tooling-iam"
       - "terraform/aws/analytical-platform-management-production/cluster"
       - "terraform/aws/analytical-platform-production/cluster"
       - "terraform/aws/analytical-platform-production/route53"

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 4.0.0, 5.47.0"
   hashes = [
     "h1:49aEnvHJ/M8BRGAXKzU6W3zSbf7HgIrjXkXjC5DGEWY=",
+    "h1:GZQJi9mfuKBkN5MCba5nHSG3kAJJf7OoxQcFgIpuPCw=",
     "zh:06037a14e47e8f82d0b3b326cd188566272b808b7970a9249a11db26d475b83d",
     "zh:116b7dd58ca964a1056249d2b6550f399b0a6bc9a7920b7ee134242114432c9f",
     "zh:1aa089c81459071c1d65ba7454f1122159e1fa1b5384e6e9ef85c8264f8a9ecb",

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -63,7 +63,14 @@ data "aws_iam_policy_document" "bedrock_integration" {
     }
   }
 }
-#tfsec:ignore:aws-iam-no-policy-wildcards
+
+resource "aws_iam_policy" "bedrock_integration" {
+  name        = "analytical-platform-bedrock-integration"
+  description = "Permissions needed to allow access to Bedrock in Frankfurt from tooling."
+  policy      = data.aws_iam_policy_document.bedrock_integration.json
+}
+
+#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "quicksight_author" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
@@ -72,7 +79,7 @@ data "aws_iam_policy_document" "quicksight_author" {
     sid       = "CreateAuthor"
     effect    = "Allow"
     actions   = ["quicksight:CreateUser"]
-    resources = ["arn:aws:quicksight::593291632749:user/${data.aws_caller_identity.current.user_id}"]
+    resources = ["arn:aws:quicksight::${var.account_ids["analytical-platform-data-production"]}:user/$${aws:userid}"]
   }
 
   statement {
@@ -105,13 +112,8 @@ data "aws_iam_policy_document" "quicksight_author" {
     resources = ["*"]
   }
 }
-resource "aws_iam_policy" "bedrock_integration" {
-  name        = "analytical-platform-bedrock-integration"
-  description = "Permissions needed to allow access to Bedrock in Frankfurt from tooling."
-  policy      = data.aws_iam_policy_document.bedrock_integration.json
-}
+
 resource "aws_iam_policy" "quicksight_author" {
-  name        = "alpha-quicksight-author-access"
-  description = "Permissions needed to for author access to Quicksight"
-  policy      = data.aws_iam_policy_document.quicksight_author.json
+  name   = "alpha-quicksight-author-access"
+  policy = data.aws_iam_policy_document.quicksight_author.json
 }

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -74,6 +74,7 @@ resource "aws_iam_policy" "bedrock_integration" {
 data "aws_iam_policy_document" "quicksight_author" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+  #checkov:skip=CKV_AWS_109: Needs to access multiple resources
 
   statement {
     sid       = "CreateAuthor"

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -63,8 +63,54 @@ data "aws_iam_policy_document" "bedrock_integration" {
     }
   }
 }
+data "aws_iam_policy_document" "quicksight_author" {
+  #checkov:skip=CKV_AWS_111: This is a service policy
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+
+  statement {
+    sid       = "CreateAuthor"
+    effect    = "Allow"
+    actions   = ["quicksight:CreateUser"]
+    resources = ["arn:aws:quicksight::593291632749:user/${data.aws_caller_identity.current.user_id}"]
+  }
+
+  statement {
+    sid       = "QuicksightAuthor"
+    effect    = "Allow"
+
+    actions   = [
+      "quicksight:UpdateTemplate",
+      "quicksight:ListUsers",
+      "quicksight:UpdateDashboard",
+      "quicksight:CreateTemplate",
+      "quicksight:ListTemplates",
+      "quicksight:DescribeTemplate",
+      "quicksight:DescribeDataSource",
+      "quicksight:DescribeDataSourcePermissions",
+      "quicksight:PassDataSource",
+      "quicksight:UpdateDataSource",
+      "quicksight:UpdateDataSetPermissions",
+      "quicksight:DescribeDataSet",
+      "quicksight:DescribeDataSetPermissions",
+      "quicksight:PassDataSet",
+      "quicksight:DescribeIngestion",
+      "quicksight:ListIngestions",
+      "quicksight:UpdateDataSet",
+      "quicksight:DeleteDataSet",
+      "quicksight:CreateIngestion",
+      "quicksight:CancelIngestion"
+    ]
+
+    resources = ["*"]
+  }
+}
 resource "aws_iam_policy" "bedrock_integration" {
   name        = "analytical-platform-bedrock-integration"
   description = "Permissions needed to allow access to Bedrock in Frankfurt from tooling."
   policy      = data.aws_iam_policy_document.bedrock_integration.json
+}
+resource "aws_iam_policy" "quicksight_author" {
+  name        = "alpha-quicksight-author-access"
+  description = "Permissions needed to for author access to Quicksight"
+  policy      = data.aws_iam_policy_document.quicksight_author.json
 }

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -63,6 +63,7 @@ data "aws_iam_policy_document" "bedrock_integration" {
     }
   }
 }
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "quicksight_author" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -75,10 +75,10 @@ data "aws_iam_policy_document" "quicksight_author" {
   }
 
   statement {
-    sid       = "QuicksightAuthor"
-    effect    = "Allow"
+    sid    = "QuicksightAuthor"
+    effect = "Allow"
 
-    actions   = [
+    actions = [
       "quicksight:UpdateTemplate",
       "quicksight:ListUsers",
       "quicksight:UpdateDashboard",

--- a/terraform/aws/analytical-platform-development/cluster/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-development/cluster/.terraform.lock.hcl
@@ -28,7 +28,7 @@ provider "registry.terraform.io/auth0/auth0" {
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.47.0"
-  constraints = ">= 3.0.0, >= 3.56.0, >= 4.0.0, >= 4.18.0, >= 4.47.0, >= 5.30.0, >= 5.36.0, 5.47.0"
+  constraints = ">= 3.0.0, >= 3.56.0, >= 4.0.0, >= 4.18.0, >= 4.47.0, >= 5.30.0, >= 5.47.0, 5.47.0"
   hashes = [
     "h1:49aEnvHJ/M8BRGAXKzU6W3zSbf7HgIrjXkXjC5DGEWY=",
     "h1:GZQJi9mfuKBkN5MCba5nHSG3kAJJf7OoxQcFgIpuPCw=",
@@ -56,6 +56,7 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
   version     = "2.3.3"
   constraints = ">= 2.0.0"
   hashes = [
+    "h1:6utKe3l0lf4+hw+uVK8XJVNdOmp7tOTcycyFvv1pGAA=",
     "h1:U6EC4/cJJ6Df3LztUQ/I4YuljGQQeQ+LdLndAwSSiTs=",
     "h1:ZmQ97fIcPW7hj/vynRB4zbtObK0Z/LVJPvCwlNd78zA=",
     "zh:0bd6ee14ca5cf0f0c83d3bb965346b1225ccd06a6247e80774aaaf54c729daa7",
@@ -74,8 +75,10 @@ provider "registry.terraform.io/hashicorp/cloudinit" {
 }
 
 provider "registry.terraform.io/hashicorp/helm" {
-  version = "2.13.2"
+  version     = "2.13.2"
+  constraints = "2.13.2"
   hashes = [
+    "h1:8Fuh4tL7C6vxe8/JQDCM5J3MQxEhd9XNXYBCgqeuyww=",
     "h1:nlSqCo0PajJzjSlx0lXNUq1YcOr8p9b3ahcUUYN2pEg=",
     "zh:06c0663031ef5aa19e238fe50be5d3cbf5fb00548d2b26e779c607dfd2dc69a7",
     "zh:1850b8f2e729553ba8b96d69dce035b814ce959c6805c25484f407c4e720c497",
@@ -119,6 +122,7 @@ provider "registry.terraform.io/hashicorp/local" {
   version     = "2.4.1"
   constraints = ">= 1.4.0"
   hashes = [
+    "h1:7lfUMKAsu/HRUUs02tJxBle9XvSuNKkpTOqcFqMe5JI=",
     "h1:FzraUapGrJoH3ZOWiUT2m6QpZAD+HmU+JmqZgM4/o2Y=",
     "h1:V2G4qygMV0uHy+QTMlrjSyYgzpYmYyB6gWuE09+5CPI=",
     "zh:244b445bf34ddbd167731cc6c6b95bbed231dc4493f8cc34bd6850cfe1f78528",
@@ -140,6 +144,7 @@ provider "registry.terraform.io/hashicorp/null" {
   version     = "3.2.2"
   constraints = ">= 3.0.0"
   hashes = [
+    "h1:Gef5VGfobY5uokA5nV/zFvWeMNR2Pmq79DH94QnNZPM=",
     "h1:vWAsYRd7MjYr3adj8BVKRohVfHpWQdvkIwUQ2Jf5FVM=",
     "h1:zT1ZbegaAYHwQa+QwIFugArWikRJI9dqohj8xb0GY88=",
     "zh:3248aae6a2198f3ec8394218d05bd5e42be59f43a3a7c0b71c66ec0df08b69e7",

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -61,57 +61,8 @@ data "aws_iam_policy_document" "bedrock_integration" {
   }
 }
 
-#tfsec:ignore:aws-iam-no-policy-wildcards
-data "aws_iam_policy_document" "quicksight_author" {
-  #checkov:skip=CKV_AWS_111: This is a service policy
-  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
-
-  statement {
-    sid       = "CreateAuthor"
-    effect    = "Allow"
-    actions   = ["quicksight:CreateUser"]
-    resources = ["arn:aws:quicksight::593291632749:user/${data.aws_caller_identity.current.user_id}"]
-  }
-
-  statement {
-    sid    = "QuicksightAuthor"
-    effect = "Allow"
-
-    actions = [
-      "quicksight:UpdateTemplate",
-      "quicksight:ListUsers",
-      "quicksight:UpdateDashboard",
-      "quicksight:CreateTemplate",
-      "quicksight:ListTemplates",
-      "quicksight:DescribeTemplate",
-      "quicksight:DescribeDataSource",
-      "quicksight:DescribeDataSourcePermissions",
-      "quicksight:PassDataSource",
-      "quicksight:UpdateDataSource",
-      "quicksight:UpdateDataSetPermissions",
-      "quicksight:DescribeDataSet",
-      "quicksight:DescribeDataSetPermissions",
-      "quicksight:PassDataSet",
-      "quicksight:DescribeIngestion",
-      "quicksight:ListIngestions",
-      "quicksight:UpdateDataSet",
-      "quicksight:DeleteDataSet",
-      "quicksight:CreateIngestion",
-      "quicksight:CancelIngestion"
-    ]
-
-    resources = ["*"]
-  }
-}
-
 resource "aws_iam_policy" "bedrock_integration" {
   name        = "analytical-platform-bedrock-integration"
   description = "Permissions needed to allow access to Bedrock in Frankfurt from tooling."
   policy      = data.aws_iam_policy_document.bedrock_integration.json
-}
-
-resource "aws_iam_policy" "quicksight_author" {
-  name        = "dev-quicksight-author-access"
-  description = "Permissions needed to for author access to Quicksight"
-  policy      = data.aws_iam_policy_document.quicksight_author.json
 }

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -61,6 +61,7 @@ data "aws_iam_policy_document" "bedrock_integration" {
   }
 }
 
+#tfsec:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "quicksight_author" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -73,10 +73,10 @@ data "aws_iam_policy_document" "quicksight_author" {
   }
 
   statement {
-    sid       = "QuicksightAuthor"
-    effect    = "Allow"
+    sid    = "QuicksightAuthor"
+    effect = "Allow"
 
-    actions   = [
+    actions = [
       "quicksight:UpdateTemplate",
       "quicksight:ListUsers",
       "quicksight:UpdateDashboard",

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -60,8 +60,57 @@ data "aws_iam_policy_document" "bedrock_integration" {
     }
   }
 }
+
+data "aws_iam_policy_document" "quicksight_author" {
+  #checkov:skip=CKV_AWS_111: This is a service policy
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+
+  statement {
+    sid       = "CreateAuthor"
+    effect    = "Allow"
+    actions   = ["quicksight:CreateUser"]
+    resources = ["arn:aws:quicksight::593291632749:user/${data.aws_caller_identity.current.user_id}"]
+  }
+
+  statement {
+    sid       = "QuicksightAuthor"
+    effect    = "Allow"
+
+    actions   = [
+      "quicksight:UpdateTemplate",
+      "quicksight:ListUsers",
+      "quicksight:UpdateDashboard",
+      "quicksight:CreateTemplate",
+      "quicksight:ListTemplates",
+      "quicksight:DescribeTemplate",
+      "quicksight:DescribeDataSource",
+      "quicksight:DescribeDataSourcePermissions",
+      "quicksight:PassDataSource",
+      "quicksight:UpdateDataSource",
+      "quicksight:UpdateDataSetPermissions",
+      "quicksight:DescribeDataSet",
+      "quicksight:DescribeDataSetPermissions",
+      "quicksight:PassDataSet",
+      "quicksight:DescribeIngestion",
+      "quicksight:ListIngestions",
+      "quicksight:UpdateDataSet",
+      "quicksight:DeleteDataSet",
+      "quicksight:CreateIngestion",
+      "quicksight:CancelIngestion"
+    ]
+
+    resources = ["*"]
+  }
+}
+
 resource "aws_iam_policy" "bedrock_integration" {
   name        = "analytical-platform-bedrock-integration"
   description = "Permissions needed to allow access to Bedrock in Frankfurt from tooling."
   policy      = data.aws_iam_policy_document.bedrock_integration.json
+}
+
+resource "aws_iam_policy" "quicksight_author" {
+  name        = "dev-quicksight-author-access"
+  description = "Permissions needed to for author access to Quicksight"
+  policy      = data.aws_iam_policy_document.quicksight_author.json
 }

--- a/terraform/aws/analytical-platform-development/tooling-iam/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-development/tooling-iam/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.52.0"
+  constraints = "5.52.0"
+  hashes = [
+    "h1:J3LWKMuD1JwXmlleW3vJ7FHk/Dc+gCLgrpRtjBxZ5Ro=",
+    "zh:22c4599d47cd59e5519c52afc528fa2aec43b4434f369870ee2806daa071449d",
+    "zh:3c2edc482662a654f84db4cd3f2cdd8f200147207d053d2e95082744b7814e6d",
+    "zh:57edc36f908c64de37e92a978f3d675604315a725268da936fcd1e270199db47",
+    "zh:79e7afd5fb161f2eb2b7f8e7fd5cbb7f56a2c64f141b56f511ec69337ad3e96b",
+    "zh:82c6ae9a7f971b6ee8c476b6eb7f1be9d24ddd183cbf025f52628084ddb3a5ae",
+    "zh:92faecc0a8f573f57f37d24415862380a40341eb13d66beb738dd0873899a58e",
+    "zh:963d3c0e1aa22c872cd96f04ceb41c388137b972f714efbde989221bf7f6f723",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:af6d3bb94aa8a84d740e3731d2379cc5e12aa48d5db0f7489c4639f3814a22d7",
+    "zh:b9f7aceeaf5daf71394eab9bf0f9f56fdc762cac90e4d62e63aa3fcdf6c1c127",
+    "zh:c3dcfc2569edae4f36b798c76da7f7633e7bf322505d447d7c370a56c2a30dd2",
+    "zh:c8abb21c5ceba857f0eaff9e531d781dc655f8cdfae1cf056066daae72546a7f",
+    "zh:d92004a6a2a770d2542fd9c01b685418ab8d7ab422cf2cdce35dde789bc8593c",
+    "zh:dc794660b1d6d8f26a917e0ffab1875aa75144736875efaa60f29c72bf02afbf",
+    "zh:df931c4905e35ae43d558f6cda15f05710a7a24ecbb94533f8822e7572126512",
+  ]
+}

--- a/terraform/aws/analytical-platform-development/tooling-iam/terraform.tf
+++ b/terraform/aws/analytical-platform-development/tooling-iam/terraform.tf
@@ -1,0 +1,38 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-development/tooling-iam/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.52.0"
+    }
+  }
+  required_version = "~> 1.5"
+}
+
+provider "aws" {
+  region = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-development"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-1"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-development/tooling-iam/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/tooling-iam/terraform.tfvars
@@ -1,0 +1,19 @@
+##################################################
+# General
+##################################################
+
+account_ids = {
+  analytical-platform-development           = "525294151996"
+  analytical-platform-management-production = "042130406152"
+}
+
+tags = {
+  business-unit          = "Platforms"
+  application            = "Analytical Platform"
+  component              = "Tooling IAM"
+  environment            = "development"
+  is-production          = "false"
+  owner                  = "analytical-platform:analytics-platform-tech@digital.justice.gov.uk"
+  infrastructure-support = "analytical-platform:analytics-platform-tech@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/analytical-platform/terraform/aws/analytical-platform-development/tooling-iam"
+}

--- a/terraform/aws/analytical-platform-development/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/tooling-iam/tooling-integration-iam-policies.tf
@@ -1,0 +1,47 @@
+#trivy:ignore:aws-iam-no-policy-wildcards
+data "aws_iam_policy_document" "quicksight_author" {
+  #checkov:skip=CKV_AWS_111: This is a service policy
+  #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+
+  statement {
+    sid       = "CreateAuthor"
+    effect    = "Allow"
+    actions   = ["quicksight:CreateUser"]
+    resources = ["arn:aws:quicksight::${var.account_ids["analytical-platform-development"]}:user/$${aws:userid}"]
+  }
+
+  statement {
+    sid    = "QuicksightAuthor"
+    effect = "Allow"
+
+    actions = [
+      "quicksight:UpdateTemplate",
+      "quicksight:ListUsers",
+      "quicksight:UpdateDashboard",
+      "quicksight:CreateTemplate",
+      "quicksight:ListTemplates",
+      "quicksight:DescribeTemplate",
+      "quicksight:DescribeDataSource",
+      "quicksight:DescribeDataSourcePermissions",
+      "quicksight:PassDataSource",
+      "quicksight:UpdateDataSource",
+      "quicksight:UpdateDataSetPermissions",
+      "quicksight:DescribeDataSet",
+      "quicksight:DescribeDataSetPermissions",
+      "quicksight:PassDataSet",
+      "quicksight:DescribeIngestion",
+      "quicksight:ListIngestions",
+      "quicksight:UpdateDataSet",
+      "quicksight:DeleteDataSet",
+      "quicksight:CreateIngestion",
+      "quicksight:CancelIngestion"
+    ]
+
+    resources = ["*"]
+  }
+}
+
+resource "aws_iam_policy" "quicksight_author" {
+  name   = "alpha-quicksight-author-access"
+  policy = data.aws_iam_policy_document.quicksight_author.json
+}

--- a/terraform/aws/analytical-platform-development/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/tooling-iam/tooling-integration-iam-policies.tf
@@ -2,6 +2,7 @@
 data "aws_iam_policy_document" "quicksight_author" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
+  #checkov:skip=CKV_AWS_109: Needs to access multiple resources
 
   statement {
     sid       = "CreateAuthor"

--- a/terraform/aws/analytical-platform-development/tooling-iam/variables.tf
+++ b/terraform/aws/analytical-platform-development/tooling-iam/variables.tf
@@ -1,0 +1,13 @@
+##################################################
+# General
+##################################################
+
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}


### PR DESCRIPTION
- Policy does not exist in analytical-platform-development account so this PR should create the policy
- The policy already existed in data-production account, but was managed in code. Therefore I have imported the state and added the code.

### Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/4370) GitHub Issue.

<!-- Please describe the purpose of this pull request. Detail the problem it addresses or the functionality it adds. Highlight how this contributes to the project goals, improves performance, or solves a specific issue. -->

### Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
