### PR TITLE
Upgrade EKS addons for 1.28 Analytical Platform production

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -131,7 +131,7 @@ eks_versions = {
 eks_addon_versions = {
   coredns        = "v1.10.1-eksbuild.4"
   ebs-csi-driver = "v1.32.0-eksbuild.1"
-  kube-proxy     = "v1.27.6-eksbuild.2"
+  kube-proxy     = "v1.28.2-eksbuild.2"
   vpc-cni        = "v1.15.1-eksbuild.1"
 }
 eks_node_group_name_prefix = "prod"


### PR DESCRIPTION
This pr is to upgrade the EKS addons in the prod cluster analytical-platform from 1.27->1.28. This is relates to https://github.com/ministryofjustice/analytical-platform/issues/4631
