### PR TITLE
Add glue and Lake Formation perms to Control Panel prod role

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
@@ -218,6 +218,28 @@ data "aws_iam_policy_document" "control_panel_api" {
     ]
     resources = ["arn:aws:sqs:${data.aws_region.sqs_region.name}:${var.account_ids["analytical-platform-data-production"]}:*"]
   }
+  statement {
+    sid    = "GluePolicies"
+    effect = "Allow"
+    actions = [
+      "glue:GetDatabases",
+      "glue:GetDatabase",
+      "glue:GetTables",
+      "glue:GetTable",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "LakeFormationPolicies"
+    effect = "Allow"
+    actions = [
+      "lakeformation:ListPermissions",
+      "lakeformation:GrantPermissions",
+      "lakeformation:RevokePermissions",
+      "lakeformation:GetDataAccess"
+    ]
+    resources = ["arn:aws:lakeformation:${data.aws_region.current.name}:${var.account_ids["analytical-platform-data-production"]}:*"]
+  }
 }
 
 resource "aws_iam_policy" "control_panel_api" {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/4367)
GitHub Issue.

Adds Glue and Lake Formation permissions required for the DPR work.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
