### PR TITLE
feat/AP 5859 remove reference to development replication role

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -220,8 +220,7 @@ data "aws_iam_policy_document" "mojap_cadet_production" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/mojap-data-production-cadet-to-apc-production-replication",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/mojap-data-production-cadet-to-apc-development-replication"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/mojap-data-production-cadet-to-apc-production-replication"
       ]
     }
   }
@@ -239,8 +238,7 @@ data "aws_iam_policy_document" "mojap_cadet_production" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/mojap-data-production-cadet-to-apc-production-replication",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/mojap-data-production-cadet-to-apc-development-replication"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/mojap-data-production-cadet-to-apc-production-replication"
       ]
     }
   }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/5867) GitHub Issue.

Removes reference to replication IAM role for development. The replication configuration can only accept one role, so a development role is no longer required.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist
- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

