### PR TITLE
💬  Fix Slack notification workflow

### DIFF
--- a/.github/workflows/reusable-workflow-terraform.yml
+++ b/.github/workflows/reusable-workflow-terraform.yml
@@ -371,4 +371,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: INCOMING_WEBHOOK
+          SLACK_WEBHOOK_TYPE: incoming-webhook

--- a/.github/workflows/reusable-workflow-terraform.yml
+++ b/.github/workflows/reusable-workflow-terraform.yml
@@ -372,4 +372,3 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-

--- a/.github/workflows/reusable-workflow-terraform.yml
+++ b/.github/workflows/reusable-workflow-terraform.yml
@@ -364,11 +364,10 @@ jobs:
         id: slack_notification
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook: ${{ env.SLACK_WEBHOOK_URL }}
           webhook-type: incoming-webhook
           payload: |
             {
               "run_id": "${{ github.run_id }}",
               "pr_number": "${{ steps.extract_pr.outputs.pr_number }}"
             }
-        env:
-          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}

--- a/.github/workflows/reusable-workflow-terraform.yml
+++ b/.github/workflows/reusable-workflow-terraform.yml
@@ -364,6 +364,7 @@ jobs:
         id: slack_notification
         uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
         with:
+          webhook-type: incoming-webhook
           payload: |
             {
               "run_id": "${{ github.run_id }}",
@@ -371,4 +372,4 @@ jobs:
             }
         env:
           SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
-          SLACK_WEBHOOK_TYPE: incoming-webhook
+


### PR DESCRIPTION
This relates to [this](https://github.com/ministryofjustice/analytical-platform/issues/6513) Issue.

I've altered this per my reading of the release notes which include breaking changes for [release 2.0.0 of the Slack Workflow ](https://github.com/slackapi/slack-github-action/releases/tag/v2.0.0#the-webhook-type-must-be-specified-in-webhook-inputs)which we consume.

I'm unsure if the following code should be the latter:

```yaml
      - name: Notify Slack on Failure
        if: failure() && steps.terraform_apply.outcome == 'failure'
        id: slack_notification
        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
        with:
          webhook-type: incoming-webhook
          payload: |
            {
              "run_id": "${{ github.run_id }}",
              "pr_number": "${{ steps.extract_pr.outputs.pr_number }}"
            }
        env:
          SLACK_WEBHOOK_URL: ${{ env.SLACK_WEBHOOK_URL }}
```

```yaml
      - name: Notify Slack on Failure
        if: failure() && steps.terraform_apply.outcome == 'failure'
        id: slack_notification
        uses: slackapi/slack-github-action@485a9d42d3a73031f12ec201c457e2162c45d02d # v2.0.0
        with:
          webhook:  ${{ env.SLACK_WEBHOOK_URL }}
          webhook-type: incoming-webhook
          payload: |
            {
              "run_id": "${{ github.run_id }}",
              "pr_number": "${{ steps.extract_pr.outputs.pr_number }}"
            }

```