### PR TITLE
:pencil: Typo filename

### DIFF
--- a/scripts/dependabot/list-open-dependabot-prs.sh
+++ b/scripts/dependabot/list-open-dependabot-prs.sh
@@ -9,7 +9,7 @@
 #    gh auth login
 #
 # 3. Make the script executable:
-#    chmod +x check_dependabot_prs.sh
+#    chmod +x list-open-dependabot-prs.sh
 #
 # 4. Run the script:
 #    ./list-open-dependabot-prs.sh


### PR DESCRIPTION
Fixes an incorrect file name in a README.