### PR TITLE
Remove Missing roles that cause Terraform plan failure

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.47.0"
-  constraints = "5.47.0"
+  constraints = ">= 5.27.0, 5.47.0"
   hashes = [
     "h1:49aEnvHJ/M8BRGAXKzU6W3zSbf7HgIrjXkXjC5DGEWY=",
+    "h1:bZEm2TDCM7jmpNXK6QOWsT1YU8GiGGQaraUvwO887U8=",
     "zh:06037a14e47e8f82d0b3b326cd188566272b808b7970a9249a11db26d475b83d",
     "zh:116b7dd58ca964a1056249d2b6550f399b0a6bc9a7920b7ee134242114432c9f",
     "zh:1aa089c81459071c1d65ba7454f1122159e1fa1b5384e6e9ef85c8264f8a9ecb",

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -6,8 +6,6 @@ locals {
       database_string_pattern = ["xhibit_*"]
       role_names_to_exempt = [
         "courts-data-engineer",
-        "airflow_prod_xhibit_etl",
-        "airflow_dev_xhibit_etl_athena",
         "restricted-admin",
         "create-a-derived-table"
       ]


### PR DESCRIPTION
# Pull Request Objective

In preparation for the for the S3 remediation work I ran a local terraform plan on the unaltered code unfortunately this failed highlighting theses missing roles `airflow_prod_xhibit_etl` and `airflow_dev_xhibit_etl_athena`

`Planning failed. Terraform encountered an error while generating this plan.

╷
│ Error: reading IAM Role (airflow_prod_xhibit_etl): couldn't find resource
│ 
│   with data.aws_iam_role.glue_policy_role["airflow_prod_xhibit_etl"],
│   on data.tf line 7, in data "aws_iam_role" "glue_policy_role":
│    7: data "aws_iam_role" "glue_policy_role" {
│ 
╵
╷
│ Error: reading IAM Role (airflow_dev_xhibit_etl_athena): couldn't find resource
│ 
│   with data.aws_iam_role.glue_policy_role["airflow_dev_xhibit_etl_athena"],
│   on data.tf line 7, in data "aws_iam_role" "glue_policy_role":
│    7: data "aws_iam_role" "glue_policy_role" {
│ 
`

These two role could not be found in the `analytical-platform-data-production` account so i have removed them from the `locals.tf` and this allows the local Terraform plan to run successfully.


This was in preparation for the work on
[this](https://github.com/ministryofjustice/analytical-platform/issues/<14>) GitHub Issue.


## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
