### PR TITLE
Fixing mojap-metadata-dev action and adding List Bucket policies

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -837,6 +837,17 @@ locals {
               ]
             },
             {
+              Sid    = "ListBucketAccessElectronicMonitoringService"
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::976799291502:role/send_table_to_ap"
+              }
+              Action = "s3:ListBucket"
+              Resource = [
+                "arn:aws:s3:::mojap-land",
+              ]
+            },
+            {
               Sid    = "WriteOnlyAccessElectronicMonitoringService"
               Effect = "Allow"
               Principal = {
@@ -848,7 +859,6 @@ locals {
                 "s3:PutObjectAcl"
               ]
               Resource = [
-                "arn:aws:s3:::mojap-land",
                 "arn:aws:s3:::mojap-land/electronic_monitoring/load/*"
               ]
             }
@@ -1075,6 +1085,17 @@ locals {
               Resource = [
                 "arn:aws:s3:::mojap-land-dev",
                 "arn:aws:s3:::mojap-land-dev/bold/essex-police/*"
+              ]
+            },
+            {
+              Sid    = "ListBucketAccessElectronicMonitoringService"
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::800964199911:role/send_table_to_ap"
+              }
+              Action = "s3:ListBucket"
+              Resource = [
+                "arn:aws:s3:::mojap-land",
               ]
             },
             {
@@ -1717,6 +1738,15 @@ locals {
               Sid      = "ListBucketAccess-mojap-metadata-dev"
             },
             {
+              Action = "s3:ListBucket"
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::800964199911:role/send_metadata_to_ap"
+              }
+              Resource = "arn:aws:s3:::mojap-metadata-dev"
+              Sid      = "ListAccess-mojap-metadata-dev-electronic-monitoring"
+            },
+            {
               Action = [
                 "s3:PutObject",
                 "s3:PutObjectAcl"
@@ -1901,6 +1931,15 @@ locals {
               }
               Resource = "arn:aws:s3:::mojap-metadata-prod"
               Sid      = "ListBucketAccess-mojap-metadata-prod"
+            },
+            {
+              Action = "s3:ListBucket"
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::976799291502:role/send_metadata_to_ap"
+              }
+              Resource = "arn:aws:s3:::mojap-metadata-prod"
+              Sid      = "ListAccess-mojap-metadata-prod-electronic-monitoring"
             },
             {
               Action = [

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -1720,7 +1720,7 @@ locals {
               Action = "s3:GetObject"
               Effect = "Allow"
               Principal = {
-                AWS = "AROASYCVJWSNFCCBEO2AN"
+                AWS = "arn:aws:iam::189157455002:role/oasys-lambda-copy-object-dev"
               }
               Resource = "arn:aws:s3:::mojap-metadata-dev/oasys/*"
               Sid      = "ReadOnlyAccess-mojap-metadata-dev-oasys"
@@ -1730,7 +1730,7 @@ locals {
               Effect = "Allow"
               Principal = {
                 AWS = [
-                  "AROASYCVJWSNFCCBEO2AN",
+                  "arn:aws:iam::189157455002:role/oasys-lambda-copy-object-dev",
                   "AROASYCVJWSNN3REJ3AFS",
                 ]
               }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/4296) GitHub Issue.

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

The `terraform apply` was failing due to a legacy principal, here been replaced by the actual arn (see changes to refer to the original delius iam role), the old role must have been deleted and rewritten or similar. I have checked with @davidbridgwood and he was happy with the changes. 

I also added list bucket permissions for the original issue