### PR TITLE
🔀 Switch GPU to `g5.4xlarge`

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -187,7 +187,7 @@ eks_node_group_disk_size      = 250
 eks_node_group_instance_types = ["r5.2xlarge"]
 
 ### GPU-enable node group
-eks_node_group_instance_types_gpu_node = ["p3.2xlarge"]
+eks_node_group_instance_types_gpu_node = ["g5.4xlarge"]
 eks_node_group_ami_type_gpu_node       = "AL2_x86_64_GPU"
 
 eks_node_group_capacities_gpu_node = {

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -183,12 +183,12 @@ eks_node_group_disk_size      = 250
 eks_node_group_instance_types = ["r5.2xlarge"]
 
 ### GPU-enable node group
-eks_node_group_instance_types_gpu_node = ["p3.2xlarge"]
+eks_node_group_instance_types_gpu_node = ["g5.4xlarge"]
 eks_node_group_ami_type_gpu_node       = "AL2_x86_64_GPU"
 
 eks_node_group_capacities_gpu_node = {
   desired = 0
-  max     = 2
+  max     = 10
   min     = 0
 }
 


### PR DESCRIPTION
This pull request:

- Relates to https://github.com/ministryofjustice/data-platform-support/issues/808
- Switches tooling cluster GPU node to `g5.4xlarge`, `p3.2xlarge` cannot be scheduled due to insufficient capacity

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 