### PR TITLE
🔧  EKS upgrade to `1.25` -> `1.26`

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -124,13 +124,13 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 
 eks_versions = {
-  cluster    = "1.25"
-  node-group = "1.25"
+  cluster    = "1.26"
+  node-group = "1.26"
 }
 eks_addon_versions = {
-  coredns        = "v1.9.3-eksbuild.7"
+  coredns        = "v1.9.3-eksbuild.15"
   ebs-csi-driver = "v1.32.0-eksbuild.1"
-  kube-proxy     = "v1.25.14-eksbuild.2"
+  kube-proxy     = "v1.26.15-eksbuild.5"
   vpc-cni        = "v1.15.1-eksbuild.1"
 }
 eks_node_group_name_prefix = "dev"


### PR DESCRIPTION
This pr is to upgrade eks in the analytical development cluster  1.25-> 1.26 . It upgrades the control plane, nodes, and addons. This pr links to #4618 