### PR TITLE
S3 - Bucket Policy Missing SecureTransport Statement DE pipeline - multiple buckets

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -257,6 +257,28 @@ locals {
         ignore_public_acls      = true
         restrict_public_buckets = true
       }
+      policy = jsonencode(
+        {
+          Statement = [
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Effect    = "Deny"
+              Principal = "*"
+              Resource = [
+                "arn:aws:s3:::moj-analytics-lookup-tables-dev/*",
+                "arn:aws:s3:::moj-analytics-lookup-tables-dev"
+              ]
+              Sid = "DenyInsecureTransport"
+            },
+          ]
+          Version = "2012-10-17"
+        }
+      )
     }
 
     "moj-analytics-lookup-tables-preprod" = {
@@ -385,6 +407,21 @@ locals {
               }
               Resource = "arn:aws:s3:::mojap-athena-query-dump/*"
               Sid      = "readwrite"
+            },
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Principal = "*"
+              Effect    = "Deny"
+              Resource = [
+                "arn:aws:s3:::mojap-athena-query-dump/*",
+                "arn:aws:s3:::mojap-athena-query-dump"
+              ]
+              Sid = "DenyInsecureTransport"
             },
           ]
           Version = "2012-10-17"
@@ -877,7 +914,22 @@ locals {
               Resource = [
                 "arn:aws:s3:::mojap-land/electronic_monitoring/load/*"
               ]
-            }
+            },
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Principal = "*"
+              Effect    = "Deny"
+              Resource = [
+                "arn:aws:s3:::mojap-land/*",
+                "arn:aws:s3:::mojap-land"
+              ]
+              Sid = "DenyInsecureTransport"
+            },
           ]
           Version = "2012-10-17"
         }
@@ -1129,7 +1181,22 @@ locals {
                 "arn:aws:s3:::mojap-land-dev",
                 "arn:aws:s3:::mojap-land-dev/electronic_monitoring/load/*"
               ]
-            }
+            },
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Principal = "*"
+              Effect    = "Deny"
+              Resource = [
+                "arn:aws:s3:::mojap-land-dev/*",
+                "arn:aws:s3:::mojap-land-dev"
+              ]
+              Sid = "DenyInsecureTransport"
+            },
           ]
           Version = "2012-10-17"
         }
@@ -1293,6 +1360,21 @@ locals {
               }
               Resource = "arn:aws:s3:::mojap-land-fail-dev/hmpps/oasys/*"
               Sid      = "DenyUnEncryptedObjectUploads-mojap-land-fail-dev-hmpps-oasys"
+            },
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Principal = "*"
+              Effect    = "Deny"
+              Resource = [
+                "arn:aws:s3:::mojap-land-fail-dev/*",
+                "arn:aws:s3:::mojap-land-fail-dev"
+              ]
+              Sid = "DenyInsecureTransport"
             },
           ]
           Version = "2012-10-17"
@@ -1458,6 +1540,21 @@ locals {
               }
               Resource = "arn:aws:s3:::mojap-land-fail-preprod/hmpps/oasys/*"
               Sid      = "DenyUnEncryptedObjectUploads-mojap-land-fail-preprod-hmpps-oasys"
+            },
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Principal = "*"
+              Effect    = "Deny"
+              Resource = [
+                "arn:aws:s3:::mojap-land-fail-preprod/*",
+                "arn:aws:s3::mojap-land-fail-preprod"
+              ]
+              Sid = "DenyInsecureTransport"
             },
           ]
           Version = "2012-10-17"
@@ -1666,6 +1763,21 @@ locals {
               Resource = "arn:aws:s3:::mojap-land-preprod/hmpps/oasys/*"
               Sid      = "GetDeleteAccess-mojap-land-preprod-hmpps-oasys"
             },
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Principal = "*"
+              Effect    = "Deny"
+              Resource = [
+                "arn:aws:s3:::mojap-land-preprod/*",
+                "arn:aws:s3:::mojap-land-preprod"
+              ]
+              Sid = "DenyInsecureTransport"
+            },
           ]
           Version = "2012-10-17"
         }
@@ -1773,7 +1885,22 @@ locals {
               }
               Resource = "arn:aws:s3:::mojap-metadata-dev/electronic_monitoring/*"
               Sid      = "PutAccess-mojap-metadata-dev-electronic-monitoring"
-            }
+            },
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Principal = "*"
+              Effect    = "Deny"
+              Resource = [
+                "arn:aws:s3:::mojap-metadata-dev/*",
+                "arn:aws:s3:::mojap-metadata-dev"
+              ]
+              Sid = "DenyInsecureTransport"
+            },
           ]
           Version = "2012-10-17"
         }
@@ -1860,6 +1987,21 @@ locals {
               }
               Resource = "arn:aws:s3:::mojap-metadata-preprod"
               Sid      = "ListBucketAccess-mojap-metadata-preprod"
+            },
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Principal = "*"
+              Effect    = "Deny"
+              Resource = [
+                "arn:aws:s3:::mojap-metadata-preprod/*",
+                "arn:aws:s3:::mojap-metadata-preprod"
+              ]
+              Sid = "DenyInsecureTransport"
             },
           ]
           Version = "2012-10-17"
@@ -1968,7 +2110,22 @@ locals {
               }
               Resource = "arn:aws:s3:::mojap-metadata-prod/electronic_monitoring/*"
               Sid      = "PutAccess-mojap-metadata-prod-electronic-monitoring"
-            }
+            },
+            {
+              Action = "s3:*"
+              Condition = {
+                Bool = {
+                  "aws:SecureTransport" = "false"
+                }
+              }
+              Principal = "*"
+              Effect    = "Deny"
+              Resource = [
+                "arn:aws:s3:::mojap-metadata-prod/*",
+                "arn:aws:s3:::mojap-metadata-prod"
+              ]
+              Sid = "DenyInsecureTransport"
+            },
           ]
           Version = "2012-10-17"
         }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/<your_issue_number_here>)
GitHub Issue.

# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/14) GitHub Issue.

This  work is part of the remediation for the above ticket where the ITHC report identified issues 

to implement `aws:SecureTransport" = "false"` where needed


- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

the `override-static-analysis` label has been used as there are multiple historical issues not touched by this PR

The terraform plan should be `Plan: 1 to add, 9 to change, 0 to destroy.` as one bucket does not currently have a bucket policy

