### PR TITLE
Upgrade EKS nodes to 1.27 in Analytical Platform Production

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -126,7 +126,7 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 eks_versions = {
   cluster    = "1.27"
-  node-group = "1.26"
+  node-group = "1.27"
 }
 eks_addon_versions = {
   coredns        = "v1.9.3-eksbuild.15"


### PR DESCRIPTION
This pr is to upgrade the upgrade-EKS-nodes in the production cluster in analytical-platform from 1.26->1.27 . This is relates to https://github.com/ministryofjustice/analytical-platform/issues/4631

