### PR TITLE
change oidc config

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
@@ -103,7 +103,7 @@ module "airflow_dev_monitoring_iam_role" {
 
   oidc_providers = {
     one = {
-      provider_arn               = resource.aws_iam_openid_connect_provider.analytical_platform_development.arn
+      provider_arn               = aws_eks_cluster.airflow_dev_eks_cluster.identity[0].oidc[0].issuer
       namespace_service_accounts = ["airflow:airflow"]
     }
   }


### PR DESCRIPTION
Change to oidc provider config on the airflow-monitoring-dev role to match oidc provider on airflow dev cluster as resolution  to fix assume role issues in running the DAG this relates to work in this [issue](https://github.com/ministryofjustice/analytical-platform/issues/4319) 