### PR TITLE
fix: revert `http_tokens` required setting as DAG tooling needs updating to support `"required"` setting

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -23,7 +23,7 @@ resource "aws_launch_template" "dev_standard" {
 
   metadata_options {
     http_put_response_hop_limit = 2
-    http_tokens                 = "required"
+    http_tokens                 = "optional"
   }
 
   network_interfaces {
@@ -75,7 +75,7 @@ resource "aws_launch_template" "dev_high_memory" {
 
   metadata_options {
     http_put_response_hop_limit = 2
-    http_tokens                 = "required"
+    http_tokens                 = "optional"
   }
 
   network_interfaces {


### PR DESCRIPTION
Reverting [earlier change](https://github.com/ministryofjustice/analytical-platform/pull/5437) as this is causing DAGs to fail in airflow dev. Airflow DAG templates / DE tooling may need updating before this change can be successfully rolled out. [See thread](https://mojdt.slack.com/archives/C04M8224WCV/p1727105019008249?thread_ts=1727092810.767799&cid=C04M8224WCV)