### PR TITLE
Adding permissions for cross-region inference

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -5,6 +5,7 @@ data "aws_iam_policy_document" "bedrock_integration" {
   statement {
     sid    = "AnalyticalPlatformBedrockIntegration"
     effect = "Allow"
+
     actions = [
       "bedrock:ListFoundationModels",
       "bedrock:GetFoundationModel",
@@ -53,8 +54,11 @@ data "aws_iam_policy_document" "bedrock_integration" {
       "bedrock:CreateModelInvocationJob",
       "bedrock:GetModelInvocationJob",
       "bedrock:ListModelInvocationJobs",
+      "bedrock:GetInferenceProfile",
+      "bedrock:DeleteInferenceProfile",
       "bedrock:StopModelInvocationJob"
     ]
+
     resources = ["*"]
     condition {
       test     = "StringEquals"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/5796) GitHub Issue.
closes: https://github.com/ministryofjustice/analytical-platform/issues/5796
<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

This adds missing permissions to enable cross-region inference in production

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
