### PR TITLE
S3 - Bucket Policy Missing SecureTransport Statement - create a derived table

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/.terraform.lock.hcl
@@ -6,6 +6,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   constraints = ">= 4.0.0, 5.47.0"
   hashes = [
     "h1:GZQJi9mfuKBkN5MCba5nHSG3kAJJf7OoxQcFgIpuPCw=",
+    "h1:bZEm2TDCM7jmpNXK6QOWsT1YU8GiGGQaraUvwO887U8=",
     "zh:06037a14e47e8f82d0b3b326cd188566272b808b7970a9249a11db26d475b83d",
     "zh:116b7dd58ca964a1056249d2b6550f399b0a6bc9a7920b7ee134242114432c9f",
     "zh:1aa089c81459071c1d65ba7454f1122159e1fa1b5384e6e9ef85c8264f8a9ecb",

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
@@ -90,6 +90,35 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "arn:aws:airflow:*:${var.account_ids["analytical-platform-data-production"]}:environment/prod"
     ]
   }
+  statement {
+    sid = "DenyInsecureTransport"
+    actions = [
+      "s3:*"
+    ]
+
+    effect = "Deny"
+
+    principals {
+      type = "*"
+      identifiers = [
+        "*"
+      ]
+    }
+    resources = [
+      "arn:aws:s3:::mojap-manage-offences/*",
+      "arn:aws:s3:::mojap-manage-offences"
+    ]
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values = [
+        "false"
+      ]
+    }
+
+  }
+
 }
 
 module "create_a_derived_table_iam_policy" {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/14) GitHub Issue.

This  work is part of the remediation for the above ticket where the ITHC report identified issues 

to implement `aws:SecureTransport" = "false"` where needed


- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

the `override-static-analysis` label has been used as there are multiple historical issues not touched by this PR