### PR TITLE
scope down s3 perms and increase max duration for datahub role

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -75,7 +75,9 @@ data "aws_iam_policy_document" "datahub_read_cadet_bucket" {
       "s3:Describe*"
     ]
     resources = [
-      "arn:aws:s3:::mojap-derived-tables/*",
+      "arn:aws:s3:::mojap-derived-tables/prod/run_artefacts/*",
+      "arn:aws:s3:::mojap-derived-tables/dev/run_artefacts/*",
+      "arn:aws:s3:::mojap-derived-tables/catalogue_static_dbt_docs/*",
       "arn:aws:s3:::mojap-derived-tables"
     ]
   }
@@ -113,6 +115,7 @@ data "aws_iam_policy_document" "datahub_ingestion_github_actions" {
 resource "aws_iam_role" "datahub_ingestion_github_actions" {
   name               = "datahub-ingestion-github-actions"
   assume_role_policy = data.aws_iam_policy_document.datahub_ingestion_github_actions.json
+  max_session_duration = 14400
 }
 
 resource "aws_iam_role_policy_attachment" "datahub_ingestion_github_actions" {

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -113,8 +113,8 @@ data "aws_iam_policy_document" "datahub_ingestion_github_actions" {
 }
 
 resource "aws_iam_role" "datahub_ingestion_github_actions" {
-  name               = "datahub-ingestion-github-actions"
-  assume_role_policy = data.aws_iam_policy_document.datahub_ingestion_github_actions.json
+  name                 = "datahub-ingestion-github-actions"
+  assume_role_policy   = data.aws_iam_policy_document.datahub_ingestion_github_actions.json
   max_session_duration = 14400
 }
 


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/find-moj-data/issues/499)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

Boto3 session timing out for ingestions to datahub catalogue so increasing the max session duration - It takes a really long time but we're working on optimisations. 
Increasing the session time will (should) allow us to get the cicd ingestion pipeline working for our production service.

I also noticed the role had access to much more than currently needed in s3, so have scoped down the access to required paths.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
