### PR TITLE
Allow CP Role to Assume Role in APC Test and Prod

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
@@ -3,6 +3,8 @@
 ##################################################
 
 data "aws_iam_policy_document" "ebs_csi_driver" {
+  #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
+  #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
   statement {
     sid    = "EbsCsiDriver"
     effect = "Allow"
@@ -39,6 +41,8 @@ resource "aws_iam_policy" "ebs_csi_driver" {
 ##################################################
 
 data "aws_iam_policy_document" "control_panel_api" {
+  #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
+  #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
   statement {
     sid    = "CanCreateBuckets"
     effect = "Allow"
@@ -243,6 +247,18 @@ data "aws_iam_policy_document" "control_panel_api" {
     ]
     resources = ["arn:aws:lakeformation:*:${var.account_ids["analytical-platform-data-production"]}:*"]
   }
+  statement {
+    sid    = "AssumeRoleComputeAccounnt"
+    effect = "Allow"
+    actions = [
+      "sts:AssumeRole",
+      "sts:TagSession"
+    ]
+    resources = [
+      "arn:aws:iam::${var.account_ids["analytical-platform-compute-production"]}:role/analytical-platform-control-panel",
+      "arn:aws:iam::${var.account_ids["analytical-platform-compute-test"]}:role/analytical-platform-control-panel"
+    ]
+  }
 }
 
 resource "aws_iam_policy" "control_panel_api" {
@@ -286,6 +302,8 @@ resource "aws_iam_policy" "cert_manager" {
 ##################################################
 
 data "aws_iam_policy_document" "cluster_autoscaler" {
+  #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
+  #checkov:skip=CKV_AWS_356: skip requires access to multiple resources
   statement {
     sid    = "clusterAutoscalerAll"
     effect = "Allow"

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -7,6 +7,8 @@ account_ids = {
   analytical-platform-development           = "525294151996"
   analytical-platform-management-production = "042130406152"
   analytical-platform-production            = "312423030077"
+  analytical-platform-compute-test          = "767397661611"
+  analytical-platform-compute-production    = "992382429243"
 }
 
 environment     = "production"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/5532)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

Adding permission for the Control Panel to assume a role in APC test and prod

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [X] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [X] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
