### PR TITLE
🔧 Temporarily bumping GPU capacity to support AI/ML Hackathon

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -190,7 +190,7 @@ eks_node_group_ami_type_gpu_node       = "AL2_x86_64_GPU"
 
 eks_node_group_capacities_gpu_node = {
   desired = 2
-  max     = 10
+  max     = 12
   min     = 1
 }
 

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -191,7 +191,7 @@ eks_node_group_ami_type_gpu_node       = "AL2_x86_64_GPU"
 eks_node_group_capacities_gpu_node = {
   desired = 2
   max     = 12
-  min     = 1
+  min     = 2
 }
 
 ##################################################

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -189,9 +189,9 @@ eks_node_group_instance_types_gpu_node = ["g5.4xlarge"]
 eks_node_group_ami_type_gpu_node       = "AL2_x86_64_GPU"
 
 eks_node_group_capacities_gpu_node = {
-  desired = 0
+  desired = 2
   max     = 10
-  min     = 0
+  min     = 1
 }
 
 ##################################################


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/5594)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

This temporarily sets minimum GPU instances to 2 and desired to "doesn't matter" as it doesn't get picked up by TF to accomodate additional users taking part in the hackathon. This does not represent full expected capacity, but "warms up" some nodes with the remainder to be scaled up as required. 

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [X] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [X] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [X] I have self-reviewed my code
- [X] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
