### PR TITLE
🔀 Switch to using assumed role in Management Production

### DIFF
--- a/terraform/aws/analytical-platform-management-production/terraform-state/dynamodb-table.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/dynamodb-table.tf
@@ -46,9 +46,9 @@ data "aws_iam_policy_document" "state_locking_policy" {
       identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.analytical_platform_team_access_role.names)}"]
     }
   }
-  // Data Engineering: Data Engineering Production
+  // Data Engineering Team
   statement {
-    sid    = "DataEngineeringProduction"
+    sid    = "DataEngineeringTeam"
     effect = "Allow"
     actions = [
       "dynamodb:DescribeTable",
@@ -59,42 +59,7 @@ data "aws_iam_policy_document" "state_locking_policy" {
     resources = [module.state_locking.dynamodb_table_arn]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"]
-    }
-  }
-  // Data Engineering: Data Engineering Sandbox A
-  statement {
-    sid    = "DataEngineeringSandboxA"
-    effect = "Allow"
-    actions = [
-      "dynamodb:DescribeTable",
-      "dynamodb:GetItem",
-      "dynamodb:PutItem",
-      "dynamodb:DeleteItem"
-    ]
-    resources = [module.state_locking.dynamodb_table_arn]
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_sandbox_a_admin.names)}",
-        "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_sandbox_a_data_eng.names)}"
-      ]
-    }
-  }
-  // Data Engineering: Data Production
-  statement {
-    sid    = "DataProduction"
-    effect = "Allow"
-    actions = [
-      "dynamodb:DescribeTable",
-      "dynamodb:GetItem",
-      "dynamodb:PutItem",
-      "dynamodb:DeleteItem"
-    ]
-    resources = [module.state_locking.dynamodb_table_arn]
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_production_data_eng.names)}"]
+      identifiers = [module.data_engineering_state_access_iam_role.iam_role_arn]
     }
   }
 }

--- a/terraform/aws/analytical-platform-management-production/terraform-state/iam-policies.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/iam-policies.tf
@@ -18,6 +18,17 @@ data "aws_iam_policy_document" "data_engineering_state_access" {
       "${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-production/*"
     ]
   }
+  statement {
+    sid    = "DynamoDBAccess"
+    effect = "Allow"
+    actions = [
+      "dynamodb:DescribeTable",
+      "dynamodb:GetItem",
+      "dynamodb:PutItem",
+      "dynamodb:DeleteItem"
+    ]
+    resources = [module.state_locking.dynamodb_table_arn]
+  }
 }
 
 module "data_engineering_state_access_iam_policy" {

--- a/terraform/aws/analytical-platform-management-production/terraform-state/iam-policies.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/iam-policies.tf
@@ -1,0 +1,33 @@
+data "aws_iam_policy_document" "data_engineering_state_access" {
+  statement {
+    sid       = "S3ListBucket"
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [module.state_bucket.s3_bucket_arn]
+  }
+  statement {
+    sid    = "S3ReadWriteBucket"
+    effect = "Allow"
+    actions = [
+      "s3:GetObject",
+      "s3:PutObject"
+    ]
+    resources = [
+      "${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-engineering-production/*",
+      "${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-engineering-sandbox-a/*",
+      "${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-production/*"
+    ]
+  }
+}
+
+module "data_engineering_state_access_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.47.0"
+
+  name_prefix = "data-engineering-state-access"
+
+  policy = data.aws_iam_policy_document.data_engineering_state_access.json
+}

--- a/terraform/aws/analytical-platform-management-production/terraform-state/iam-roles.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/iam-roles.tf
@@ -1,0 +1,21 @@
+module "data_engineering_state_access_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.47.0"
+
+
+  create_role       = true
+  role_name         = "data-engineering-state-access"
+  role_requires_mfa = false
+
+  trusted_role_arns = [
+    "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}",
+    "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_sandbox_a_admin.names)}",
+    "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_sandbox_a_data_eng.names)}",
+    "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_production_data_eng.names)}"
+  ]
+
+  custom_role_policy_arns = [module.data_engineering_state_access_iam_policy.arn]
+}

--- a/terraform/aws/analytical-platform-management-production/terraform-state/outputs.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/outputs.tf
@@ -1,0 +1,3 @@
+output "data_engineering_state_access_iam_role" {
+  value = module.data_engineering_state_access_iam_role.iam_role_arn
+}

--- a/terraform/aws/analytical-platform-management-production/terraform-state/s3-bucket.tf
+++ b/terraform/aws/analytical-platform-management-production/terraform-state/s3-bucket.tf
@@ -45,82 +45,32 @@ data "aws_iam_policy_document" "state_bucket_policy" {
       identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.analytical_platform_team_access_role.names)}"]
     }
   }
-  // Data Engineering: Data Engineering Production
+  // Data Engineering Team
   statement {
-    sid       = "DataEngineeringProductionListBucket"
+    sid       = "DataEngineeringTeamListBucket"
     effect    = "Allow"
     actions   = ["s3:ListBucket"]
     resources = [module.state_bucket.s3_bucket_arn]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"]
+      identifiers = [module.data_engineering_state_access_iam_role.iam_role_arn]
     }
   }
   statement {
-    sid    = "DataEngineeringProductionReadWriteBucket"
+    sid    = "DataEngineeringTeamReadWriteBucket"
     effect = "Allow"
     actions = [
       "s3:GetObject",
       "s3:PutObject"
     ]
-    resources = ["${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-engineering-production/*"]
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"]
-    }
-  }
-  // Data Engineering: Data Engineering Sandbox A
-  statement {
-    sid       = "DataEngineeringSandboxAListBucket"
-    effect    = "Allow"
-    actions   = ["s3:ListBucket"]
-    resources = [module.state_bucket.s3_bucket_arn]
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_sandbox_a_admin.names)}",
-        "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_sandbox_a_data_eng.names)}"
-      ]
-    }
-  }
-  statement {
-    sid    = "DataEngineeringSandboxAReadWriteBucket"
-    effect = "Allow"
-    actions = [
-      "s3:GetObject",
-      "s3:PutObject"
+    resources = [
+      "${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-engineering-production/*",
+      "${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-engineering-sandbox-a/*",
+      "${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-production/*"
     ]
-    resources = ["${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-engineering-sandbox-a/*"]
-    principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_sandbox_a_admin.names)}",
-        "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_sandbox_a_data_eng.names)}"
-      ]
-    }
-  }
-  // Data Engineering: Data Production
-  statement {
-    sid       = "DEDataProductionListBucket"
-    effect    = "Allow"
-    actions   = ["s3:ListBucket"]
-    resources = [module.state_bucket.s3_bucket_arn]
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_production_data_eng.names)}"]
-    }
-  }
-  statement {
-    sid    = "DEDataProductionReadWriteBucket"
-    effect = "Allow"
-    actions = [
-      "s3:GetObject",
-      "s3:PutObject"
-    ]
-    resources = ["${module.state_bucket.s3_bucket_arn}/aws/analytical-platform-data-production/*"]
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_production_data_eng.names)}"]
+      identifiers = [module.data_engineering_state_access_iam_role.iam_role_arn]
     }
   }
 }


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5658
- Creates a new role and policy for access S3 and DynamoDB
- Updates S3 bucket policy and DynamoDB policy to allow new role
- Removes references to external roles on S3 and DynamoDB

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 