### PR TITLE
fix: reconfigure CaDeT bucket replication config prefix filter

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -122,7 +122,7 @@ module "mojap_cadet_production" {
           account_id = var.account_ids["analytical-platform-compute-production"]
           bucket     = "arn:aws:s3:::mojap-compute-production-derived-tables-replication"
           filter = {
-            prefix = "prod/"
+            prefix = "prod"
           }
           storage_class = "STANDARD"
           access_control_translation = {
@@ -148,7 +148,7 @@ module "mojap_cadet_production" {
           account_id = var.account_ids["analytical-platform-compute-development"]
           bucket     = "arn:aws:s3:::mojap-compute-development-derived-tables-replication"
           filter = {
-            prefix = "prod/"
+            prefix = "prod"
           }
           storage_class = "STANDARD"
           access_control_translation = {

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -117,13 +117,13 @@ module "mojap_cadet_production" {
         status                    = "Enabled"
         delete_marker_replication = true
         priority                  = 0
+        filter = {
+          prefix = "prod"
+        }
 
         destination = {
-          account_id = var.account_ids["analytical-platform-compute-production"]
-          bucket     = "arn:aws:s3:::mojap-compute-production-derived-tables-replication"
-          filter = {
-            prefix = "prod"
-          }
+          account_id    = var.account_ids["analytical-platform-compute-production"]
+          bucket        = "arn:aws:s3:::mojap-compute-production-derived-tables-replication"
           storage_class = "STANDARD"
           access_control_translation = {
             owner = "Destination"
@@ -143,13 +143,13 @@ module "mojap_cadet_production" {
         status                    = "Enabled"
         delete_marker_replication = true
         priority                  = 10
+        filter = {
+          prefix = "prod"
+        }
 
         destination = {
-          account_id = var.account_ids["analytical-platform-compute-development"]
-          bucket     = "arn:aws:s3:::mojap-compute-development-derived-tables-replication"
-          filter = {
-            prefix = "prod"
-          }
+          account_id    = var.account_ids["analytical-platform-compute-development"]
+          bucket        = "arn:aws:s3:::mojap-compute-development-derived-tables-replication"
           storage_class = "STANDARD"
           access_control_translation = {
             owner = "Destination"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in #5859.

removes delimiter from `replication_configuration.rules[].destination.filter.prefix` to match docs as replication config `scope` is empty in aws console

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
