### PR TITLE
💼 Add `analytical-platform-infrastructure-access` as part of baseline

### DIFF
--- a/terraform/aws/analytical-platform/baseline/infrastructure-access.tf
+++ b/terraform/aws/analytical-platform/baseline/infrastructure-access.tf
@@ -4,4 +4,8 @@
 
 module "data_production_infrastructure_access" {
   source = "./modules/infrastructure-access"
+
+  providers = {
+    aws = aws.analytical-platform-data-production-eu-west-2
+  }
 }

--- a/terraform/aws/analytical-platform/baseline/infrastructure-access.tf
+++ b/terraform/aws/analytical-platform/baseline/infrastructure-access.tf
@@ -1,0 +1,7 @@
+##################################################
+# Data Production
+##################################################
+
+module "data_production_infrastructure_access" {
+  source = "./modules/infrastructure-access"
+}

--- a/terraform/aws/analytical-platform/baseline/modules/cost-explorer-anomaly-monitor/providers.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/cost-explorer-anomaly-monitor/providers.tf
@@ -5,4 +5,5 @@ terraform {
       configuration_aliases = [aws.management, aws.target]
     }
   }
+  required_version = "~> 1.10"
 }

--- a/terraform/aws/analytical-platform/baseline/modules/guardduty/providers.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/guardduty/providers.tf
@@ -5,4 +5,5 @@ terraform {
       configuration_aliases = [aws.management, aws.target]
     }
   }
+  required_version = "~> 1.10"
 }

--- a/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/main.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/main.tf
@@ -1,0 +1,16 @@
+module "analytical_platform_infrastructure_access_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.52.2"
+
+  create_role = true
+
+  role_name         = "analytical-platform-infrastructure-access"
+  role_requires_mfa = false
+
+  trusted_role_arns = ["arn:aws:iam::509399598587:role/analytical-platform-github-actions"]
+
+  attach_admin_policy = true
+}

--- a/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/providers.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/providers.tf
@@ -1,0 +1,8 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}

--- a/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/providers.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/providers.tf
@@ -5,4 +5,5 @@ terraform {
       version = "~> 5.0"
     }
   }
+  required_version = "~> 1.10"
 }


### PR DESCRIPTION
This pull request:

- Creates a new role `analytical-platform-infrastructure-access` with `AdministratorAccess`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 