### PR TITLE
Change to require http_tokens (IMDSv2) in Dev

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -23,7 +23,7 @@ resource "aws_launch_template" "dev_standard" {
 
   metadata_options {
     http_put_response_hop_limit = 2
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
   }
 
   network_interfaces {
@@ -75,7 +75,7 @@ resource "aws_launch_template" "dev_high_memory" {
 
   metadata_options {
     http_put_response_hop_limit = 2
-    http_tokens                 = "optional"
+    http_tokens                 = "required"
   }
 
   network_interfaces {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform-ithc-2024/issues/2)
GitHub Issue.

This PR enables IMDSv2 in both airflow dev launch templates. Further work will follow on enabling the same in Prod.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

Once live will put out comms in channels.