### PR TITLE
🔭 Onboard to Observability Platform Production

### DIFF
--- a/.github/workflows/build-publish-documentation.yml
+++ b/.github/workflows/build-publish-documentation.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - main
     paths:
-      - 'config/**'
-      - 'source/**'
+      - "config/**'"
+      - "source/**"
 
 permissions: {}
 

--- a/.github/workflows/build-publish-documentation.yml
+++ b/.github/workflows/build-publish-documentation.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'config/**'
+      - 'source/**'
 
 permissions: {}
 

--- a/.github/workflows/build-test-documentation.yml
+++ b/.github/workflows/build-test-documentation.yml
@@ -6,8 +6,8 @@ on:
     branches:
       - main
     paths:
-      - 'config/**'
-      - 'source/**'
+      - "config/**'"
+      - "source/**"
 
 permissions: {}
 

--- a/.github/workflows/build-test-documentation.yml
+++ b/.github/workflows/build-test-documentation.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - 'config/**'
+      - 'source/**'
 
 permissions: {}
 

--- a/terraform/aws/analytical-platform-development/cluster/observability-platform.tf
+++ b/terraform/aws/analytical-platform-development/cluster/observability-platform.tf
@@ -1,0 +1,11 @@
+module "observability_platform_tenant" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "ministryofjustice/observability-platform-tenant/aws"
+  version = "1.2.0"
+
+  observability_platform_account_id = "319748487814" # observability-platform-production
+  enable_prometheus                 = true
+
+}

--- a/terraform/aws/analytical-platform-development/cluster/observability-platform.tf
+++ b/terraform/aws/analytical-platform-development/cluster/observability-platform.tf
@@ -6,6 +6,4 @@ module "observability_platform_tenant" {
   version = "1.2.0"
 
   observability_platform_account_id = "319748487814" # observability-platform-production
-  enable_prometheus                 = true
-
 }

--- a/terraform/aws/analytical-platform/baseline/guardduty.tf
+++ b/terraform/aws/analytical-platform/baseline/guardduty.tf
@@ -25,7 +25,7 @@ module "data_development_guardduty_eu_west_2" {
 }
 
 ##################################################
-# Data Engineering Development
+# Data Engineering Production
 ##################################################
 
 module "data_engineering_guardduty_eu_west_1" {

--- a/terraform/aws/analytical-platform/baseline/observability-platform.tf
+++ b/terraform/aws/analytical-platform/baseline/observability-platform.tf
@@ -1,4 +1,47 @@
+##################################################
+# Data Development
+##################################################
+
+module "data_development_observability_platform" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "ministryofjustice/observability-platform-tenant/aws"
+  version = "1.2.0"
+
+  providers = {
+    aws = aws.analytical-platform-data-development-eu-west-2
+  }
+
+  observability_platform_account_id = var.observability_platform_account_ids["production"]
+}
+
+##################################################
+# Data Engineering Production
+##################################################
+
+module "data_engineering_production_observability_platform" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "ministryofjustice/observability-platform-tenant/aws"
+  version = "1.2.0"
+
+  providers = {
+    aws = aws.analytical-platform-data-engineering-production-eu-west-2
+  }
+
+  observability_platform_account_id = var.observability_platform_account_ids["production"]
+}
+
+##################################################
+# Data Engineering Sandbox A
+##################################################
+
 module "data_engineering_sandbox_a_observability_platform" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
   source  = "ministryofjustice/observability-platform-tenant/aws"
   version = "1.2.0"
 
@@ -6,5 +49,71 @@ module "data_engineering_sandbox_a_observability_platform" {
     aws = aws.analytical-platform-data-engineering-sandbox-a-eu-west-2
   }
 
-  observability_platform_account_id = var.observability_platform_account_ids["development"]
+  observability_platform_account_id = var.observability_platform_account_ids["production"]
 }
+
+##################################################
+# Data Production
+##################################################
+
+module "data_production_observability_platform" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "ministryofjustice/observability-platform-tenant/aws"
+  version = "1.2.0"
+
+  providers = {
+    aws = aws.analytical-platform-data-production-eu-west-2
+  }
+
+  observability_platform_account_id = var.observability_platform_account_ids["production"]
+}
+
+##################################################
+# Development
+##################################################
+
+# This is done in terraform/aws/analytical-platform-development/cluster
+
+##################################################
+# Landing Production
+##################################################
+
+module "landing_production_observability_platform" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "ministryofjustice/observability-platform-tenant/aws"
+  version = "1.2.0"
+
+  providers = {
+    aws = aws.analytical-platform-landing-production-eu-west-2
+  }
+
+  observability_platform_account_id = var.observability_platform_account_ids["production"]
+}
+
+##################################################
+# Management Production
+##################################################
+
+module "management_production_observability_platform" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "ministryofjustice/observability-platform-tenant/aws"
+  version = "1.2.0"
+
+  providers = {
+    aws = aws.analytical-platform-management-production-eu-west-2
+  }
+
+  observability_platform_account_id = var.observability_platform_account_ids["production"]
+}
+
+##################################################
+# Production
+##################################################
+
+# This is done in terraform/aws/analytical-platform-production/cluster


### PR DESCRIPTION
This pull request:

- Is part of https://github.com/ministryofjustice/observability-platform/issues/148
- Onboards all Analytical Platform accounts to Observability Platform Production
- Updates docs workflows, now they only trigger on change to its paths

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 