### PR TITLE
revert #5700 due to CrashLoopBackOffs

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow/launch-templates.tf
@@ -23,7 +23,7 @@ resource "aws_launch_template" "dev_standard" {
 
   metadata_options {
     http_put_response_hop_limit = 2
-    http_tokens                 = "required"
+    http_tokens                 = "optional"
   }
 
   network_interfaces {
@@ -75,7 +75,7 @@ resource "aws_launch_template" "dev_high_memory" {
 
   metadata_options {
     http_put_response_hop_limit = 2
-    http_tokens                 = "required"
+    http_tokens                 = "optional"
   }
 
   network_interfaces {


### PR DESCRIPTION
Revering changes made in #5700 due to them introducing `CrashLoopBackOff`s in systems that aren't worth debugging due to imminent shutdown.