### PR TITLE
AP-6238 suspend versioning for `mojap-derived-tables` bucket and add lifecycle policy to remove noncurrent versions

### DIFF
--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -1,4 +1,5 @@
 #trivy:ignore:avd-aws-0132:Replicating existing bucket that does not encrypt data with a customer managed key
+#trivy:ignore:avd-aws-0090:Bucket versioning is not preferred for this bucket for now as data is produced on-demand (and versioning is expensive)
 module "mojap_cadet_production" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 
@@ -43,7 +44,7 @@ module "mojap_cadet_production" {
       id      = "remove-object-versions"
 
       noncurrent_version_expiration = {
-        days = 0
+        days = 1
       }
     },
     {

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -41,14 +41,6 @@ module "mojap_cadet_production" {
   lifecycle_rule = [
     {
       enabled = true
-      id      = "remove-object-versions"
-
-      noncurrent_version_expiration = {
-        days = 1
-      }
-    },
-    {
-      enabled = true
       id      = "dev/models"
 
       filter = {
@@ -110,6 +102,14 @@ module "mojap_cadet_production" {
       expiration = {
         days                         = 3
         expired_object_delete_marker = false
+      }
+    },
+    {
+      enabled = true
+      id      = "remove-object-versions"
+
+      noncurrent_version_expiration = {
+        days = 1
       }
     }
   ]

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -14,7 +14,7 @@ module "mojap_cadet_production" {
   force_destroy       = false
   object_lock_enabled = false
   versioning = {
-    status     = "Enabled"
+    status     = "Suspended"
     mfa_delete = false
   }
   server_side_encryption_configuration = {
@@ -38,6 +38,14 @@ module "mojap_cadet_production" {
   restrict_public_buckets = true
 
   lifecycle_rule = [
+    {
+      enabled = true
+      id      = "remove-object-versions"
+
+      noncurrent_version_expiration = {
+        days = 0
+      }
+    },
     {
       enabled = true
       id      = "dev/models"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked as part of #6238.

This PR stops object versioning for the `mojap-derived-tables` bucket, and adds a lifecycle policy to remove noncurrent versions after 1 days (which should delete all object versions in the bucket besides the latest).

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
