### PR TITLE
🐛  Hotfix: Ensure Avature DBT tables are outputted to correct location

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -64,6 +64,7 @@ resource "aws_athena_workgroup" "airflow" {
 #trivy:ignore:avd-aws-0006:Not encrypting the workgroup currently
 resource "aws_athena_workgroup" "dbt" {
   #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
+  #checkov:skip=CKV_AWS_82:Can't enforce output location due to DBT requirements
 
   for_each = local.dbt_athena_workgroups
 
@@ -75,7 +76,6 @@ resource "aws_athena_workgroup" "dbt" {
     engine_version {
       selected_engine_version = "Athena engine version 3"
     }
-    #checkov:skip=CKV_AWS_82:Can't enforce output location due to DBT requirements
     result_configuration {
       output_location = "s3://dbt-query-dump/"
     }

--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -71,7 +71,7 @@ resource "aws_athena_workgroup" "dbt" {
 
   configuration {
     bytes_scanned_cutoff_per_query  = 1099511627776000
-    enforce_workgroup_configuration = true
+    enforce_workgroup_configuration = false
     engine_version {
       selected_engine_version = "Athena engine version 3"
     }

--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -75,6 +75,7 @@ resource "aws_athena_workgroup" "dbt" {
     engine_version {
       selected_engine_version = "Athena engine version 3"
     }
+    #checkov:skip=CKV_AWS_82:Can't enforce output location due to DBT requirements
     result_configuration {
       output_location = "s3://dbt-query-dump/"
     }

--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -62,6 +62,7 @@ resource "aws_athena_workgroup" "airflow" {
 }
 
 #trivy:ignore:avd-aws-0006:Not encrypting the workgroup currently
+#trivy:ignore:avd-aws-0007:Can't enforce output location due to DBT requirements
 resource "aws_athena_workgroup" "dbt" {
   #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
   #checkov:skip=CKV_AWS_82:Can't enforce output location due to DBT requirements


### PR DESCRIPTION
# Pull Request Objective

This change will allow DBT to specify that intermediary views should live at the query dump, but final tables live in the proper bucket. Currently the override is forcing the final tables to live in the query dump.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
