### PR TITLE
🔐 Add IRSA role(s) for Analytical Platform Compute's MWAA environment to get secrets

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow-service/data.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow-service/data.tf
@@ -7,3 +7,9 @@ data "aws_iam_session_context" "session" {
 
   arn = data.aws_caller_identity.session.arn
 }
+
+data "aws_iam_openid_connect_provider" "eks_oidc" {
+  for_each = local.analytical_platform_compute_environments
+
+  arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/${each.value.eks_oidc_id}"
+}

--- a/terraform/aws/analytical-platform-data-production/airflow-service/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow-service/iam-roles.tf
@@ -1,0 +1,24 @@
+module "mojap_compute_external_secrets_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  for_each = local.analytical_platform_compute_environments
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.52.2"
+
+  role_name                      = "mojap-compute-${each.key}-external-secrets"
+  attach_external_secrets_policy = true
+  external_secrets_kms_key_arns = [
+    module.secrets_manager_kms.key_arn,
+    module.secrets_manager_eu_west_1_replica_kms.key_arn,
+  ]
+  external_secrets_secrets_manager_arns = formatlist("arn:aws:secretsmanager:%s:${var.account_ids["analytical-platform-data-production"]}:secret:/airflow/${each.key}/*", ["eu-west-2", "eu-west-1"])
+
+  oidc_providers = {
+    main = {
+      provider_arn               = data.aws_iam_openid_connect_provider.eks_oidc[each.key].arn
+      namespace_service_accounts = ["mwaa:external-secrets-analytical-platform-data-production"]
+    }
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/airflow-service/local.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow-service/local.tf
@@ -1,0 +1,13 @@
+locals {
+  analytical_platform_compute_environments = {
+    development = {
+      eks_oidc_id = "1972AFFBD0701A0D1FD291E34F7D1287"
+    }
+    test = {
+      eks_oidc_id = "9FAFCA50C4DA68A8E75FD21EA53A4F2B"
+    }
+    production = {
+      eks_oidc_id = "801920EDEF91E3CAB03E04C03A2DE2BB"
+    }
+  }
+}


### PR DESCRIPTION
This pull request:

- Creates an IRSA enabled IAM role to be used in APC to create a cross-account secret store

Reference: https://external-secrets.io/latest/provider/aws-secrets-manager/#eks-service-account-credentials

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk> 