### PR TITLE
Fixing deprecation of role_arn supplied via backend_config

### DIFF
--- a/.github/workflows/reusable-workflow-terraform.yml
+++ b/.github/workflows/reusable-workflow-terraform.yml
@@ -243,7 +243,7 @@ jobs:
         working-directory: ${{ env.working-directory }}
         run: |
           terraform init \
-            -backend-config="role_arn=arn:aws:iam::042130406152:role/GlobalGitHubActionAdmin" \
+            -backend-config="assume_role={role_arn=\"arn:aws:iam::042130406152:role/GlobalGitHubActionAdmin\"}" \
             -reconfigure \
             -upgrade \
             -no-color


### PR DESCRIPTION
Reference issue:
https://github.com/hashicorp/terraform/issues/27579

We are having issues running init due to role_arn being passed directly to backend config having been deprecated as a configuration option.

Applying a fix.
