### PR TITLE
eks prod nodes 1.25

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -126,7 +126,7 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 eks_versions = {
   cluster    = "1.25"
-  node-group = "1.24"
+  node-group = "1.25"
 }
 eks_addon_versions = {
   coredns        = "v1.8.7-eksbuild.3"


### PR DESCRIPTION
This pr is to upgrade the nodes in prod cluster in analytical-platform from 1.24->1.25 . This is relates to https://github.com/ministryofjustice/analytical-platform/issues/4631