### PR TITLE
⏫  Airflow: Development EKS `1.27` -> `1.28`

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -7,7 +7,7 @@ resource "aws_eks_cluster" "airflow_dev_eks_cluster" {
     "controllerManager",
     "scheduler",
   ]
-  version = "1.27"
+  version = "1.28"
 
   vpc_config {
     subnet_ids          = aws_subnet.dev_private_subnet[*].id

--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -289,7 +289,7 @@ resource "kubernetes_namespace" "kyverno_prod" {
 resource "aws_eks_addon" "kube_proxy_dev" {
   cluster_name                = var.dev_eks_cluster_name
   addon_name                  = "kube-proxy"
-  addon_version               = "v1.27.12-eksbuild.5"
+  addon_version               = "v1.28.8-eksbuild.5"
   resolve_conflicts_on_create = "OVERWRITE"
 }
 

--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -1,6 +1,6 @@
 resource "aws_launch_template" "dev_standard" {
   name          = "dev_standard"
-  image_id      = "ami-064e6ccd9f6d74534"
+  image_id      = "ami-0246ad1c10bc9a7ab"
   instance_type = "t3a.large"
 
   disable_api_stop        = false


### PR DESCRIPTION
Raised in relation to [this](https://github.com/ministryofjustice/analytical-platform/issues/4426) piece of work.

Upgrades: 
- control plane version `1.27` -> `1.28`
- node groups AMI 
- Add Ons