### PR TITLE
Electronic Monitoring: Put Object Bucket Permissions

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -849,7 +849,7 @@ locals {
               ]
               Resource = [
                 "arn:aws:s3:::mojap-land",
-                "arn:aws:s3:::mojap-land/electronic-monitoring/load/*"
+                "arn:aws:s3:::mojap-land/electronic_monitoring/load/*"
               ]
             }
           ]
@@ -1090,7 +1090,7 @@ locals {
               ]
               Resource = [
                 "arn:aws:s3:::mojap-land",
-                "arn:aws:s3:::mojap-land/electronic-monitoring/load/*"
+                "arn:aws:s3:::mojap-land/electronic_monitoring/load/*"
               ]
             }
           ]
@@ -1725,7 +1725,7 @@ locals {
               Principal = {
                 AWS = "arn:aws:iam::800964199911:role/send_metadata_to_ap"
               }
-              Resource = "arn:aws:s3:::mojap-metadata-dev/electronic-monitoring/*"
+              Resource = "arn:aws:s3:::mojap-metadata-dev/electronic_monitoring/*"
               Sid      = "PutAccess-mojap-metadata-dev-electronic-monitoring"
             }
           ]
@@ -1911,7 +1911,7 @@ locals {
               Principal = {
                 AWS = "arn:aws:iam::976799291502:role/send_metadata_to_ap"
               }
-              Resource = "arn:aws:s3:::mojap-metadata-prod/electronic-monitoring/*"
+              Resource = "arn:aws:s3:::mojap-metadata-prod/electronic_monitoring/*"
               Sid      = "PutAccess-mojap-metadata-prod-electronic-monitoring"
             }
           ]

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -1719,7 +1719,7 @@ locals {
             {
               Action = [
                 "s3:PutObject",
-                "s3:PutObjectACL"
+                "s3:PutObjectAcl"
                 ]
               Effect = "Allow"
               Principal = {
@@ -1905,7 +1905,7 @@ locals {
             {
               Action = [
                 "s3:PutObject",
-                "s3:PutObjectACL"
+                "s3:PutObjectAcl"
                 ]
               Effect = "Allow"
               Principal = {

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -1720,7 +1720,7 @@ locals {
               Action = [
                 "s3:PutObject",
                 "s3:PutObjectAcl"
-                ]
+              ]
               Effect = "Allow"
               Principal = {
                 AWS = "arn:aws:iam::800964199911:role/send_metadata_to_ap"
@@ -1814,7 +1814,7 @@ locals {
               }
               Resource = "arn:aws:s3:::mojap-metadata-preprod"
               Sid      = "ListBucketAccess-mojap-metadata-preprod"
-            },
+            }
           ]
           Version = "2012-10-17"
         }

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -1089,8 +1089,8 @@ locals {
                 "s3:PutObjectAcl"
               ]
               Resource = [
-                "arn:aws:s3:::mojap-land",
-                "arn:aws:s3:::mojap-land/electronic_monitoring/load/*"
+                "arn:aws:s3:::mojap-land-dev",
+                "arn:aws:s3:::mojap-land-dev/electronic_monitoring/load/*"
               ]
             }
           ]

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -835,6 +835,22 @@ locals {
                 "arn:aws:s3:::mojap-land",
                 "arn:aws:s3:::mojap-land/bold/essex-police/*"
               ]
+            },
+            {
+              Sid    = "WriteOnlyAccessElectronicMonitoringService"
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::976799291502:role/send_table_to_ap"
+              }
+              Action = [
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:PutObjectAcl"
+              ]
+              Resource = [
+                "arn:aws:s3:::mojap-land",
+                "arn:aws:s3:::mojap-land/electronic-monitoring/load/*"
+              ]
             }
           ]
           Version = "2012-10-17"
@@ -1059,6 +1075,22 @@ locals {
               Resource = [
                 "arn:aws:s3:::mojap-land-dev",
                 "arn:aws:s3:::mojap-land-dev/bold/essex-police/*"
+              ]
+            },
+            {
+              Sid    = "WriteOnlyAccessElectronicMonitoringService"
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::800964199911:role/send_table_to_ap"
+              }
+              Action = [
+                "s3:PutObject",
+                "s3:PutObjectTagging",
+                "s3:PutObjectAcl"
+              ]
+              Resource = [
+                "arn:aws:s3:::mojap-land",
+                "arn:aws:s3:::mojap-land/electronic-monitoring/load/*"
               ]
             }
           ]
@@ -1684,6 +1716,18 @@ locals {
               Resource = "arn:aws:s3:::mojap-metadata-dev"
               Sid      = "ListBucketAccess-mojap-metadata-dev"
             },
+            {
+              Action = [
+                "s3:PutObject",
+                "s3:PutObjectACL"
+                ]
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::800964199911:role/send_metadata_to_ap"
+              }
+              Resource = "arn:aws:s3:::mojap-metadata-dev/electronic-monitoring/*"
+              Sid      = "PutAccess-mojap-metadata-dev-electronic-monitoring"
+            }
           ]
           Version = "2012-10-17"
         }
@@ -1858,6 +1902,18 @@ locals {
               Resource = "arn:aws:s3:::mojap-metadata-prod"
               Sid      = "ListBucketAccess-mojap-metadata-prod"
             },
+            {
+              Action = [
+                "s3:PutObject",
+                "s3:PutObjectACL"
+                ]
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::976799291502:role/send_metadata_to_ap"
+              }
+              Resource = "arn:aws:s3:::mojap-metadata-prod/electronic-monitoring/*"
+              Sid      = "PutAccess-mojap-metadata-prod-electronic-monitoring"
+            }
           ]
           Version = "2012-10-17"
         }

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -1906,7 +1906,7 @@ locals {
               Action = [
                 "s3:PutObject",
                 "s3:PutObjectAcl"
-                ]
+              ]
               Effect = "Allow"
               Principal = {
                 AWS = "arn:aws:iam::976799291502:role/send_metadata_to_ap"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/4296)
GitHub Issue.

Adding access to the 4 buckets listed above for the EM data AWS accounts two for dev and two for prod.

## Checklist


- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

