### PR TITLE
another deformed resource

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -1095,7 +1095,7 @@ locals {
               }
               Action = "s3:ListBucket"
               Resource = [
-                "arn:aws:s3:::mojap-land",
+                "arn:aws:s3:::mojap-land-dev",
               ]
             },
             {

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -1711,7 +1711,7 @@ locals {
               Action = "s3:GetObject"
               Effect = "Allow"
               Principal = {
-                AWS = "AROASYCVJWSNN3REJ3AFS"
+                AWS = "arn:aws:iam::189157455002:role/delius-lambda-copy-object-dev"
               }
               Resource = "arn:aws:s3:::mojap-metadata-dev/delius/*"
               Sid      = "ReadOnlyAccess-mojap-metadata-dev-delius"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/4296)
GitHub Issue.

Adding access to the 4 buckets listed above for the EM data AWS accounts two for dev and two for prod.

## Checklist


- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

