### PR TITLE
update bedrock permissions for access to AWS Bedrock batch inference

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -50,7 +50,11 @@ data "aws_iam_policy_document" "bedrock_integration" {
       "bedrock:CreateFoundationModelAgreement",
       "bedrock:DeleteFoundationModelAgreement",
       "bedrock:ListFoundationModelAgreementOffers",
-      "bedrock:GetUseCaseForModelAccess"
+      "bedrock:GetUseCaseForModelAccess",
+      "bedrock:CreateModelInvocationJob",
+      "bedrock:GetModelInvocationJob",
+      "bedrock:ListModelInvocationJobs",
+      "bedrock:StopModelInvocationJob"
     ]
 
     resources = ["*"]


### PR DESCRIPTION
This pr is to add the additional permissions required for access to AWS Bedrock batch inference as per this issue Access to AWS Bedrock batch inference
[#6253](https://github.com/ministryofjustice/analytical-platform/issues/6253)