### PR TITLE
:wrench: Remove blocks which mention `send_metadata_to_ap` role

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -1846,27 +1846,6 @@ locals {
               Sid      = "ListBucketAccess-mojap-metadata-dev"
             },
             {
-              Action = "s3:ListBucket"
-              Effect = "Allow"
-              Principal = {
-                AWS = "arn:aws:iam::800964199911:role/send_metadata_to_ap"
-              }
-              Resource = "arn:aws:s3:::mojap-metadata-dev"
-              Sid      = "ListAccess-mojap-metadata-dev-electronic-monitoring"
-            },
-            {
-              Action = [
-                "s3:PutObject",
-                "s3:PutObjectAcl"
-              ]
-              Effect = "Allow"
-              Principal = {
-                AWS = "arn:aws:iam::800964199911:role/send_metadata_to_ap"
-              }
-              Resource = "arn:aws:s3:::mojap-metadata-dev/electronic_monitoring/*"
-              Sid      = "PutAccess-mojap-metadata-dev-electronic-monitoring"
-            },
-            {
               Action = "s3:*"
               Condition = {
                 Bool = {
@@ -2069,27 +2048,6 @@ locals {
               }
               Resource = "arn:aws:s3:::mojap-metadata-prod"
               Sid      = "ListBucketAccess-mojap-metadata-prod"
-            },
-            {
-              Action = "s3:ListBucket"
-              Effect = "Allow"
-              Principal = {
-                AWS = "arn:aws:iam::976799291502:role/send_metadata_to_ap"
-              }
-              Resource = "arn:aws:s3:::mojap-metadata-prod"
-              Sid      = "ListAccess-mojap-metadata-prod-electronic-monitoring"
-            },
-            {
-              Action = [
-                "s3:PutObject",
-                "s3:PutObjectAcl"
-              ]
-              Effect = "Allow"
-              Principal = {
-                AWS = "arn:aws:iam::976799291502:role/send_metadata_to_ap"
-              }
-              Resource = "arn:aws:s3:::mojap-metadata-prod/electronic_monitoring/*"
-              Sid      = "PutAccess-mojap-metadata-prod-electronic-monitoring"
             },
             {
               Action = "s3:*"


### PR DESCRIPTION
This PR is being raised as a result of this failed [dependabot](https://github.com/ministryofjustice/analytical-platform/actions/runs/13119465587) apply. 

The `send_metadata_to_ap` role no longer exists hence the change, I'll liaise with data-engineering to ensure this is acceptable. 

Slack discussion on this [here](https://mojdt.slack.com/archives/C04M8224WCV/p1738605080527499).