### PR TITLE
feat: allow `sts:TagSession` when assuming metadata copy role

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -94,7 +94,7 @@ data "aws_iam_policy_document" "create_a_derived_table" {
   statement {
     sid       = "AllowAssumeAPComputeMetadataTransferRole"
     effect    = "Allow"
-    actions   = ["sts:AssumeRole"]
+    actions   = ["sts:AssumeRole", "sts:TagSession"]
     resources = ["arn:aws:iam::${var.account_ids["analytical-platform-compute-production"]}:role/analytical-platform-cadet-runner-assumable"]
   }
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in #6133.

Adds `sts:TagSession` permission required by [workflow action](https://github.com/aws-actions/configure-aws-credentials?tab=readme-ov-file#using-this-action) to assume the role to run metadata export

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
