### PR TITLE
Upgrade EKS nodes to 1.26 in Analytical Platform Production

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -126,7 +126,7 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 eks_versions = {
   cluster    = "1.26"
-  node-group = "1.25"
+  node-group = "1.26"
 }
 eks_addon_versions = {
   coredns        = "v1.9.3-eksbuild.7"


### PR DESCRIPTION
This pr is to upgrade the upgrade-EKS-nodes-to-1.26 for prod cluster in analytical-platform from 1.25->1.26 . This is relates to https://github.com/ministryofjustice/analytical-platform/issues/4631

