### PR TITLE
add TLS to bucket remediation work

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -217,8 +217,11 @@ locals {
               }
               Effect    = "Deny"
               Principal = "*"
-              Resource  = "arn:aws:s3:::moj-analytics-lookup-tables"
-              Sid       = "DenyInsecureTransport"
+              Resource = [
+                "arn:aws:s3:::moj-analytics-lookup-tables/*",
+                "arn:aws:s3:::moj-analytics-lookup-tables"
+              ]
+              Sid = "DenyInsecureTransport"
             },
           ]
           Version = "2012-10-17"

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -205,6 +205,25 @@ locals {
         ignore_public_acls      = true
         restrict_public_buckets = true
       }
+      policy = jsonencode(
+        {
+          Statement = [
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Effect    = "Deny"
+              Principal = "*"
+              Resource  = "arn:aws:s3:::moj-analytics-lookup-tables"
+              Sid       = "DenyInsecureTransport"
+            },
+          ]
+          Version = "2012-10-17"
+        }
+      )
     }
     "moj-analytics-lookup-tables-dev" = {
       grant = [{


### PR DESCRIPTION
This pr is to add a Bucket Policy Missing SecureTransport Statement as part of the remiation work being carried out for this [issue]([#14](https://github.com/ministryofjustice/analytical-platform-ithc-2024/issues/14)) 
