### PR TITLE
🚑 Fix Cluster AutoScaler IAM Policy

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -38,8 +38,13 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeScalingActivities",
       "autoscaling:DescribeTags",
       "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes",
+      "eks:DescribeNodegroup",
+      "ec2:DescribeImages",
+      "ec2:GetInstanceTypesFromInstanceRequirements"
     ]
     resources = ["*"]
   }
@@ -49,18 +54,12 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
     actions = [
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
     ]
     resources = ["*"]
     condition {
       test     = "StringEquals"
       variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${module.eks.cluster_id}"
       values   = ["owned"]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
-      values   = ["true"]
     }
   }
 }

--- a/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
@@ -268,8 +268,13 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
       "autoscaling:DescribeAutoScalingGroups",
       "autoscaling:DescribeAutoScalingInstances",
       "autoscaling:DescribeLaunchConfigurations",
+      "autoscaling:DescribeScalingActivities",
       "autoscaling:DescribeTags",
       "ec2:DescribeLaunchTemplateVersions",
+      "ec2:DescribeInstanceTypes",
+      "eks:DescribeNodegroup",
+      "ec2:DescribeImages",
+      "ec2:GetInstanceTypesFromInstanceRequirements"
     ]
     resources = ["*"]
   }
@@ -280,18 +285,12 @@ data "aws_iam_policy_document" "cluster_autoscaler" {
     actions = [
       "autoscaling:SetDesiredCapacity",
       "autoscaling:TerminateInstanceInAutoScalingGroup",
-      "autoscaling:UpdateAutoScalingGroup",
     ]
     resources = ["*"]
     condition {
       test     = "StringEquals"
       variable = "autoscaling:ResourceTag/kubernetes.io/cluster/${module.eks.cluster_id}"
       values   = ["owned"]
-    }
-    condition {
-      test     = "StringEquals"
-      variable = "autoscaling:ResourceTag/k8s.io/cluster-autoscaler/enabled"
-      values   = ["true"]
     }
   }
 }


### PR DESCRIPTION
This pull request:

- Aligns CAS IAM policy with https://github.com/terraform-aws-modules/terraform-aws-iam/blob/v5.40.0/modules/iam-role-for-service-accounts-eks/policies.tf#L86

Related changes:

- https://github.com/moj-analytical-services/analytical-platform-flux/pull/1270
- https://github.com/moj-analytical-services/analytical-platform-flux/pull/1271

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 