### PR TITLE
fix: AP-5599 remove SSE-KMS encryption references for replication config

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -124,9 +124,6 @@ module "mojap_cadet_production" {
           access_control_translation = {
             owner = "Destination"
           }
-          encryption_configuration = {
-            replica_kms_key_id = "arn:aws:kms:${local.destination_region}:${var.account_ids["analytical-platform-compute-production"]}:key/${local.mojap_apc_prod_cadet_replication_kms_key_id}"
-          }
           metrics = {
             status  = "Enabled"
             minutes = 15


### PR DESCRIPTION
fix for changes merged in #5810

removes [extraneous SSE-KMS encryption reference](https://docs.aws.amazon.com/AmazonS3/latest/API/API_SourceSelectionCriteria.html) within replication config destination block, as source bucket doesn't use SSE-KMS