### PR TITLE
feat: AP-5599 add permission to put inventory config in source bucket for replication

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
@@ -16,7 +16,8 @@ data "aws_iam_policy_document" "mojap_cadet_production_replication" {
     effect = "Allow"
     actions = [
       "s3:GetReplicationConfiguration",
-      "s3:ListBucket"
+      "s3:ListBucket",
+      "s3:PutInventoryConfiguration"
     ]
     resources = [module.mojap_cadet_production.s3_bucket_arn]
   }

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
@@ -12,6 +12,16 @@ data "aws_iam_policy_document" "mojap_cadet_production_replication" {
     resources = ["arn:aws:s3:::${local.mojap_apc_prod_cadet_replication_bucket}/*"]
   }
   statement {
+    sid    = "SourceBucketManifestPermissions"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:GetObject",
+      "s3:GetObjectVersion"
+    ]
+    resources = ["${module.mojap_cadet_production.s3_bucket_arn}/batch-manifest/*"]
+  }
+  statement {
     sid    = "SourceBucketPermissions"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in #5599

[`s3:PutInventoryConfiguration` permission is required to put an inventory config within the source bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/example-bucket-policies.html#example-bucket-policies-s3-inventory-2), used for batch replication. We also need [put and get permissions for the replication report](https://docs.aws.amazon.com/AmazonS3/latest/userguide/s3-batch-replication-policies.html).

This PR adds those permission to the IAM role used for replication.

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
