### PR TITLE
🚑 Add provider to Kubernetes SA

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/kubernetes-service-accounts.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/kubernetes-service-accounts.tf
@@ -1,4 +1,6 @@
-resource "kubernetes_service_account" "airflow" {
+resource "kubernetes_service_account" "dev_airflow" {
+  provider = kubernetes.dev-airflow-cluster
+
   metadata {
     namespace = kubernetes_namespace.dev_airflow.metadata[0].name
     name      = "airflow"


### PR DESCRIPTION
This pull request:

- Adds providers to Kubernetes SA, dev and prod's providers are aliased, there is no default

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 