### PR TITLE
feat: add dynamic `s3Locations` statements to allow oidc roles access to specified s3 paths

### DIFF
--- a/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
+++ b/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
@@ -7,6 +7,7 @@
         "stateBucketKey": ".pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/moj-data-transfer-api"],
     "targets": [
       "analytical-platform-data-production",
@@ -24,6 +25,7 @@
         "stateBucketKey": ".pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/data-engineering-pulumi-components"],
     "targets": ["analytical-platform-data-engineering-sandbox-a"],
     "stateLockingDetails": [],
@@ -42,6 +44,7 @@
         "stateBucketKey": ".pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/register-my-data"],
     "targets": [
       "analytical-platform-data-engineering-production",
@@ -63,6 +66,7 @@
         "stateBucketKey": ".pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/data-engineering-airflow"],
     "targets": [
       "analytical-platform-data-engineering-production",
@@ -79,6 +83,7 @@
         "stateBucketKey": ".pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/analytical-platform-uploader"],
     "targets": [
       "analytical-platform-data-engineering-production",
@@ -104,6 +109,7 @@
         "stateBucketKey": ".pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/analytical-platform-data-engineering"],
     "targets": [
       "analytical-platform-data-production",
@@ -120,6 +126,7 @@
         "stateBucketKey": ".pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/analytical-platform-data-engineering"],
     "targets": ["analytical-platform-data-engineering-sandbox-a"],
     "stateLockingDetails": [],
@@ -133,6 +140,7 @@
         "stateBucketKey": "pulumi-oidc-test/.pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": ["moj-analytical-services/pulumi-oidc-test"],
     "targets": ["analytical-platform-data-engineering-sandbox-a"],
     "stateLockingDetails": [],
@@ -141,6 +149,7 @@
   "lookup-offence-sandbox": {
     "account": "analytical-platform-data-engineering-sandbox-a",
     "stateConfig": [],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/lookup-offence-sandbox"],
     "targets": ["analytical-platform-data-engineering-sandbox-a"],
     "stateLockingDetails": [],
@@ -149,6 +158,7 @@
   "create-a-derived-table": {
     "account": "analytical-platform-data-production",
     "stateConfig": [],
+    "s3Locations": [],
     "repositories": ["moj-analytical-services/create-a-derived-table"],
     "targets": ["analytical-platform-data-production"],
     "stateLockingDetails": [],
@@ -157,6 +167,7 @@
   "lookup-offence": {
     "account": "analytical-platform-data-production",
     "stateConfig": [],
+    "s3Locations": [],
     "repositories": ["moj-analytical-services/lookup_offence"],
     "targets": ["analytical-platform-data-production"],
     "stateLockingDetails": [],
@@ -165,6 +176,7 @@
   "data-platform-apps": {
     "account": "analytical-platform-data-production",
     "stateConfig": [],
+    "s3Locations": [],
     "repositories": [
       "ministryofjustice/hmpps-hr-dashboard",
       "ministryofjustice/ltc-capabilites-app",
@@ -180,6 +192,7 @@
   "modernisation-platform-lake-formation-share": {
     "account": "analytical-platform-data-production",
     "stateConfig": [],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/modernisation-platform-environments"],
     "targets": [],
     "stateLockingDetails": [],
@@ -189,6 +202,7 @@
   "data-discovery": {
     "account": "analytical-platform-data-production",
     "stateConfig": [],
+    "s3Locations": [],
     "repositories": ["moj-analytical-services/data-discovery"],
     "targets": ["analytical-platform-data-production"],
     "stateLockingDetails": [],
@@ -211,6 +225,7 @@
   "data-engineering-cleanup": {
     "account": "analytical-platform-data-engineering-production",
     "stateConfig": [],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/data-engineering-cleanup"],
     "targets": [
       "analytical-platform-data-engineering-production",
@@ -227,6 +242,7 @@
   "airflow-contracts-etl": {
     "account": "analytical-platform-data-engineering-production",
     "stateConfig": [],
+    "s3Locations": [],
     "repositories": ["moj-analytical-services/airflow-contracts-etl"],
     "targets": [
       "analytical-platform-data-engineering-production",
@@ -243,6 +259,7 @@
         "stateBucketKey": ".pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": ["ministryofjustice/create-a-derived-table-infrastructure"],
     "targets": ["analytical-platform-data-production"],
     "stateLockingDetails": [],
@@ -256,6 +273,7 @@
         "stateBucketKey": ".pulumi/"
       }
     ],
+    "s3Locations": [],
     "repositories": [
       "moj-analytical-services/data-engineering-database-access"
     ],

--- a/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
+++ b/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
@@ -197,6 +197,12 @@
   "analytics-platform-helm-charts": {
     "account": "analytical-platform-data-production",
     "stateConfig": [],
+    "s3Locations": [
+      {
+        "bucket": "moj-analytics-helm-repo",
+        "keys": [""]
+      }
+    ],
     "repositories": ["ministryofjustice/analytics-platform-helm-charts"],
     "targets": ["analytical-platform-data-production"],
     "stateLockingDetails": [],

--- a/terraform/aws/analytical-platform/oidc/oidc-roles.tf
+++ b/terraform/aws/analytical-platform/oidc/oidc-roles.tf
@@ -47,6 +47,38 @@ data "aws_iam_policy_document" "github_oidc_role" {
     }
   }
   dynamic "statement" {
+    for_each = each.value.s3Locations
+
+    content {
+      sid    = "AllowS3LocationRead"
+      effect = "Allow"
+      actions = [
+        "s3:Get*",
+        "s3:List*"
+      ]
+      resources = [
+        "arn:aws:s3:::${statement.value.bucket}"
+      ]
+    }
+  }
+  dynamic "statement" {
+    for_each = each.value.s3Locations
+
+    content {
+      #checkov:skip=CKV_AWS_111: skip requires access to multiple resources
+      sid    = "AllowS3LocationWrite"
+      effect = "Allow"
+      actions = [
+        "s3:PutObject",
+        "s3:PutObjectAcl",
+        "s3:DeleteObject"
+      ]
+      resources = [
+        for key in statement.value.keys : "arn:aws:s3:::${statement.value.bucket}/${key}*"
+      ]
+    }
+  }
+  dynamic "statement" {
     for_each = each.value.stateLockingDetails
 
     content {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in #4622.

#4622 involves switching over workflow processes to run on GitHub Actions runners assuming roles by OIDC (roles specified in the files edited in this PR) rather than running on self-hosted runners (see [this PR](https://github.com/ministryofjustice/analytics-platform-helm-charts/pull/785/files) for an example). In order to do this, the new OIDC roles need permissions to be able to carry out all of the duties of the existing roles.

A change is required to allow the `analytics-platform-helm-charts` role to deposit artefacts (which [fails without this change](https://github.com/ministryofjustice/analytics-platform-helm-charts/actions/runs/12791904830/job/35661137176#step:8:109)) in s3. This is separate from the requirement for state bucket access, so a key:value pair was added to the oidc-roles json that creates a dynamic statement in the `github_oidc_role` for each role.


## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
