### PR TITLE
🔧 EKS Development upgrade: `1.24` -> `1.25`

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -123,7 +123,7 @@ redis_alarm_memory_threshold_bytes = 100000
 # EKS
 ##################################################
 eks_versions = {
-  cluster    = "1.24"
+  cluster    = "1.25"
   node-group = "1.24"
 }
 eks_addon_versions = {

--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -122,15 +122,16 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 # EKS
 ##################################################
+
 eks_versions = {
   cluster    = "1.25"
-  node-group = "1.24"
+  node-group = "1.25"
 }
 eks_addon_versions = {
-  coredns        = "v1.8.7-eksbuild.3"
-  ebs-csi-driver = "v1.16.0-eksbuild.1"
-  kube-proxy     = "v1.24.7-eksbuild.2"
-  vpc-cni        = "v1.12.2-eksbuild.1"
+  coredns        = "v1.9.3-eksbuild.7"
+  ebs-csi-driver = "v1.32.0-eksbuild.1"
+  kube-proxy     = "v1.25.14-eksbuild.2"
+  vpc-cni        = "v1.15.1-eksbuild.1"
 }
 eks_node_group_name_prefix = "dev"
 eks_node_group_capacities = {


### PR DESCRIPTION
This pr is to upgrade the dev cluster in analytical-platform from 1.24->1.25 . The control plane, the nodes and eks addons.
https://github.com/ministryofjustice/analytical-platform/issues/4618
