### PR TITLE
Test disabling enforce client side settings on athena workgroups

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -34,7 +34,7 @@ resource "aws_athena_workgroup" "airflow" {
 
   configuration {
     bytes_scanned_cutoff_per_query  = 1099511627776
-    enforce_workgroup_configuration = strcontains(each.value.name, "airflow-dev-workgroup") ? "false" : "true"
+    enforce_workgroup_configuration = strcontains(each.value.name, "airflow-dev-workgroup") ? false : true
     engine_version {
       selected_engine_version = "Athena engine version 3"
     }

--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -34,7 +34,7 @@ resource "aws_athena_workgroup" "airflow" {
 
   configuration {
     bytes_scanned_cutoff_per_query  = 1099511627776
-    enforce_workgroup_configuration = true
+    enforce_workgroup_configuration = strcontains(each.value.name, "airflow-dev-workgroup") ? "false" : "true"
     engine_version {
       selected_engine_version = "Athena engine version 3"
     }


### PR DESCRIPTION
# Pull Request Objective

The Athena Primary workgroup does not enforce client side settings which means that [IAM builder](https://github.com/moj-analytical-services/iam_builder/blob/4b39d53d87329a614473c8d6107ee1e6f3d82487/examples/iam_policy.json#L56) automatically grants access to the right folder : arn:aws:s3:::mojap-athena-query-dump/${aws:userid}/*"

We want to test the impact of not enforcing client https://docs.aws.amazon.com/athena/latest/ug/workgroups-settings-override.html on the new Airflow workgroups

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
