### PR TITLE
feat: update AP compute role for mojap-derived-tables data retrieval

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -160,7 +160,7 @@ data "aws_iam_policy_document" "mojap_cadet_production" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.account_ids["analytical-platform-compute-development"]}:role/service-role/AWSGlueServiceRole-mojap-cadet-manual"
+        "arn:aws:iam::${var.account_ids["analytical-platform-compute-production"]}:role/lake-formation-data-production-data-access"
       ]
     }
   }
@@ -176,7 +176,7 @@ data "aws_iam_policy_document" "mojap_cadet_production" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${var.account_ids["analytical-platform-compute-development"]}:role/service-role/AWSGlueServiceRole-mojap-cadet-manual"
+        "arn:aws:iam::${var.account_ids["analytical-platform-compute-production"]}:role/lake-formation-data-production-data-access"
       ]
     }
   }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in #6133.

This updates the role name for the AP compute production lake formation role that registers `mojap-derived-tables`, permitting APC athena to query the bucket.

## Checklist

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
