### PR TITLE
Update JupyterLab Auth0 client callbacks

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/auth0-clients.tf
+++ b/terraform/aws/analytical-platform-production/cluster/auth0-clients.tf
@@ -37,10 +37,10 @@ resource "auth0_client" "rstudio" {
 ##################################################
 
 resource "auth0_client" "jupyter_lab" {
-  name        = "Jupyter Lab EKS"
-  description = "Auth0 Client used by Jupyter Lab on EKS"
-  app_type    = "regular_web"
-  callbacks = [
+  name                = "Jupyter Lab EKS"
+  description         = "Auth0 Client used by Jupyter Lab on EKS"
+  app_type            = "regular_web"
+  callbacks           = [
     "https://*-jupyter-lab.tools.${var.route53_zone}/callback",
     "https://*-jupyter-lab-tunnel.tools.analytical-platform.service.justice.gov.uk/callback"
   ]
@@ -48,8 +48,8 @@ resource "auth0_client" "jupyter_lab" {
     "https://*-jupyter-lab.tools.${var.route53_zone}",
     "https://*-jupyter-lab-tunnel.tools.${var.route53_zone}"
   ]
-  oidc_conformant   = true
-  cross_origin_auth = true
+  oidc_conformant     = true
+  cross_origin_auth   = true
   jwt_configuration {
     alg = "HS256"
   }

--- a/terraform/aws/analytical-platform-production/cluster/auth0-clients.tf
+++ b/terraform/aws/analytical-platform-production/cluster/auth0-clients.tf
@@ -37,10 +37,10 @@ resource "auth0_client" "rstudio" {
 ##################################################
 
 resource "auth0_client" "jupyter_lab" {
-  name                = "Jupyter Lab EKS"
-  description         = "Auth0 Client used by Jupyter Lab on EKS"
-  app_type            = "regular_web"
-  callbacks           = [
+  name        = "Jupyter Lab EKS"
+  description = "Auth0 Client used by Jupyter Lab on EKS"
+  app_type    = "regular_web"
+  callbacks = [
     "https://*-jupyter-lab.tools.${var.route53_zone}/callback",
     "https://*-jupyter-lab-tunnel.tools.analytical-platform.service.justice.gov.uk/callback"
   ]
@@ -48,8 +48,8 @@ resource "auth0_client" "jupyter_lab" {
     "https://*-jupyter-lab.tools.${var.route53_zone}",
     "https://*-jupyter-lab-tunnel.tools.${var.route53_zone}"
   ]
-  oidc_conformant     = true
-  cross_origin_auth   = true
+  oidc_conformant   = true
+  cross_origin_auth = true
   jwt_configuration {
     alg = "HS256"
   }

--- a/terraform/aws/analytical-platform-production/cluster/auth0-clients.tf
+++ b/terraform/aws/analytical-platform-production/cluster/auth0-clients.tf
@@ -37,13 +37,19 @@ resource "auth0_client" "rstudio" {
 ##################################################
 
 resource "auth0_client" "jupyter_lab" {
-  name                = "Jupyter Lab EKS"
-  description         = "Auth0 Client used by Jupyter Lab on EKS"
-  app_type            = "regular_web"
-  callbacks           = ["https://*-jupyter-lab.tools.${var.route53_zone}/callback"]
-  allowed_logout_urls = ["https://*-jupyter-lab.tools.${var.route53_zone}"]
-  oidc_conformant     = true
-  cross_origin_auth   = true
+  name        = "Jupyter Lab EKS"
+  description = "Auth0 Client used by Jupyter Lab on EKS"
+  app_type    = "regular_web"
+  callbacks = [
+    "https://*-jupyter-lab.tools.${var.route53_zone}/callback",
+    "https://*-jupyter-lab-tunnel.tools.analytical-platform.service.justice.gov.uk/callback"
+  ]
+  allowed_logout_urls = [
+    "https://*-jupyter-lab.tools.${var.route53_zone}",
+    "https://*-jupyter-lab-tunnel.tools.${var.route53_zone}"
+  ]
+  oidc_conformant   = true
+  cross_origin_auth = true
   jwt_configuration {
     alg = "HS256"
   }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/6358)
GitHub Issue.

Add in tunnel urls to the JupyterLab Auth0 clients. These had previously been added manually in the Auth0 UI, and have since been removed when a dependabot PR was merged and applied.
<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
