### PR TITLE
🏷️  update ECR images to immutable tags

### DIFF
--- a/terraform/aws/analytical-platform-data-production/artifact-repos/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/artifact-repos/.terraform.lock.hcl
@@ -5,6 +5,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.69.0"
   constraints = "5.69.0"
   hashes = [
+    "h1:Ccpjmuu4G6k6ET0yf9lfhRywN7GBAAxR4rfTl5aY5+U=",
     "h1:hV8b5zl9mFgeUInTMYtnq9Sj0o7OBca9CIBRMP3whXU=",
     "zh:123af8815a80abfd62eab5f9fc3d9226735cfea3627e834a1b48321cd8d391a6",
     "zh:1298f312e239768c1846541e89b4fbec7eb21769c4a488c87181909049219fbe",

--- a/terraform/aws/analytical-platform-data-production/artifact-repos/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/artifact-repos/locals.tf
@@ -42,10 +42,6 @@ locals {
       "allowed_push_arns" = [local.github_actions_runner]
       "allowed_pull_arns" = [local.data_account_arn, local.development_account_arn, local.production_account_arn]
     },
-    # "github-actions-template" = {
-    #   "allowed_push_arns" = [local.github_actions_runner]
-    #   "allowed_pull_arns" = [local.data_account_arn, local.development_account_arn]
-    # }
     "controlpanel_eks" = {
       "allowed_push_arns" = [local.github_actions_runner]
       "allowed_pull_arns" = [local.data_account_arn, local.development_account_arn, local.production_account_arn]

--- a/terraform/aws/analytical-platform-data-production/artifact-repos/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/artifact-repos/locals.tf
@@ -42,10 +42,10 @@ locals {
       "allowed_push_arns" = [local.github_actions_runner]
       "allowed_pull_arns" = [local.data_account_arn, local.development_account_arn, local.production_account_arn]
     },
-    "github-actions-template" = {
-      "allowed_push_arns" = [local.github_actions_runner]
-      "allowed_pull_arns" = [local.data_account_arn, local.development_account_arn]
-    }
+    # "github-actions-template" = {
+    #   "allowed_push_arns" = [local.github_actions_runner]
+    #   "allowed_pull_arns" = [local.data_account_arn, local.development_account_arn]
+    # }
     "controlpanel_eks" = {
       "allowed_push_arns" = [local.github_actions_runner]
       "allowed_pull_arns" = [local.data_account_arn, local.development_account_arn, local.production_account_arn]

--- a/terraform/aws/analytical-platform-data-production/artifact-repos/modules/ecr/main.tf
+++ b/terraform/aws/analytical-platform-data-production/artifact-repos/modules/ecr/main.tf
@@ -1,7 +1,7 @@
 resource "aws_ecr_repository" "this" {
   #ts:skip=AWS.AER.DP.MEDIUM.0026 ECR is shared between all environments
   name                 = var.name
-  image_tag_mutability = "MUTABLE"
+  image_tag_mutability = "IMMUTABLE"
 
   image_scanning_configuration {
     scan_on_push = true


### PR DESCRIPTION
This pull request:

- contributes to https://github.com/ministryofjustice/analytical-platform-ithc-2024/issues/5
- updates analytical-platform-data-production image tags to be immutable
- removes github-actions-template repo, which was found to be empty and unused

## Checklist
- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected


Signed off by: Anthony Fitzroy <anthony.fitzroy@justice.gov.uk>