### PR TITLE
🛂 Preparing mojap-land for DataSync S3 replication

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/.terraform.lock.hcl
@@ -7,6 +7,7 @@ provider "registry.terraform.io/hashicorp/aws" {
   hashes = [
     "h1:PIBnv1Mi0tX2GF6qUSdps3IouABeTqVgJZ4aAzIVzdI=",
     "h1:fr252BPFVqsCcVoLMN4PTVacXmrW3pbMlK1ibi/wHiU=",
+    "h1:ijX5mwbQZOnPVQGxxVsJs6Yh6h2w+V3mQmKznB6pIkw=",
     "zh:1075825e7311a8d2d233fd453a173910e891b0320e8a7698af44d1f90b02621d",
     "zh:203c5d09a03fcaa946defb8459f01227f2fcda07df768f74777beb328d6751ae",
     "zh:21bc79ccb09bfdeb711a3a5226c6c4a457ac7c4bb781dbda6ade7be38461739f",

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/buckets.tf
@@ -1,4 +1,6 @@
 module "data_engineering_pipeline_buckets" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
   for_each = local.data_engineering_buckets
   source   = "terraform-aws-modules/s3-bucket/aws"
   version  = "4.2.2"

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/kms-keys.tf
@@ -1,3 +1,31 @@
+module "mojap_land_dev_datasync_replication_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
+
+  aliases               = ["s3/mojap-land-dev-datasync-replication"]
+  enable_default_policy = true
+  key_statements = [
+    {
+      sid = "AllowAnalyticalPlatformIngestionDevelopment"
+      actions = [
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = ["arn:aws:iam::730335344807:role/datasync-replication"]
+        }
+      ]
+    }
+  ]
+  deletion_window_in_days = 7
+}
+
 module "mojap_land_datasync_replication_kms" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
@@ -8,7 +36,7 @@ module "mojap_land_datasync_replication_kms" {
   enable_default_policy = true
   key_statements = [
     {
-      sid = "AllowAnalyticalPlatformIngestion"
+      sid = "AllowAnalyticalPlatformIngestionProduction"
       actions = [
         "kms:Encrypt",
         "kms:GenerateDataKey"
@@ -17,10 +45,8 @@ module "mojap_land_datasync_replication_kms" {
       effect    = "Allow"
       principals = [
         {
-          type = "AWS"
-          identifiers = [
-            "arn:aws:iam::730335344807:role/datasync-replication" // analytical-platform-ingestion-development
-          ]
+          type        = "AWS"
+          identifiers = ["arn:aws:iam::471112983409:role/datasync-replication"]
         }
       ]
     }

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/kms-keys.tf
@@ -1,0 +1,29 @@
+module "mojap_land_datasync_replication_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.0"
+
+  aliases               = ["s3/mojap-land-datasync-replication"]
+  enable_default_policy = true
+  key_statements = [
+    {
+      sid = "AllowAnalyticalPlatformIngestion"
+      actions = [
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type = "AWS"
+          identifiers = [
+            "arn:aws:iam::730335344807:role/datasync-replication" // analytical-platform-ingestion-development
+          ]
+        }
+      ]
+    }
+  ]
+  deletion_window_in_days = 7
+}

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -974,6 +974,23 @@ locals {
               ]
             },
             {
+              Sid    = "AllowAnalyticalPlatformIngestionDataSyncReplication"
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::730335344807:role/datasync-replication"
+              }
+              Action = [
+                "s3:ReplicateObject",
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:GetObjectVersionTagging",
+                "s3:ReplicateTags",
+                "s3:ReplicateDelete"
+              ]
+              Resource = [
+                "arn:aws:s3:::mojap-land-dev/*"
+              ]
+            },
+            {
               Sid    = "ListBucketAccessElectronicMonitoringService"
               Effect = "Allow"
               Principal = {

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -708,6 +708,23 @@ locals {
               ]
             },
             {
+              Sid    = "AllowAnalyticalPlatformIngestionDataSyncReplication"
+              Effect = "Allow"
+              Principal = {
+                AWS = "arn:aws:iam::471112983409:role/datasync-replication"
+              }
+              Action = [
+                "s3:ReplicateObject",
+                "s3:ObjectOwnerOverrideToBucketOwner",
+                "s3:GetObjectVersionTagging",
+                "s3:ReplicateTags",
+                "s3:ReplicateDelete"
+              ]
+              Resource = [
+                "arn:aws:s3:::mojap-land/*"
+              ]
+            },
+            {
               Sid    = "ListBucketAccessElectronicMonitoringService"
               Effect = "Allow"
               Principal = {


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/analytical-platform/issues/5175
- Requires https://github.com/ministryofjustice/modernisation-platform-environments/pull/8656
- Creates CMK for encrypting transferred objects
- Updates mojap-land-dev and mojap-land so DataSync S3 replication can do its thing

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 