### PR TITLE
🔥 Remove invalid principal

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -400,36 +400,6 @@ locals {
         {
           Statement = [
             {
-              Action = [
-                "s3:ListBucket",
-                "s3:GetBucketLocation",
-              ]
-              Effect = "Allow"
-              Principal = {
-                AWS = "AROA27HJSWAHEPTTLIWSO"
-              }
-              Resource = "arn:aws:s3:::mojap-athena-query-dump"
-              Sid      = "list"
-            },
-            {
-              Action = [
-                "s3:GetObject",
-                "s3:GetObjectAcl",
-                "s3:GetObjectVersion",
-                "s3:DeleteObject",
-                "s3:DeleteObjectVersion",
-                "s3:PutObject",
-                "s3:PutObjectAcl",
-                "s3:RestoreObject",
-              ]
-              Effect = "Allow"
-              Principal = {
-                AWS = "AROA27HJSWAHEPTTLIWSO"
-              }
-              Resource = "arn:aws:s3:::mojap-athena-query-dump/*"
-              Sid      = "readwrite"
-            },
-            {
               Action = "s3:*"
               Condition = {
                 Bool = {


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform-ithc-2024/issues/14
- Removes statements referencing `AROA27HJSWAHEPTTLIWSO` as its returning the following
    ```bash
    Error: putting S3 Bucket (mojap-athena-query-dump) Policy: operation error S3: PutBucketPolicy, https response error StatusCode: 400, RequestID: EFGE55VM21VYP63G, HostID: qYQNK9197xg1jd2v3CqFX4RNlro80z5HWwL9hx8MJFJlY88k3ytqyCayNbDHp6Zd7wB+kKSBdC8=, api error MalformedPolicy: Invalid principal in policy
    ```

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 