### PR TITLE
⏫  Airflow: Production EKS `1.27` -> `1.28`

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -175,7 +175,7 @@ resource "aws_eks_cluster" "airflow_prod_eks_cluster" {
     "controllerManager",
     "scheduler",
   ]
-  version = "1.27"
+  version = "1.28"
 
   vpc_config {
     subnet_ids          = aws_subnet.prod_private_subnet[*].id

--- a/terraform/aws/analytical-platform-data-production/airflow/eks.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/eks.tf
@@ -310,7 +310,7 @@ resource "aws_eks_addon" "coredns_dev" {
 resource "aws_eks_addon" "kube_proxy_prod" {
   cluster_name                = var.prod_eks_cluster_name
   addon_name                  = "kube-proxy"
-  addon_version               = "v1.27.12-eksbuild.5"
+  addon_version               = "v1.28.8-eksbuild.5"
   resolve_conflicts_on_create = "OVERWRITE"
 }
 

--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -104,7 +104,7 @@ resource "aws_launch_template" "dev_high_memory" {
 
 resource "aws_launch_template" "prod_standard" {
   name          = "prod_standard"
-  image_id      = "ami-0701694cedbb71f26"
+  image_id      = "ami-0246ad1c10bc9a7ab"
   instance_type = "t3a.large"
 
   disable_api_stop        = false
@@ -156,7 +156,7 @@ resource "aws_launch_template" "prod_standard" {
 
 resource "aws_launch_template" "prod_high_memory" {
   name          = "prod_high_memory"
-  image_id      = "ami-0701694cedbb71f26"
+  image_id      = "ami-0246ad1c10bc9a7ab"
   instance_type = "r6i.8xlarge"
 
   disable_api_stop        = false


### PR DESCRIPTION
Raised in relation to [this](https://github.com/ministryofjustice/analytical-platform/issues/4428) piece of work.

Upgrades: 
- control plane version `1.27` -> `1.28`
- node groups AMI 
- Add Ons