### PR TITLE
fix: AP-5599 apply `InitiateReplication` permission to all objects in source bucket

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/iam-policies.tf
@@ -17,10 +17,17 @@ data "aws_iam_policy_document" "mojap_cadet_production_replication" {
     actions = [
       "s3:GetObject",
       "s3:GetObjectVersion",
-      "s3:InitiateReplication",
       "s3:PutObject"
     ]
     resources = ["${module.mojap_cadet_production.s3_bucket_arn}/batch-manifest/*"]
+  }
+  statement {
+    sid    = "SourceBucketReplicatePermissions"
+    effect = "Allow"
+    actions = [
+      "s3:InitiateReplication"
+    ]
+    resources = ["${module.mojap_cadet_production.s3_bucket_arn}/*"]
   }
   statement {
     sid    = "SourceBucketPermissions"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in #5599

Apply InitiateReplication permission to all objects in source bucket ([required for replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/batch-ops-iam-role-policies.html#batch-ops-batch-replication-policy)).

## Checklist


- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
