### PR TITLE
fix: use `dbt-query-dump` bucket for `dev` CaDeT, use `mojap-derived-tables` for `prod`

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -76,7 +76,7 @@ resource "aws_athena_workgroup" "dbt" {
       selected_engine_version = "Athena engine version 3"
     }
     result_configuration {
-      output_location = "s3://dbt-query-dump/"
+      output_location = strcontains(each.value.name, "dev") ? "s3://dbt-query-dump/" : "s3://mojap-derived-tables/"
     }
   }
 


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/<your_issue_number_here>)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
