### PR TITLE
Allowing Control Panel to Assume Role in Parent Account

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -531,7 +531,8 @@ data "aws_iam_policy_document" "control_panel_api" {
     ]
     resources = [
       "arn:aws:iam::${var.account_ids["analytical-platform-compute-development"]}:role/analytical-platform-control-panel",
-      "arn:aws:iam::${var.account_ids["analytical-platform-compute-test"]}:role/analytical-platform-control-panel"
+      "arn:aws:iam::${var.account_ids["analytical-platform-compute-test"]}:role/analytical-platform-control-panel",
+      "arn:aws:iam::${var.account_ids["parent-account"]}:role/AnalyticalPlatformIdentityCenter"
     ]
   }
   statement {

--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -8,6 +8,7 @@ account_ids = {
   analytical-platform-production            = "312423030077"
   analytical-platform-compute-development   = "381491960855"
   analytical-platform-compute-test          = "767397661611"
+  parent-account                            = "295814833350"
 }
 
 environment     = "development"

--- a/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
@@ -260,7 +260,8 @@ data "aws_iam_policy_document" "control_panel_api" {
     ]
     resources = [
       "arn:aws:iam::${var.account_ids["analytical-platform-compute-production"]}:role/analytical-platform-control-panel",
-      "arn:aws:iam::${var.account_ids["analytical-platform-compute-test"]}:role/analytical-platform-control-panel"
+      "arn:aws:iam::${var.account_ids["analytical-platform-compute-test"]}:role/analytical-platform-control-panel",
+      "arn:aws:iam::${var.account_ids["parent-account"]}:role/AnalyticalPlatformIdentityCenter"
     ]
   }
   statement {

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -8,7 +8,7 @@ account_ids = {
   analytical-platform-management-production = "042130406152"
   analytical-platform-production            = "312423030077"
   analytical-platform-compute-test          = "767397661611"
-  analytical-platform-compute-production    = "992382429243",
+  analytical-platform-compute-production    = "992382429243"
   parent-account                            = "295814833350"
 }
 

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -8,7 +8,8 @@ account_ids = {
   analytical-platform-management-production = "042130406152"
   analytical-platform-production            = "312423030077"
   analytical-platform-compute-test          = "767397661611"
-  analytical-platform-compute-production    = "992382429243"
+  analytical-platform-compute-production    = "992382429243",
+  parent-account                            = "295814833350"
 }
 
 environment     = "production"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/6510)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->
This allows the control panel dev and prod roles to assume the role in the parent account in order to add/remove and manage quicksight users.
## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [X] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [X] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
