### PR TITLE
Add AssumeRole Permissions to Control Panel Dev Role

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -31,6 +31,8 @@ resource "aws_iam_policy" "cert_manager" {
 ##################################################
 
 data "aws_iam_policy_document" "cluster_autoscaler" {
+  #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
+  #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
   statement {
     sid    = "clusterAutoscalerAll"
     effect = "Allow"
@@ -311,6 +313,8 @@ resource "aws_iam_policy" "ebs_csi_driver" {
 ##################################################
 
 data "aws_iam_policy_document" "control_panel_api" {
+  #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
+  #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
   statement {
     sid    = "CanCreateBuckets"
     effect = "Allow"

--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -515,6 +515,18 @@ data "aws_iam_policy_document" "control_panel_api" {
     ]
     resources = ["arn:aws:lakeformation:*:${var.account_ids["analytical-platform-development"]}:*"]
   }
+  statement {
+    sid    = "AssumeRoleComputeAccounnt"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_ids["analytical-platform-compute-development"]}:role/analytical-platform-control-panel",
+      "arn:aws:iam::${var.account_ids["analytical-platform-compute-test"]}:role/analytical-platform-control-panel"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "control_panel_api" {

--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -6,6 +6,8 @@ account_ids = {
   analytical-platform-development           = "525294151996"
   analytical-platform-management-production = "042130406152"
   analytical-platform-production            = "312423030077"
+  analytical-platform-compute-development   = "381491960855"
+  analytical-platform-compute-test          = "767397661611"
 }
 
 environment     = "development"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/5532)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

This PR adds permissions to the Control Panel Development role to assume service roles in Compute development and test accounts to allow the Control Panel to manage LakeFormation and QuickSight-related assets in those accounts.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [X] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [X] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
