### PR TITLE
Bumping Test PBI Gateway to WS2025

### DIFF
--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
@@ -153,7 +153,7 @@ module "test_powerbi_gateway_ec2" {
   monitoring                  = true
   create_iam_instance_profile = true
   iam_role_description        = "IAM role for PowerBI Gateway Instance"
-  ignore_ami_changes          = timestamp() > "2025-15-02T00:00:00Z" ? true : false
+  ignore_ami_changes          = timestamp() > "2025-02-15T00:00:00Z" ? true : false
   enable_volume_tags          = false
   associate_public_ip_address = false
   iam_role_name               = local.powerbi_gateway_role

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
@@ -153,7 +153,7 @@ module "test_powerbi_gateway_ec2" {
   monitoring                  = true
   create_iam_instance_profile = true
   iam_role_description        = "IAM role for PowerBI Gateway Instance"
-  ignore_ami_changes          = timecmp(timestamp(), "2025-02-15T00:00:00Z") > 0 ? true : false
+  ignore_ami_changes          = timecmp(var.current-time, "2025-02-15T00:00:00Z") > 0 ? true : false
   enable_volume_tags          = false
   associate_public_ip_address = false
   iam_role_name               = local.powerbi_gateway_role

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
@@ -153,7 +153,7 @@ module "test_powerbi_gateway_ec2" {
   monitoring                  = true
   create_iam_instance_profile = true
   iam_role_description        = "IAM role for PowerBI Gateway Instance"
-  ignore_ami_changes          = true
+  ignore_ami_changes          = timestamp() > "2025-15-02T00:00:00Z"
   enable_volume_tags          = false
   associate_public_ip_address = false
   iam_role_name               = local.powerbi_gateway_role

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
@@ -12,6 +12,20 @@ data "aws_ami" "windows_server_2022" {
   }
 }
 
+data "aws_ami" "windows_server_2025" {
+  most_recent = local.powerbi_gateway_ec2.most_recent
+  owners      = [local.powerbi_gateway_ec2.owner_account]
+
+  filter {
+    name   = "name"
+    values = ["Windows_Server-2022-English-Full-Base-*"]
+  }
+  filter {
+    name   = "virtualization-type"
+    values = [local.powerbi_gateway_ec2.virtualization_type]
+  }
+}
+
 data "aws_iam_policy" "powerbi_user" {
   name = "powerbi_user"
 }
@@ -133,7 +147,7 @@ module "test_powerbi_gateway_ec2" {
   source                      = "terraform-aws-modules/ec2-instance/aws"
   version                     = "5.7.1"
   name                        = "test-gateway-data-production-powerbi"
-  ami                         = data.aws_ami.windows_server_2022.id
+  ami                         = data.aws_ami.windows_server_2025.id
   instance_type               = "t3a.xlarge"
   key_name                    = aws_key_pair.powerbi_gateway_keypair.key_name
   monitoring                  = true

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
@@ -153,7 +153,7 @@ module "test_powerbi_gateway_ec2" {
   monitoring                  = true
   create_iam_instance_profile = true
   iam_role_description        = "IAM role for PowerBI Gateway Instance"
-  ignore_ami_changes          = timestamp() > "2025-15-02T00:00:00Z"
+  ignore_ami_changes          = timestamp() > "2025-15-02T00:00:00Z" ? true : false
   enable_volume_tags          = false
   associate_public_ip_address = false
   iam_role_name               = local.powerbi_gateway_role

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
@@ -126,3 +126,56 @@ module "test_powerbi_ec2" {
 
   tags = var.tags
 }
+
+module "test_powerbi_gateway_ec2" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source                      = "terraform-aws-modules/ec2-instance/aws"
+  version                     = "5.7.1"
+  name                        = "test-gateway-data-production-powerbi"
+  ami                         = data.aws_ami.windows_server_2022.id
+  instance_type               = "t3a.xlarge"
+  key_name                    = aws_key_pair.powerbi_gateway_keypair.key_name
+  monitoring                  = true
+  create_iam_instance_profile = true
+  iam_role_description        = "IAM role for PowerBI Gateway Instance"
+  ignore_ami_changes          = true
+  enable_volume_tags          = false
+  associate_public_ip_address = false
+  iam_role_name               = local.powerbi_gateway_role
+
+  iam_role_policies = {
+    SSMCore            = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    PowerBI_DataAccess = data.aws_iam_policy.powerbi_user.arn
+    ReadOnlyAccess     = "arn:aws:iam::aws:policy/ReadOnlyAccess"
+  }
+  root_block_device = [
+    {
+      encrypted   = true
+      volume_type = "gp3"
+      volume_size = 100
+      tags = merge({
+        Name = "test-data-production-powerbi-gateway-root-volume"
+      }, var.tags)
+    },
+  ]
+
+  ebs_block_device = [
+    {
+      volume_type = "gp3"
+      device_name = "/dev/sdf"
+      volume_size = 300
+      encrypted   = true
+      tags = merge({
+        Name = "test-data-production-powerbi-gateway-data-volume"
+      }, var.tags)
+    }
+  ]
+  metadata_options = {
+    http_tokens = "required"
+  }
+  vpc_security_group_ids = [module.test_powerbi_security_group.security_group_id]
+  subnet_id              = module.vpc.private_subnets[0]
+
+  tags = var.tags
+}

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
@@ -153,7 +153,7 @@ module "test_powerbi_gateway_ec2" {
   monitoring                  = true
   create_iam_instance_profile = true
   iam_role_description        = "IAM role for PowerBI Gateway Instance"
-  ignore_ami_changes          = timestamp() > "2025-02-15T00:00:00Z" ? true : false
+  ignore_ami_changes          = timecmp(timestamp(), "2025-02-15T00:00:00Z") > 0 ? true : false
   enable_volume_tags          = false
   associate_public_ip_address = false
   iam_role_name               = local.powerbi_gateway_role

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
@@ -18,7 +18,7 @@ data "aws_ami" "windows_server_2025" {
 
   filter {
     name   = "name"
-    values = ["Windows_Server-2022-English-Full-Base-*"]
+    values = ["Windows_Server-2025-English-Full-Base-*"]
   }
   filter {
     name   = "virtualization-type"

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/ec2-instances.tf
@@ -153,7 +153,7 @@ module "test_powerbi_gateway_ec2" {
   monitoring                  = true
   create_iam_instance_profile = true
   iam_role_description        = "IAM role for PowerBI Gateway Instance"
-  ignore_ami_changes          = timecmp(var.current-time, "2025-02-15T00:00:00Z") > 0 ? true : false
+  ignore_ami_changes          = timecmp(var.ami_maintenance_date, "2025-02-15T00:00:00Z") > 0 ? true : false
   enable_volume_tags          = false
   associate_public_ip_address = false
   iam_role_name               = local.powerbi_gateway_role

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/variables.tf
@@ -12,7 +12,7 @@ variable "tags" {
   description = "Map of tags to apply to resources"
 }
 
-variable "current-time" {
+variable "ami_maintenance_date" {
   type    = string
   default = "2025-02-14T00:00:00Z"
 }

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/variables.tf
@@ -11,3 +11,8 @@ variable "tags" {
   type        = map(string)
   description = "Map of tags to apply to resources"
 }
+
+variable "current-time" {
+  type = string
+  default = "2025-02-14T00:00:00Z"
+}

--- a/terraform/aws/analytical-platform-data-production/powerbi-gateway/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/powerbi-gateway/variables.tf
@@ -13,6 +13,6 @@ variable "tags" {
 }
 
 variable "current-time" {
-  type = string
+  type    = string
   default = "2025-02-14T00:00:00Z"
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/6708)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

This bumps the second gateway to use Windows Server 2025 ami since that comes with PowerShell 7 as standard. The PShell commandlets to provision gateway require powershell 7 to work.

`ignore_ami_changes` code is to make it simpler to rotate AMI on request. By default, the AMI changes are ignored or not in test machines, but what I'd like to do is update the AMI when I specifically y want to, and for the rest of the time ignore AMI changes (to avoid recreating the gateway on a random terraform run)

This is a way to enforce that. Today I want that field to be false (don't ignore ami changes) but after tomorrow, I want to ignore it.

If I want to change it down the road sometime, I can pass a different value and update the date on the other side of the `>`



## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
