### PR TITLE
📌 Update `tech-docs-github-pages-publisher` to v5.0.0

### DIFF
--- a/.github/workflows/build-publish-documentation.yml
+++ b/.github/workflows/build-publish-documentation.yml
@@ -17,7 +17,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684 # v4.0.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 # v5.0.0
     permissions:
       contents: read
     steps:

--- a/.github/workflows/build-test-documentation.yml
+++ b/.github/workflows/build-test-documentation.yml
@@ -13,7 +13,7 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     container:
-      image: docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684 # v4.0.0
+      image: ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8 # v5.0.0
     permissions:
       contents: read
     steps:

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -10,13 +10,13 @@ host: https://technical-documentation.data-platform.service.justice.gov.uk
 show_govuk_logo: false
 service_name: Analytical Platform
 service_link: /
-phase: Alpha
+phase: INTERNAL
 
 # Links to show on right-hand-side of header
 header_links:
-  🏠 Home: https://docs.analytical-platform.service.justice.gov.uk/
-  🔧 Our Main GitHub repo: https://github.com/ministryofjustice/analytical-platform
-  💬 Ask Slack Channel: https://mojdt.slack.com/archives/C04VBJTKY58
+  Home: https://docs.analytical-platform.service.justice.gov.uk/
+  GitHub: https://github.com/ministryofjustice/analytical-platform
+  Slack: https://mojdt.slack.com/archives/C04VBJTKY58
 
 # Enables search functionality. This indexes pages only and is not recommended for single-page sites.
 enable_search: true

--- a/scripts/docs/local.sh
+++ b/scripts/docs/local.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 MODE="${1:-preview}"
-TECH_DOCS_PUBLISHER_IMAGE="docker.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:cd3513beca3fcaf5dd34cbe81a33b3ff30337d8ada5869b40a6454c21d6f7684" # v4.0.0
+TECH_DOCS_PUBLISHER_IMAGE="ghcr.io/ministryofjustice/tech-docs-github-pages-publisher@sha256:35699473dbeefeeb8b597de024125a241277ee03587d5fe8e72545e4b27b33f8" # v5.0.0
 
 case ${MODE} in
 package | preview)
@@ -19,9 +19,9 @@ else
   PLATFORM_FLAG=""
 fi
 
-docker run -it --rm ${PLATFORM_FLAG} \
+docker run -it --rm "${PLATFORM_FLAG}" \
   --name "tech-docs-${MODE}" \
   --publish 4567:4567 \
-  --volume "${PWD}/config:/app/config" \
-  --volume "${PWD}/source:/app/source" \
+  --volume "${PWD}/config:/tech-docs-github-pages-publisher/config" \
+  --volume "${PWD}/source:/tech-docs-github-pages-publisher/source" \
   "${TECH_DOCS_PUBLISHER_IMAGE}" "/usr/local/bin/${MODE}"

--- a/source/javascripts/govuk_frontend.js
+++ b/source/javascripts/govuk_frontend.js
@@ -1,0 +1,1 @@
+//= require govuk_frontend_all


### PR DESCRIPTION
This pull request:

- Updates `tech-docs-github-pages-publisher` to [v5.0.0](https://github.com/ministryofjustice/tech-docs-github-pages-publisher/releases/tag/v5.0.0)
- Adds required `source/javascripts/govuk_frontend.js`
- Updates `scripts/local.sh` to use new working directory
- Updates phase to "INTERNAL"
- Removes emojis, not good for a11y

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 