### PR TITLE
⏫ Airflow: Development EKS `1.26` -> `1.27`

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -18,7 +18,7 @@ resource "aws_eks_cluster" "airflow_dev_eks_cluster" {
 
 resource "aws_security_group" "airflow_dev_cluster_additional_security_group" {
   name        = var.dev_cluster_additional_sg_name
-  description = "Managed in Terraform"
+  description = "Managed by Pulumi"
   vpc_id      = aws_vpc.airflow_dev.id
   ingress {
     description     = "Allow pods to communicate with the cluster API Server"
@@ -38,7 +38,7 @@ resource "aws_security_group" "airflow_dev_cluster_additional_security_group" {
 
 resource "aws_security_group" "airflow_dev_cluster_node_security_group" {
   name        = var.dev_cluster_node_sg_name
-  description = "Managed in Terraform"
+  description = "Managed by Pulumi"
   vpc_id      = aws_vpc.airflow_dev.id
 
   ingress {
@@ -186,7 +186,7 @@ resource "aws_eks_cluster" "airflow_prod_eks_cluster" {
 
 resource "aws_security_group" "airflow_prod_cluster_additional_security_group" {
   name        = var.prod_cluster_additional_sg_name
-  description = "Managed in Terraform"
+  description = "Managed by Pulumi"
   vpc_id      = aws_vpc.airflow_prod.id
   ingress {
     description     = "Allow pods to communicate with the cluster API Server"
@@ -289,7 +289,7 @@ resource "kubernetes_namespace" "kyverno_prod" {
 resource "aws_eks_addon" "kube_proxy_dev" {
   cluster_name                = var.dev_eks_cluster_name
   addon_name                  = "kube-proxy"
-  addon_version               = "v1.26.15-eksbuild.2"
+  addon_version               = "v1.27.12-eksbuild.5"
   resolve_conflicts_on_create = "OVERWRITE"
 }
 
@@ -303,7 +303,7 @@ resource "aws_eks_addon" "vpc_cni_dev" {
 resource "aws_eks_addon" "coredns_dev" {
   cluster_name                = var.dev_eks_cluster_name
   addon_name                  = "coredns"
-  addon_version               = "v1.9.3-eksbuild.7"
+  addon_version               = "v1.10.1-eksbuild.11"
   resolve_conflicts_on_create = "OVERWRITE"
 }
 

--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -7,7 +7,7 @@ resource "aws_eks_cluster" "airflow_dev_eks_cluster" {
     "controllerManager",
     "scheduler",
   ]
-  version = "1.26"
+  version = "1.27"
 
   vpc_config {
     subnet_ids          = aws_subnet.dev_private_subnet[*].id

--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -18,7 +18,7 @@ resource "aws_eks_cluster" "airflow_dev_eks_cluster" {
 
 resource "aws_security_group" "airflow_dev_cluster_additional_security_group" {
   name        = var.dev_cluster_additional_sg_name
-  description = "Managed by Pulumi"
+  description = "Managed in Terraform"
   vpc_id      = aws_vpc.airflow_dev.id
   ingress {
     description     = "Allow pods to communicate with the cluster API Server"
@@ -38,7 +38,7 @@ resource "aws_security_group" "airflow_dev_cluster_additional_security_group" {
 
 resource "aws_security_group" "airflow_dev_cluster_node_security_group" {
   name        = var.dev_cluster_node_sg_name
-  description = "Managed by Pulumi"
+  description = "Managed in Terraform"
   vpc_id      = aws_vpc.airflow_dev.id
 
   ingress {
@@ -186,7 +186,7 @@ resource "aws_eks_cluster" "airflow_prod_eks_cluster" {
 
 resource "aws_security_group" "airflow_prod_cluster_additional_security_group" {
   name        = var.prod_cluster_additional_sg_name
-  description = "Managed by Pulumi"
+  description = "Managed in Terraform"
   vpc_id      = aws_vpc.airflow_prod.id
   ingress {
     description     = "Allow pods to communicate with the cluster API Server"

--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -52,7 +52,7 @@ resource "aws_launch_template" "dev_standard" {
 
 resource "aws_launch_template" "dev_high_memory" {
   name          = "dev_high_memory"
-  image_id      = "ami-0e169b410a06c4a29"
+  image_id      = "ami-064e6ccd9f6d74534"
   instance_type = "r6i.8xlarge"
 
   disable_api_stop        = false

--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -1,6 +1,6 @@
 resource "aws_launch_template" "dev_standard" {
   name          = "dev_standard"
-  image_id      = "ami-0e169b410a06c4a29"
+  image_id      = "ami-064e6ccd9f6d74534"
   instance_type = "t3a.large"
 
   disable_api_stop        = false


### PR DESCRIPTION
Raised in relation to [this](https://github.com/ministryofjustice/analytical-platform/issues/4426) piece of work.

Upgrades: 
- control plane version `1.26` -> `1.27`
- node groups AMI 
- Add Ons