### PR TITLE
⬆️  Upgrade add-ons for EKS `1.25`

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -129,10 +129,10 @@ eks_versions = {
   node-group = "1.25"
 }
 eks_addon_versions = {
-  coredns        = "v1.8.7-eksbuild.3"
-  ebs-csi-driver = "v1.16.0-eksbuild.1"
-  kube-proxy     = "v1.24.7-eksbuild.2"
-  vpc-cni        = "v1.12.2-eksbuild.1"
+  coredns        = "v1.9.3-eksbuild.7"
+  ebs-csi-driver = "v1.32.0-eksbuild.1"
+  kube-proxy     = "v1.25.14-eksbuild.2"
+  vpc-cni        = "v1.15.1-eksbuild.1"
 }
 eks_node_group_name_prefix = "prod"
 eks_node_group_capacities = {


### PR DESCRIPTION
This pr is to upgrade the addons for prod cluster in analytical-platform from 1.24->1.25 . This is relates to https://github.com/ministryofjustice/analytical-platform/issues/4631