### PR TITLE
feat: add `s3:InitiateReplication` permission for replication iam policy

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
@@ -15,9 +15,10 @@ data "aws_iam_policy_document" "mojap_cadet_production_replication" {
     sid    = "SourceBucketManifestPermissions"
     effect = "Allow"
     actions = [
-      "s3:PutObject",
       "s3:GetObject",
-      "s3:GetObjectVersion"
+      "s3:GetObjectVersion",
+      "s3:InitiateReplication",
+      "s3:PutObject"
     ]
     resources = ["${module.mojap_cadet_production.s3_bucket_arn}/batch-manifest/*"]
   }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in #5599

[`s3:InitiateReplication` looks to be required for using S3-generated manifests for batch replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/batch-ops-iam-role-policies.html#batch-ops-batch-replication-policy)

This PR adds that permission to the IAM role used for replication.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
