### PR TITLE
Control Plane EKS Production Cluster Upgrade from 1.25 -> 1.26

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -125,7 +125,7 @@ redis_alarm_memory_threshold_bytes = 100000
 # EKS
 ##################################################
 eks_versions = {
-  cluster    = "1.25"
+  cluster    = "1.26"
   node-group = "1.25"
 }
 eks_addon_versions = {


### PR DESCRIPTION
This pr is to upgrade the EKS control plane in the production cluster in Analytical-Platform from 1.25->1.26 . This is relates to https://github.com/ministryofjustice/analytical-platform/issues/4631
