### PR TITLE
Policy Option for LakeFormation Sharing for OIDC roles

### DIFF
--- a/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
+++ b/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
@@ -183,16 +183,5 @@
     "stateLockingDetails": [],
     "ssmParameterConfig": [],
     "lakeFormationSharePolicy": true
-  },
-  "modernisation-platform-lake-formation-share-dev": {
-    "account": "analytical-platform-development",
-    "stateConfig": [],
-    "repositories": [
-      "ministryofjustice/modernisation-platform-environments"
-    ],
-    "targets": [],
-    "stateLockingDetails": [],
-    "ssmParameterConfig": [],
-    "lakeFormationSharePolicy": true
   }
 }

--- a/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
+++ b/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
@@ -172,5 +172,27 @@
     "targets": ["analytical-platform-data-production"],
     "stateLockingDetails": [],
     "ssmParameterConfig": []
+  },
+  "modernisation-platform-lake-formation-share": {
+    "account": "analytical-platform-data-production",
+    "stateConfig": [],
+    "repositories": [
+      "ministryofjustice/modernisation-platform-environments"
+    ],
+    "targets": [],
+    "stateLockingDetails": [],
+    "ssmParameterConfig": [],
+    "lakeFormationSharePolicy": true
+  },
+  "modernisation-platform-lake-formation-share-dev": {
+    "account": "analytical-platform-development",
+    "stateConfig": [],
+    "repositories": [
+      "ministryofjustice/modernisation-platform-environments"
+    ],
+    "targets": [],
+    "stateLockingDetails": [],
+    "ssmParameterConfig": [],
+    "lakeFormationSharePolicy": true
   }
 }

--- a/terraform/aws/analytical-platform/oidc/oidc-roles.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-roles.tf
@@ -1,6 +1,5 @@
 data "aws_iam_policy_document" "github_oidc_role" {
   for_each = local.oidc_roles
-
   dynamic "statement" {
     for_each = length(each.value.targets) > 0 ? [1] : [0]
 
@@ -74,6 +73,26 @@ data "aws_iam_policy_document" "github_oidc_role" {
         "ssm:GetParametersByPath"
       ]
       resources = formatlist("arn:aws:ssm:%s:%s:parameter/%s*", statement.value.ssmParameterRegion, var.account_ids[try(each.value.account, "analytical-platform-management-production")], statement.value.ssmParameterArnPrefixes)
+    }
+  }
+
+  dynamic "statement" {
+    for_each = try(each.value.lakeFormationSharePolicy, false) == true ? [1] : []
+    content {
+      actions = [
+        "lakeformation:GrantPermissions",
+        "lakeformation:BatchGrantPermissions",
+        "lakeformation:RegisterResource",
+        "lakeformation:DeregisterResource",
+        "lakeformation:LisPermissions",
+        "glue:GetDatabase",
+        "glue:GetTable",
+        "glue:PutResourcePolicy",
+        "glue:DeleteResourcePolicy",
+        "iam:PassRole"
+      ]
+      effect    = "Allow"
+      resources = ["*"]
     }
   }
   statement {


### PR DESCRIPTION
- Adding LakeFormation share policy option to oidc roles

# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/4358)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->
This PR allows creation of OIDC roles which can create resource links from resources shared from other accounts into our member-unrestricted accounts. The LakeFormation policy has permissions limited to those needed to create the links since they'll be assumed from another account
## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
