### PR TITLE
feat: AP-5599 add replication manifest manipulation file permissions

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -181,6 +181,8 @@ data "aws_iam_policy_document" "mojap_cadet_production" {
     effect = "Allow"
     actions = [
       "s3:PutObject",
+      "s3:GetObject",
+      "s3:GetObjectVersion"
     ]
     resources = [
       "arn:aws:s3:::mojap-derived-tables/batch-replication/*",


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in #5599

The replication IAM role needs extra permissions for handling the replication manifest during the batch replication process.

This PR adds those permission to the IAM role used for replication.

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
