### PR TITLE
🔥 Stop feature requests being added to GitHub Project

### DIFF
--- a/.github/workflows/repository-update-issue-type.yml
+++ b/.github/workflows/repository-update-issue-type.yml
@@ -36,9 +36,6 @@ jobs:
             } else if (labels.includes("epic")) {
               type = "epic";
               fieldOptionId = "0c0fae3e";
-            } else if (labels.includes("feature-request")) {
-              type = "feature-request";
-              fieldOptionId = "f9d31408";
             } else if (labels.includes("story")) {
               type = "story";
               fieldOptionId = "28d2bccc";


### PR DESCRIPTION
As per an internal conversation, feature requests are no longer added to the project, instead only the outputted story from BA will be added

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 