### PR TITLE
S3 remediation -  correct typo in mojap-land-fail-preprod policy

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -1573,7 +1573,7 @@ locals {
               Effect    = "Deny"
               Resource = [
                 "arn:aws:s3:::mojap-land-fail-preprod/*",
-                "arn:aws:s3::mojap-land-fail-preprod"
+                "arn:aws:s3:::mojap-land-fail-preprod"
               ]
               Sid = "DenyInsecureTransport"
             },


### PR DESCRIPTION

# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/orgs/ministryofjustice/projects/27/views/18?pane=issue&itemId=61406352) GitHub Issue.

This  work is part of the remediation for the above ticket where the ITHC report identified issues 

to implement `aws:SecureTransport" = "false"` where needed


- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

the `override-static-analysis` label has been used as there are multiple historical issues not touched by this PR

This pr is to correct a typo in the policy for `mojap-land-fail-preprod`

The terraform apply will fail for` mojap-athena-query-dump` as the issue with its invalid principal is yet to be resolved.

