### PR TITLE
Fixing malformed policy bug in oidc roles

### DIFF
--- a/terraform/aws/analytical-platform/oidc/oidc-roles.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-roles.tf
@@ -1,7 +1,7 @@
 data "aws_iam_policy_document" "github_oidc_role" {
   for_each = local.oidc_roles
   dynamic "statement" {
-    for_each = length(each.value.targets) > 0 ? [1] : [0]
+    for_each = length(each.value.targets) > 0 ? [1] : []
 
     content {
       sid     = "AllowOIDCToAssumeRoles"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in https://github.com/ministryofjustice/analytical-platform/issues/4358 GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->
This is fixing the malformed policy error when no target role is specified in the oidc role config.
Introduced in this PR: https://github.com/ministryofjustice/analytical-platform/pull/4648
 
## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
