### PR TITLE
:wrench: Update Secrets + Add workflow

### DIFF
--- a/.github/workflows/schedule-issue-jml-report.yml
+++ b/.github/workflows/schedule-issue-jml-report.yml
@@ -1,54 +1,54 @@
 ---
-  name: 📥 Maintenance - Create JupyterLab Issue
+name: 📥 Maintenance - Create JupyterLab Issue
 
-  on:
-    schedule:
-      - cron: "0 8 1 * *" # UTC time: “At 08:00 on first day-of-month”
+on:
+  schedule:
+    - cron: "0 8 1 * *" # UTC time: “At 08:00 on first day-of-month”
 
-  permissions: {}
+permissions: {}
 
-  jobs:
-    create-maintenance-issue:
-      name: Create Maintenance Issue
-      runs-on: ubuntu-latest
-      permissions:
-        issues: write
-      steps:
-        - name: Create Maintenance Issue
-          id: create_maintenance_issue
-          run: |
-            if [[ "${CLOSE_PREVIOUS}" == true ]]; then
-              previous_issue_number=$(gh issue list \
-                --label "$LABELS" \
-                --json number \
-                --jq '.[0].number')
-              if [[ -n $previous_issue_number ]]; then
-                gh issue close "$previous_issue_number"
-                gh issue unpin "$previous_issue_number"
-              fi
-            fi
-            new_issue_url=$(gh issue create \
-              --title "$TITLE" \
-              --assignee "$ASSIGNEES" \
+jobs:
+  create-maintenance-issue:
+    name: Create Maintenance Issue
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Create Maintenance Issue
+        id: create_maintenance_issue
+        run: |
+          if [[ "${CLOSE_PREVIOUS}" == true ]]; then
+            previous_issue_number=$(gh issue list \
               --label "$LABELS" \
-              --body "$BODY")
-            if [[ $PINNED == true ]]; then
-              gh issue pin "$new_issue_url"
+              --json number \
+              --jq '.[0].number')
+            if [[ -n $previous_issue_number ]]; then
+              gh issue close "$previous_issue_number"
+              gh issue unpin "$previous_issue_number"
             fi
-          env:
-            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-            GH_REPO: ${{ github.repository }}
-            TITLE: 📥 Maintenance - JML Report
-            ASSIGNEES:
-            LABELS: maintenance
-            BODY: |
-              ### User Story
-              As a… engineer on the Analytical Platform
-              I need/want/expect to… keep the JML report mechanism up to date
-              So that… security / best practice etc
-              ### Definition of Done
-              - [ ] Merge any open dependabot Pull Requests in the JML report [repository](https://github.com/ministryofjustice/analytical-platform-jml-report).
-              - [ ] Create new [release](https://github.com/ministryofjustice/analytical-platform-jml-report/releases).
-              - [ ] Update the [lambda function](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/lambda-functions.tf) to consume the new release
-            PINNED: false
-            CLOSE_PREVIOUS: false
+          fi
+          new_issue_url=$(gh issue create \
+            --title "$TITLE" \
+            --assignee "$ASSIGNEES" \
+            --label "$LABELS" \
+            --body "$BODY")
+          if [[ $PINNED == true ]]; then
+            gh issue pin "$new_issue_url"
+          fi
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          TITLE: 📥 Maintenance - JML Report
+          ASSIGNEES:
+          LABELS: maintenance
+          BODY: |
+            ### User Story
+            As a… engineer on the Analytical Platform
+            I need/want/expect to… keep the JML report mechanism up to date
+            So that… security / best practice etc
+            ### Definition of Done
+            - [ ] Merge any open dependabot Pull Requests in the JML report [repository](https://github.com/ministryofjustice/analytical-platform-jml-report).
+            - [ ] Create new [release](https://github.com/ministryofjustice/analytical-platform-jml-report/releases).
+            - [ ] Update the [lambda function](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/lambda-functions.tf) to consume the new release
+          PINNED: false
+          CLOSE_PREVIOUS: false

--- a/.github/workflows/schedule-issue-jml-report.yml
+++ b/.github/workflows/schedule-issue-jml-report.yml
@@ -1,0 +1,54 @@
+---
+  name: 📥 Maintenance - Create JupyterLab Issue
+
+  on:
+    schedule:
+      - cron: "0 8 1 * *" # UTC time: “At 08:00 on first day-of-month”
+
+  permissions: {}
+
+  jobs:
+    create-maintenance-issue:
+      name: Create Maintenance Issue
+      runs-on: ubuntu-latest
+      permissions:
+        issues: write
+      steps:
+        - name: Create Maintenance Issue
+          id: create_maintenance_issue
+          run: |
+            if [[ "${CLOSE_PREVIOUS}" == true ]]; then
+              previous_issue_number=$(gh issue list \
+                --label "$LABELS" \
+                --json number \
+                --jq '.[0].number')
+              if [[ -n $previous_issue_number ]]; then
+                gh issue close "$previous_issue_number"
+                gh issue unpin "$previous_issue_number"
+              fi
+            fi
+            new_issue_url=$(gh issue create \
+              --title "$TITLE" \
+              --assignee "$ASSIGNEES" \
+              --label "$LABELS" \
+              --body "$BODY")
+            if [[ $PINNED == true ]]; then
+              gh issue pin "$new_issue_url"
+            fi
+          env:
+            GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+            GH_REPO: ${{ github.repository }}
+            TITLE: 📥 Maintenance - JML Report
+            ASSIGNEES:
+            LABELS: maintenance
+            BODY: |
+              ### User Story
+              As a… engineer on the Analytical Platform
+              I need/want/expect to… keep the JML report mechanism up to date
+              So that… security / best practice etc
+              ### Definition of Done
+              - [ ] Merge any open dependabot Pull Requests in the JML report [repository](https://github.com/ministryofjustice/analytical-platform-jml-report).
+              - [ ] Create new [release](https://github.com/ministryofjustice/analytical-platform-jml-report/releases).
+              - [ ] Update the [lambda function](https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/lambda-functions.tf) to consume the new release
+            PINNED: false
+            CLOSE_PREVIOUS: false

--- a/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/data.tf
+++ b/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/data.tf
@@ -7,11 +7,3 @@ data "aws_iam_session_context" "session" {
 
   arn = data.aws_caller_identity.session.arn
 }
-
-data "aws_secretsmanager_secret_version" "govuk_notify_api_key" {
-  secret_id = aws_secretsmanager_secret.govuk_notify_api_key.id
-}
-
-data "aws_secretsmanager_secret_version" "jml_email" {
-  secret_id = aws_secretsmanager_secret.jml_email.id
-}

--- a/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/lambda-functions.tf
+++ b/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/lambda-functions.tf
@@ -15,9 +15,9 @@ module "jml_report_lambda" {
   image_uri     = "509399598587.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-jml-report:1.4.4"
 
   environment_variables = {
-    SECRET_ID       = data.aws_secretsmanager_secret_version.govuk_notify_api_key.id
+    SECRET_ID       = module.govuk_notify_api_key_secret.secret_id
     LOG_GROUP_NAMES = "/aws/events/auth0/alpha-analytics-moj"
-    EMAIL_SECRET    = data.aws_secretsmanager_secret_version.jml_email.id
+    EMAIL_SECRET    = module.jml_email_secret.secret_id
     TEMPLATE_ID     = "de618989-db86-4d9a-aa55-4724d5485fa5"
   }
 
@@ -49,8 +49,8 @@ module "jml_report_lambda" {
         "secretsmanager:ListSecrets"
       ]
       resources = [
-        aws_secretsmanager_secret.govuk_notify_api_key.arn,
-        aws_secretsmanager_secret.jml_email.arn
+        module.govuk_notify_api_key_secret.secret_arn,
+        module.jml_email_secret.secret_arn
       ]
     }
   }

--- a/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/secrets.tf
+++ b/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/secrets.tf
@@ -1,13 +1,25 @@
-#tfsec:ignore:avd-aws-0098 CMK not required currently
-resource "aws_secretsmanager_secret" "govuk_notify_api_key" {
-  # checkov:skip=CKV2_AWS_57:These won't be rotated in the traditional manner
-  # checkov:skip=CKV_AWS_149:No KMS key needed as per above, these won't be rotated
-  name = "gov-uk-notify/production/api-key"
+module "jml_email_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name = "jml-report/email"
+
+  ignore_secret_changes = true
+  secret_string         = "CHANGEME"
 }
 
-#tfsec:ignore:avd-aws-0098 CMK not required currently
-resource "aws_secretsmanager_secret" "jml_email" {
-  # checkov:skip=CKV2_AWS_57:These won't be rotated in the traditional manner
-  # checkov:skip=CKV_AWS_149:No KMS key needed as per above, these won't be rotated
-  name = "jml/email"
+module "govuk_notify_api_key_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "1.3.1"
+
+  name = "gov-uk-notify/api-key"
+
+  ignore_secret_changes = true
+  secret_string         = "CHANGEME"
 }

--- a/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/terraform.tf
@@ -21,7 +21,7 @@ provider "aws" {
 }
 
 provider "aws" {
-  region = "eu-west-1"
+  region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/GlobalGitHubActionAdmin"
   }


### PR DESCRIPTION
This PR is related to https://github.com/ministryofjustice/analytical-platform/issues/6517 piece of work.

- Adds workflow to ensure JML report is kept up to date going forward.
- Uses the secrets module over the explicit terraform resources.
- switches the region from `ireland` to `london`