### PR TITLE
Raise lifecycling cap on CaDeT run artefacts

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/locals.tf
@@ -82,7 +82,7 @@ locals {
           }
 
           expiration = {
-            days                         = 3
+            days                         = 14
             expired_object_delete_marker = false
           }
         },


### PR DESCRIPTION
# Pull Request Objective

This is in response to a request from the catalog team to allow run artefacts to persist longer.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [X] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [X] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [X] I have self-reviewed my code
- [X] I have reviewed the checks and can attest they're as expected

### Additional Comments

[In response to this thread](https://mojdt.slack.com/archives/CBVUV2613/p1730121931506789)
