### PR TITLE
Revert ":dependabot: terraform(deps): Bump cloudposse/elasticache-red is/aws from 1.3.0 to 1.4.0 in /terraform/aws/analytical-platform-development/cluster (#4543)"

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/redis.tf
+++ b/terraform/aws/analytical-platform-development/cluster/redis.tf
@@ -6,7 +6,7 @@ module "control_panel_redis" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
   source  = "cloudposse/elasticache-redis/aws"
-  version = "1.4.0"
+  version = "1.3.0"
 
   enabled                    = var.redis_enabled
   replication_group_id       = local.redis_replication_group_id


### PR DESCRIPTION
Revert ":dependabot: terraform(deps): Bump cloudposse/elasticache-red is/aws from 1.3.0 to 1.4.0 in /terraform/aws/analytical-platform-development/cluster (#4543)" #4575

This reverts commit fdeaf0c75d46f0e0cda6da1c1c4d9bb2281bc8ca.

# Pull Request Objective

The terraform apply failed after merging, despite the checks passing on the PR.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
