### PR TITLE
🚑 Add non-spot service account to trust policy

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -121,7 +121,10 @@ module "create_a_derived_table_iam_role" {
   oidc_providers = {
     analytical-platform-compute-production = {
       provider_arn               = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/801920EDEF91E3CAB03E04C03A2DE2BB"
-      namespace_service_accounts = ["actions-runners:actions-runner-mojas-create-a-derived-table"]
+      namespace_service_accounts = [
+        "actions-runners:actions-runner-mojas-create-a-derived-table",
+        "actions-runners:actions-runner-mojas-create-a-derived-table-non-spot"
+      ]
     }
     cloud-platform = {
       provider_arn               = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/DF366E49809688A3B16EEC29707D8C09"

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -120,7 +120,7 @@ module "create_a_derived_table_iam_role" {
 
   oidc_providers = {
     analytical-platform-compute-production = {
-      provider_arn               = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/801920EDEF91E3CAB03E04C03A2DE2BB"
+      provider_arn = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/801920EDEF91E3CAB03E04C03A2DE2BB"
       namespace_service_accounts = [
         "actions-runners:actions-runner-mojas-create-a-derived-table",
         "actions-runners:actions-runner-mojas-create-a-derived-table-non-spot"


### PR DESCRIPTION
This pull request:

- Adds `actions-runner-mojas-create-a-derived-table-non-spot`, which is the new role from https://github.com/ministryofjustice/analytical-platform/issues/5666

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 