### PR TITLE
⏫ Airflow: Development EKS `1.25` -> `1.26`

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -7,7 +7,7 @@ resource "aws_eks_cluster" "airflow_dev_eks_cluster" {
     "controllerManager",
     "scheduler",
   ]
-  version = "1.25"
+  version = "1.26"
 
   vpc_config {
     subnet_ids          = aws_subnet.dev_private_subnet[*].id

--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -289,14 +289,14 @@ resource "kubernetes_namespace" "kyverno_prod" {
 resource "aws_eks_addon" "kube_proxy_dev" {
   cluster_name                = var.dev_eks_cluster_name
   addon_name                  = "kube-proxy"
-  addon_version               = "v1.25.14-eksbuild.2"
+  addon_version               = "v1.26.15-eksbuild.2"
   resolve_conflicts_on_create = "OVERWRITE"
 }
 
 resource "aws_eks_addon" "vpc_cni_dev" {
   cluster_name                = var.dev_eks_cluster_name
   addon_name                  = "vpc-cni"
-  addon_version               = "v1.16.0-eksbuild.1"
+  addon_version               = "v1.18.1-eksbuild.3"
   resolve_conflicts_on_create = "OVERWRITE"
 }
 

--- a/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/iam-roles.tf
@@ -103,7 +103,7 @@ module "airflow_dev_monitoring_iam_role" {
 
   oidc_providers = {
     one = {
-      provider_arn               = aws_eks_cluster.airflow_dev_eks_cluster.identity[0].oidc[0].issuer
+      provider_arn               = resource.aws_iam_openid_connect_provider.analytical_platform_development.arn
       namespace_service_accounts = ["airflow:airflow"]
     }
   }

--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -52,7 +52,7 @@ resource "aws_launch_template" "dev_standard" {
 
 resource "aws_launch_template" "dev_high_memory" {
   name          = "dev_high_memory"
-  image_id      = "ami-03857889452e262ff"
+  image_id      = "ami-0e169b410a06c4a29"
   instance_type = "r6i.8xlarge"
 
   disable_api_stop        = false

--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -1,6 +1,6 @@
 resource "aws_launch_template" "dev_standard" {
   name          = "dev_standard"
-  image_id      = "ami-0aa9fe9eb35cf4eaf"
+  image_id      = "ami-0e169b410a06c4a29"
   instance_type = "t3a.large"
 
   disable_api_stop        = false


### PR DESCRIPTION
Raised in relation to [this](https://github.com/ministryofjustice/analytical-platform/issues/4426) piece of work.

Upgrades: 
- control plane version `1.25` -> `1.26`
- node groups AMI 
- Add Ons