### PR TITLE
Add missing permission causing error in bedrock

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -18,6 +18,7 @@ data "aws_iam_policy_document" "bedrock_integration" {
       "bedrock:GetCustomModel",
       "bedrock:ListCustomModels",
       "bedrock:DeleteCustomModel",
+      "bedrock:ListInferenceProfiles",
       "bedrock:CreateProvisionedModelThroughput",
       "bedrock:UpdateProvisionedModelThroughput",
       "bedrock:GetProvisionedModelThroughput",

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -19,6 +19,7 @@ data "aws_iam_policy_document" "bedrock_integration" {
       "bedrock:GetCustomModel",
       "bedrock:ListCustomModels",
       "bedrock:DeleteCustomModel",
+      "bedrock:ListInferenceProfiles",
       "bedrock:CreateProvisionedModelThroughput",
       "bedrock:UpdateProvisionedModelThroughput",
       "bedrock:GetProvisionedModelThroughput",


### PR DESCRIPTION
# Pull Request Objective

This piece of work is relating to [this support issue](https://github.com/ministryofjustice/data-platform-support/issues/825).

This PR adds a list permission for `Inference Profiles`, a new feature that allows for distributed inference across an entire region (e.g. EU-West, as opposed to EU-West-1). The list permission alone will return an empty list (as they have no inference profiles that they can get), but should resolve the banner the customer is seeing in the console. A separate PR may be raised to add `Get` permissions associated with this functionality, but that should be accompanied with comms to customers on data sovereignty issues that this process would entail, and so is not handled here.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected
