### PR TITLE
⏫ Airflow: Production EKS `1.26` -> `1.27`

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -310,7 +310,7 @@ resource "aws_eks_addon" "coredns_dev" {
 resource "aws_eks_addon" "kube_proxy_prod" {
   cluster_name                = var.prod_eks_cluster_name
   addon_name                  = "kube-proxy"
-  addon_version               = "v1.26.15-eksbuild.2"
+  addon_version               = "v1.27.12-eksbuild.5"
   resolve_conflicts_on_create = "OVERWRITE"
 }
 
@@ -324,6 +324,6 @@ resource "aws_eks_addon" "vpc_cni_prod" {
 resource "aws_eks_addon" "coredns_prod" {
   cluster_name                = var.prod_eks_cluster_name
   addon_name                  = "coredns"
-  addon_version               = "v1.9.3-eksbuild.7"
+  addon_version               = "v1.10.1-eksbuild.11"
   resolve_conflicts_on_create = "OVERWRITE"
 }

--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -175,7 +175,7 @@ resource "aws_eks_cluster" "airflow_prod_eks_cluster" {
     "controllerManager",
     "scheduler",
   ]
-  version = "1.26"
+  version = "1.27"
 
   vpc_config {
     subnet_ids          = aws_subnet.prod_private_subnet[*].id

--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -104,7 +104,7 @@ resource "aws_launch_template" "dev_high_memory" {
 
 resource "aws_launch_template" "prod_standard" {
   name          = "prod_standard"
-  image_id      = "ami-0cd6a2d5595e5f5fe"
+  image_id      = "ami-0701694cedbb71f26"
   instance_type = "t3a.large"
 
   disable_api_stop        = false
@@ -156,7 +156,7 @@ resource "aws_launch_template" "prod_standard" {
 
 resource "aws_launch_template" "prod_high_memory" {
   name          = "prod_high_memory"
-  image_id      = "ami-0cd6a2d5595e5f5fe"
+  image_id      = "ami-0701694cedbb71f26"
   instance_type = "r6i.8xlarge"
 
   disable_api_stop        = false


### PR DESCRIPTION
Raised in relation to [this](https://github.com/ministryofjustice/analytical-platform/issues/4428) piece of work.

Upgrades: 
- control plane version `1.26` -> `1.27`
- node groups AMI 
- Add Ons