### PR TITLE
Grant Control Panel role read policy permissions

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -348,6 +348,15 @@ data "aws_iam_policy_document" "control_panel_api" {
     resources = ["arn:aws:iam::${var.account_ids["analytical-platform-development"]}:policy/${var.resource_prefix}-*"]
   }
   statement {
+    sid    = "CanReadIAMPolicies"
+    effect = "Allow"
+    actions = [
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+    ]
+    resources = ["arn:aws:iam::${var.account_ids["analytical-platform-development"]}:policy/*"]
+  }
+  statement {
     sid     = "CanAttachPolicies"
     effect  = "Allow"
     actions = ["iam:AttachRolePolicy", ]

--- a/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
@@ -75,6 +75,15 @@ data "aws_iam_policy_document" "control_panel_api" {
     resources = ["arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:policy/${var.resource_prefix}-*"]
   }
   statement {
+    sid    = "CanReadIAMPolicies"
+    effect = "Allow"
+    actions = [
+      "iam:GetPolicy",
+      "iam:GetPolicyVersion",
+    ]
+    resources = ["arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:policy/*"]
+  }
+  statement {
     sid     = "CanAttachPolicies"
     effect  = "Allow"
     actions = ["iam:AttachRolePolicy", ]


### PR DESCRIPTION
### Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/4370) GitHub Issue.

Additional permissions are required by the Control Panel role to check a users IAM policies, to check if they have Quicksight enabled or not

### Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://technical-documentation.data-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
