### PR TITLE
Amend  list-open-dependabot-prs.sh  script  to skip mlflow

### DIFF
--- a/scripts/dependabot/list-open-dependabot-prs.sh
+++ b/scripts/dependabot/list-open-dependabot-prs.sh
@@ -70,6 +70,12 @@ for REPO in "${REPOSITORIES[@]}"; do
         continue
     fi
 
+    # Skip mlflow repositories
+    if [[ "$REPO" == "analytical-platform-mlflow" ]]; then
+    echo "Skipping mlflow repository: $REPO"
+    continue
+    fi
+
     # Use gh cli to list pull requests with the label 'dependencies'
     pr_list=$(gh pr list --repo "$REPO_OWNER/$REPO" --label "dependencies" --state open --json number,title,url,createdAt -q '.[] | "\(.number) | \(.url) | \(.title)"')
 


### PR DESCRIPTION
While working through the Dependabot pull requests I found that t no action was required on the `analytical-platform-mlflow` repository.

This PR is for the changes to ` list-open-dependabot-prs.sh` to skip this reposotory.
