### PR TITLE
add s3 batch inference policy attachment

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -201,3 +201,7 @@ resource "aws_iam_policy" "bedrock_batch_inference_s3_access" {
   policy      = data.aws_iam_policy_document.bedrock_batch_inference_s3_access.json
 }
 
+resource "aws_iam_role_policy_attachment" "bedrock_batch_inference_s3_access" {
+  role       = aws_iam_role.bedrock_batch_inference.name
+  policy_arn = aws_iam_policy.bedrock_batch_inference_s3_access.arn
+}


### PR DESCRIPTION
this pr is to add s3 batch inference policy attachment for bedrock as upon merge test I realised I forgot to do this . The policy has been manually tested end to end in the console and works 

<img width="1327" alt="image" src="https://github.com/user-attachments/assets/ff4eb006-1f53-4ffe-901d-a09b5defcab2" />
This is part of the work for issue [#6253](https://github.com/ministryofjustice/analytical-platform/issues/6253)


