### PR TITLE
📝 Amend references to `ministryofjustice/data-platform` repository in the docs

### DIFF
--- a/source/documentation/joining-our-team/index.html.md.erb
+++ b/source/documentation/joining-our-team/index.html.md.erb
@@ -50,8 +50,8 @@ Our PagerDuty configuration is managed in Terraform.
 
 To add a user, do the following:
 
-1. Add an entry into [`users.tf`](https://github.com/ministryofjustice/data-platform/blob/main/terraform/pagerduty/users.tf)
+1. Add an entry into [`users.tf`](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/pagerduty/users.tf)
 
-1. Add an entry into [`teams.tf`](https://github.com/ministryofjustice/data-platform/blob/main/terraform/pagerduty/teams.tf)
+1. Add an entry into [`teams.tf`](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/pagerduty/teams.tf)
 
-1. Add an entry into [`schedules.tf`](https://github.com/ministryofjustice/data-platform/blob/main/terraform/pagerduty/schedules.tf)
+1. Add an entry into [`schedules.tf`](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/pagerduty/schedules.tf)

--- a/source/documentation/platform/infrastructure/terraform.html.md.erb
+++ b/source/documentation/platform/infrastructure/terraform.html.md.erb
@@ -63,7 +63,7 @@ To create a new Terraform component, you will need to:
     | `ENVIRONMENT` | Name of the environment<br /> | `development` |
     | `IS_PRODUCTION` | Whether the environment is production<br /> | `false` |
 
-    `data.tf` [(Example)](https://github.com/ministryofjustice/data-platform/blob/main/terraform/aws/analytical-platform-data-production/airflow/data.tf)
+    `data.tf` [(Example)](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/aws/analytical-platform-data-production/airflow/data.tf)
 
       <details>
 
@@ -83,7 +83,7 @@ To create a new Terraform component, you will need to:
 
       </details>
 
-    `terraform.tf` [(Example)](https://github.com/ministryofjustice/data-platform/blob/main/terraform/aws/analytical-platform-data-production/airflow/terraform.tf)
+    `terraform.tf` [(Example)](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/aws/analytical-platform-data-production/airflow/terraform.tf)
 
       <details>
 
@@ -136,7 +136,7 @@ To create a new Terraform component, you will need to:
 
       </details>
 
-    `terraform.tfvars` [(Example)](https://github.com/ministryofjustice/data-platform/blob/main/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars)
+    `terraform.tfvars` [(Example)](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/aws/analytical-platform-data-production/airflow/terraform.tfvars)
 
       <details>
 
@@ -156,13 +156,13 @@ To create a new Terraform component, you will need to:
         is-production          = "${IS_PRODUCTION}"
         owner                  = "data-platform:data-platform-tech@digital.justice.gov.uk"
         infrastructure-support = "data-platform:data-platform-tech@digital.justice.gov.uk"
-        source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/${AWS_ACCOUNT_NAME}/${COMPONENT}"
+        source-code            = "github.com/ministryofjustice/analytical-platform/terraform/aws/${AWS_ACCOUNT_NAME}/${COMPONENT}"
       }
       ```
 
       </details>
 
-    `variables.tf` [(Example)](https://github.com/ministryofjustice/data-platform/blob/main/terraform/aws/analytical-platform-data-production/airflow/variables.tf)
+    `variables.tf` [(Example)](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/aws/analytical-platform-data-production/airflow/variables.tf)
 
       <details>
 
@@ -198,8 +198,8 @@ To create a new Terraform component, you will need to:
 
 ## Static Analysis
 
-Static analysis was introduced in [#866](https://github.com/ministryofjustice/data-platform/pull/866), however the components that make up Analytical Platform
-have not been remediated yet, this is addressed in [#886](https://github.com/ministryofjustice/data-platform/issues/886)
+Static analysis was introduced in [#866](https://github.com/ministryofjustice/analytical-platform/pull/866), however the components that make up Analytical Platform
+have not been remediated yet, this is addressed in [#886](https://github.com/ministryofjustice/analytical-platform/issues/886)
 
 If you are working on a component that has not yet been addressed, you will need to add the label `override-static-analysis` to your pull request
 


### PR DESCRIPTION
This pull request:

- Amends references to `ministryofjustice/data-platform` because the auto redirect doesn't work for issues anymore

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 