### PR TITLE
Update bedrock policy regions

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -57,6 +57,7 @@ data "aws_iam_policy_document" "bedrock_integration" {
       values = [
         "eu-central-1",
         "eu-west-1",
+        "eu-west-2",
         "eu-west-3",
         "us-east-1"
       ]

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -59,6 +59,7 @@ data "aws_iam_policy_document" "bedrock_integration" {
       values = [
         "eu-central-1",
         "eu-west-1",
+        "eu-west-2",
         "eu-west-3",
         "us-east-1"
       ]

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -56,7 +56,12 @@ data "aws_iam_policy_document" "bedrock_integration" {
     condition {
       test     = "StringEquals"
       variable = "aws:RequestedRegion"
-      values   = ["eu-central-1", "eu-west-3"]
+      values = [
+        "eu-central-1",
+        "eu-west-1",
+        "eu-west-3",
+        "us-east-1"
+      ]
     }
   }
 }


### PR DESCRIPTION
# Pull Request Objective

Bedrock is now available within London, so this PR adds London to the regions defined in our Bedrock policy for dev and data-prod accounts.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
