### PR TITLE
❌  Break: Deliberate break to test Slack workflow

### DIFF
--- a/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/lambda-functions.tf
+++ b/terraform/aws/analytical-platform-data-production/joiners-movers-leavers/lambda-functions.tf
@@ -7,13 +7,6 @@ module "jml_report_lambda" {
   publish        = true
   create_package = false
 
-  function_name = "analytical-platform-jml-report"
-  description   = "Generates a JML report and sends it to JMLv4"
-  package_type  = "Image"
-  memory_size   = 512
-  timeout       = 120
-  image_uri     = "509399598587.dkr.ecr.eu-west-2.amazonaws.com/analytical-platform-jml-report:1.4.4"
-
   environment_variables = {
     SECRET_ID       = data.aws_secretsmanager_secret_version.govuk_notify_api_key.id
     LOG_GROUP_NAMES = "/aws/events/auth0/alpha-analytics-moj"


### PR DESCRIPTION
Deliberate breaking change to cause `terraform apply` to fail. This will be reverted.