### PR TITLE
➕ `dbeaver.io` to `.lycheeignore`

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -14,3 +14,4 @@ https://github.com/moj-analytical-services/create-a-derived-table
 https://github.com/ministryofjustice/analytics-platform-helm-charts/tree/main/charts/jupyter-lab-datascience-notebook
 https://github.com/ministryofjustice/analytics-platform-helm-charts/tree/main/charts/jupyter-lab-all-spark
 https://github.com/ministryofjustice/analytics-platform-helm-charts/tree/main/charts/jupyter-lab
+https://dbeaver.io/download/


### PR DESCRIPTION
Resolves this failing despite the URL being correct. 