### PR TITLE
feature: require http_tokens for airflow-prod instances (NCC-MOJU147-9JU)

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -127,7 +127,7 @@ resource "aws_launch_template" "prod_standard" {
 
   metadata_options {
     http_put_response_hop_limit = 2
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
   }
 
   network_interfaces {
@@ -179,7 +179,7 @@ resource "aws_launch_template" "prod_high_memory" {
 
   metadata_options {
     http_put_response_hop_limit = 2
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
   }
 
   network_interfaces {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this GitHub issue](https://github.com/ministryofjustice/analytical-platform-ithc-2024/issues/2).

This PR sets airflow-**prod** EC2 instances to use Instance Metadata Service (IMDS) Version 2 rather than Version 1. This should improve the security profile of these instances. 

## Checklist

- [X] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [X] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected