### PR TITLE
feat: add assume compute metadata transfer role permission to cadet runner role

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -91,6 +91,12 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "arn:aws:airflow:*:${var.account_ids["analytical-platform-data-production"]}:environment/prod"
     ]
   }
+  statement {
+    sid       = "AllowAssumeAPComputeMetadataTransferRole"
+    effect    = "Allow"
+    actions   = ["sts:AssumeRole"]
+    resources = ["arn:aws:iam::${var.account_ids["analytical-platform-compute-production"]}:role/analytical-platform-cadet-runner-compute-policy"]
+  }
 }
 
 module "create_a_derived_table_iam_policy" {

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/terraform.tfvars
@@ -1,6 +1,7 @@
 account_ids = {
   analytical-platform-data-production       = "593291632749"
   analytical-platform-management-production = "042130406152"
+  analytical-platform-compute-production    = "992382429243"
 }
 
 tags = {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in #6133.

This PR allows the CaDeT runner role to assume the [compute role that transfers metadata into AP compute](https://github.com/ministryofjustice/modernisation-platform-environments/blob/main/terraform/environments/analytical-platform-compute/iam-roles.tf#L377-L392).

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
