### PR TITLE
upgrade EKS control plane to 1.28 on Analytical Platform Production

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -125,7 +125,7 @@ redis_alarm_memory_threshold_bytes = 100000
 # EKS
 ##################################################
 eks_versions = {
-  cluster    = "1.27"
+  cluster    = "1.28"
   node-group = "1.27"
 }
 eks_addon_versions = {


### PR DESCRIPTION
This pr is to upgrade the control plane prod cluster in analytical-platform from 1.27->1.28. This is relates to https://github.com/ministryofjustice/analytical-platform/issues/4631
