### PR TITLE
create new policy assignments for lakeformation

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/data.tf
+++ b/terraform/aws/analytical-platform-development/cluster/data.tf
@@ -75,3 +75,7 @@ data "aws_nat_gateways" "nat_gateways" {
     values = ["available"]
   }
 }
+
+data "aws_iam_policy" "lake_formation_data_access" {
+  name = "lake-formation-data-access-additional"
+}

--- a/terraform/aws/analytical-platform-development/cluster/iam-roles.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-roles.tf
@@ -58,6 +58,11 @@ resource "aws_iam_role_policy_attachment" "prometheus_central_ingest" {
   policy_arn = "arn:aws:iam::aws:policy/AmazonPrometheusRemoteWriteAccess"
 }
 
+resource "aws_iam_role_policy_attachment" "prometheus_lake_formation_data_access" {
+  role       = aws_iam_role.prometheus_central_ingest.name
+  policy_arn = data.aws_iam_policy.lake_formation_data_access.arn
+}
+
 ##################################################
 # RDS Enhanced Monitoring
 ##################################################
@@ -81,6 +86,11 @@ resource "aws_iam_role" "rds_enhanced_monitoring" {
 resource "aws_iam_role_policy_attachment" "rds_enhanced_monitoring" {
   role       = aws_iam_role.rds_enhanced_monitoring.name
   policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole"
+}
+
+resource "aws_iam_role_policy_attachment" "rds_lake_formation_data_access" {
+  role       = aws_iam_role.rds_enhanced_monitoring.name
+  policy_arn = data.aws_iam_policy.lake_formation_data_access.arn
 }
 
 ##################################################

--- a/terraform/aws/analytical-platform-development/sagemaker/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-development/sagemaker/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.61.0"
-  constraints = ">= 5.30.0, 5.61.0"
+  constraints = ">= 5.46.0, 5.61.0"
   hashes = [
     "h1:1g7bIzb0pLRMKY16G5j2cXhAun2DmTg/HT9wX1IlhBE=",
+    "h1:VE5N7OZPW6/SRMTWX5JZ9XDMcwvs9GhUtSzhVG7DLIg=",
     "zh:1a0a150b6adaeacc8f56763182e76c6219ac67de1217b269d24b770067b7bab0",
     "zh:1d9c3a8ac3934a147569254d6e2e6ea5293974d0595c02c9e1aa31499a8f0042",
     "zh:1f4d1d5e2e02fd5cccafa28dade8735a3059ed1ca3284fb40116cdb67d0e7ee4",

--- a/terraform/aws/analytical-platform-development/sagemaker/data.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/data.tf
@@ -1,0 +1,7 @@
+##################################################
+# AWS
+##################################################
+
+data "aws_iam_policy" "lake_formation_data_access" {
+  name = "lake-formation-data-access-additional"
+}

--- a/terraform/aws/analytical-platform-development/sagemaker/iam-roles.tf
+++ b/terraform/aws/analytical-platform-development/sagemaker/iam-roles.tf
@@ -19,3 +19,8 @@ resource "aws_iam_role_policy_attachment" "sagemaker_full_access_studio" {
   role       = aws_iam_role.sagemaker_studio_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSageMakerFullAccess"
 }
+
+resource "aws_iam_role_policy_attachment" "sagemaker_lake_formation_data_access" {
+  role       = aws_iam_role.sagemaker_studio_execution_role.name
+  policy_arn = data.aws_iam_policy.lake_formation_data_access.arn
+}


### PR DESCRIPTION
This pull request:
- is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/4837) GitHub Issue
- creates IAM policy attachments for `lake-formation-data-access-additional` to IAM roles in `cluster` and `sagemaker` components in analytical-platform-development account

Static Analysis has been overridden due to historic errors not arising due to changes in this PR.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist
- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

Signed off by: Anthony Fitzroy <anthony.fitzroy@justice.gov.uk>
