### PR TITLE
Added glue role for find moj data

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/find-moj-data-glue-ingestion.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/find-moj-data-glue-ingestion.tf
@@ -14,7 +14,7 @@ data "aws_iam_policy_document" "find_moj_data_glue_ingestion" {
   }
 }
 
-module "find_moj_data_glue_policy" {
+module "find_moj_data_glue_access_iam_policy" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
@@ -31,11 +31,11 @@ module "find_moj_data_glue_access_iam_role" {
   source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
   version = "5.47.1"
 
-  name = "github_find_moj_data_glue_access"
+  name = "github-find-moj-data-glue-access"
 
   subjects = ["ministryofjustice/data-catalogue:*"]
 
   policies = {
-    github_find_moj_data_glue_access = module.find_moj_data_glue_policy.arn
+    github_find_moj_data_glue_access = module.find_moj_data_glue_access_iam_policy.arn
   }
 }

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/find-moj-data-glue-ingestion.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/find-moj-data-glue-ingestion.tf
@@ -1,0 +1,41 @@
+data "aws_iam_policy_document" "find_moj_data_glue_ingestion" {
+  statement {
+    sid    = "GlueMetadataAccess"
+    effect = "Allow"
+    actions = [
+      "glue:GetDatabases",
+      "glue:GetTables"
+    ]
+    resources = [
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:catalog",
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:database/*",
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:table/*"
+    ]
+  }
+}
+
+module "find_moj_data_glue_policy" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.47.1"
+
+  name_prefix = "github-find-moj-data-glue-access"
+
+  policy = data.aws_iam_policy_document.find_moj_data_glue_ingestion.json
+}
+
+module "find_moj_data_glue_access_iam_role" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-github-oidc-role"
+  version = "5.47.1"
+
+  name = "github_find_moj_data_glue_access"
+
+  subjects = ["ministryofjustice/data-catalogue:*"]
+
+  policies = {
+    github_find_moj_data_glue_access = module.find_moj_data_glue_policy.arn
+  }
+}


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/find-moj-data/issues/1017)
GitHub Issue.

## Please describe the purpose of this pull request.
We are looking to ingest limited metadata from Glue to Datahub. I have scoped the permissions to all tables. If needed we can restrict this further to just the tables we want to ingest.

The policy document is from datahub https://datahubproject.io/docs/generated/ingestion/sources/glue/#iam-permissions

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
