### PR TITLE
:wrench: Update `set-output` as per deprecation

### DIFF
--- a/.github/workflows/reusable-workflow-terraform.yml
+++ b/.github/workflows/reusable-workflow-terraform.yml
@@ -357,7 +357,7 @@ jobs:
         run: |
           PR_NUMBER=$(git log -1 --pretty=%B | grep -oP '#\K\d+')
           echo "PR_NUMBER=$PR_NUMBER" >> $GITHUB_ENV
-          echo "::set-output name=pr_number::$PR_NUMBER"
+          echo "pr_number=$PR_NUMBER" >> $GITHUB_OUTPUT
 
       - name: Notify Slack on Failure
         if: failure() && steps.terraform_apply.outcome == 'failure'


### PR DESCRIPTION
This hopefully resolves a deprecation causing failures as seen [here](https://github.com/ministryofjustice/analytical-platform/actions/runs/12787265160/job/35646105945#step:18:4) by `set-output` being deprecated. Deprecation notes are [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/#examples).