### PR TITLE
Upgrade EKS nodes to 1.28 in Analytical Platform Production

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -126,7 +126,7 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 eks_versions = {
   cluster    = "1.28"
-  node-group = "1.27"
+  node-group = "1.28"
 }
 eks_addon_versions = {
   coredns        = "v1.10.1-eksbuild.4"


### PR DESCRIPTION
This pr is to upgrade the EKS nodes in the prod cluster analytical-platform from 1.27->1.28. This is relates to https://github.com/ministryofjustice/analytical-platform/issues/4631