### PR TITLE
HMCTS Airflow Test Perms: Add get Obj attributes

### DIFF
--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/airflow-create-a-pipeline/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/airflow-create-a-pipeline/iam-policies.tf
@@ -118,7 +118,8 @@ data "aws_iam_policy_document" "airflow_create_a_pipeline" {
       "s3:DeleteObjectVersion",
       "s3:PutObject",
       "s3:PutObjectAcl",
-      "s3:RestoreObject"
+      "s3:RestoreObject",
+      "s3:GetObjectAttributes"
     ]
     resources = [
       "arn:aws:s3:::alpha-hmcts-de-testing-sandbox",


### PR DESCRIPTION
# Pull Request Objective

While adding to the hmcts generic airflow job, we need to add the functionality to get the timestamp dump date (previously weve been doing it from filepath and this was breaking some pipelines). So to test this, we need `GetObjectAttributes` permissions from the github job.

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected
