### PR TITLE
🚚 Import Analytical Platform's Terraform backend

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -67,6 +67,7 @@ updates:
       - "terraform/aws/analytical-platform-development/sagemaker"
       - "terraform/aws/analytical-platform-development/tooling-iam"
       - "terraform/aws/analytical-platform-management-production/cluster"
+      - "terraform/aws/analytical-platform-management-production/terraform-state"
       - "terraform/aws/analytical-platform-production/cluster"
       - "terraform/aws/analytical-platform-production/route53"
       - "terraform/aws/analytical-platform/baseline"

--- a/terraform/aws/analytical-platform-management-production/terraform-state/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.72.1"
+  constraints = "5.72.1"
+  hashes = [
+    "h1:vxyASKtB4cH3WR1Rcd8n93hO1Ge++3I/Iuc1MMWceKI=",
+    "zh:0dea6843836e926d33469b48b948744079023816d16a2ff7666bcfb6aa3522d4",
+    "zh:195fa9513f75800a0d62797ebec75ee73e9b8c28d713fe9b63d3b1d1eec129b3",
+    "zh:1ed92f3961715bf0e024bcde3c12dfbdc50b00c1f8a43cc00802cfc45a256208",
+    "zh:2ac687e3a52606466cae4a6813e81d923042488df88d2424e28d3f8530f091bb",
+    "zh:32e7ca75f9314557daada3c44628fe1f3bf964a4f833bfb4b2295d833fe64b6f",
+    "zh:374ee0e6b4327cc6ef666908ce5d6450a3a56e90cd2b785e83c2bcfc100021d2",
+    "zh:5500fd6fdac44f96411fcf9c6d01691159ec35455ed127eb4c3a498e1cc92a64",
+    "zh:723a2dc4b064c12e7ee62ad4fbfd72fa5e025206ea47b735994ef53f3c373152",
+    "zh:89d97b87605f1d734f27e642567cbecf785b521af8ea81dac55c77ccde876221",
+    "zh:951ee1e5731e8d65d521d71b95927e55055b3c4656eef6d46fa580a63328befc",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b2b362470b64ec227b2da64762ab8bc4111c6b80365fd9d82fc5e1e33f44038",
+    "zh:aa6e57d0cb974ff0da5dee5d43ad2745cbbc4a2b507d4c799839b9fa96daf688",
+    "zh:ba0d14c4a6b7aa844a830d47c0bf995b632e37f0795394b5b60c638b62b7fc03",
+    "zh:c9764065a9c5d324db0b02bd201b9e3a2118e49c4960884acdeea377173302e9",
+  ]
+}

--- a/terraform/aws/analytical-platform-management-production/terraform-state/data.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/data.tf
@@ -1,0 +1,9 @@
+data "aws_caller_identity" "session" {
+  provider = aws.session
+}
+
+data "aws_iam_session_context" "session" {
+  provider = aws.session
+
+  arn = data.aws_caller_identity.session.arn
+}

--- a/terraform/aws/analytical-platform-management-production/terraform-state/dynamodb-table.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/dynamodb-table.tf
@@ -1,0 +1,11 @@
+module "state_locking" {
+  source  = "terraform-aws-modules/dynamodb-table/aws"
+  version = "4.2.0"
+
+  name = "global-tf-state-aqsvzyd5u9-locks"
+}
+
+import {
+  to = module.state_locking.aws_dynamodb_table.this[0]
+  id = "global-tf-state-aqsvzyd5u9-locks"
+}

--- a/terraform/aws/analytical-platform-management-production/terraform-state/dynamodb-table.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/dynamodb-table.tf
@@ -1,4 +1,7 @@
 module "state_locking" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
   source  = "terraform-aws-modules/dynamodb-table/aws"
   version = "4.2.0"
 

--- a/terraform/aws/analytical-platform-management-production/terraform-state/s3-bucket.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/s3-bucket.tf
@@ -1,0 +1,16 @@
+module "state_bucket" {
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.2.1"
+
+  bucket = "global-tf-state-aqsvzyd5u9"
+}
+
+import {
+  to = module.state_bucket.aws_s3_bucket.this[0]
+  id = "global-tf-state-aqsvzyd5u9"
+}
+
+import {
+  to = module.state_bucket.aws_s3_bucket_public_access_block.this[0]
+  id = "global-tf-state-aqsvzyd5u9"
+}

--- a/terraform/aws/analytical-platform-management-production/terraform-state/s3-bucket.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/s3-bucket.tf
@@ -1,4 +1,7 @@
 module "state_bucket" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "4.2.1"
 

--- a/terraform/aws/analytical-platform-management-production/terraform-state/terraform.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/terraform.tf
@@ -1,0 +1,31 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-management-production/terraform-state/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.72.1"
+    }
+  }
+  required_version = "~> 1.5"
+}
+
+provider "aws" {
+  alias = "session"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-management-production/terraform-state/terraform.tfvars
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/terraform.tfvars
@@ -1,0 +1,14 @@
+account_ids = {
+  analytical-platform-management-production = "042130406152"
+}
+
+tags = {
+  business-unit          = "Platforms"
+  application            = "Analytical Platform"
+  component              = "Terrform State"
+  environment            = "production"
+  is-production          = "true"
+  owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/analytical-platform/terraform/aws/analytical-platform-management-production/terraform-state"
+}

--- a/terraform/aws/analytical-platform-management-production/terraform-state/variables.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/variables.tf
@@ -1,0 +1,9 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5658
- Imports S3 bucket and DynamoDB table created here https://github.com/ministryofjustice/ap-terraform-bootstrap/blob/main/state.tf

I am overriding static analysis because this is legacy infrastructure and out of scope to remediate.

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 