### PR TITLE
fix: AP-6640 revert broken athena workgroup apply

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -27,11 +27,6 @@ locals {
       name = "dbt-avature"
     }
   }
-  dbt_spark_workgroups = {
-    "dbt-spark" = {
-      name = "dbt-spark"
-    }
-  }
 }
 
 #trivy:ignore:avd-aws-0006:Not encrypting the workgroup currently
@@ -81,40 +76,6 @@ resource "aws_athena_workgroup" "dbt" {
     enforce_workgroup_configuration = false
     engine_version {
       selected_engine_version = "Athena engine version 3"
-    }
-    result_configuration {
-      output_location = "s3://dbt-query-dump/"
-    }
-  }
-
-  tags = merge(var.tags,
-    {
-      "Name"             = each.value.name
-      "application"      = "CaDeT"
-      "business-unit"    = try(each.value.business_unit, var.tags["business-unit"])
-      "component"        = try(each.value.component, var.tags["component"])
-      "environment-name" = strcontains(each.value.name, "dev") ? "dev" : "prod"
-      "is-production"    = strcontains(each.value.name, "dev") ? "False" : "True"
-      "owner"            = "Data Engineering:dataengineering@digital.justice.gov.uk"
-    }
-  )
-}
-
-#trivy:ignore:avd-aws-0006:Not encrypting the workgroup currently
-#trivy:ignore:avd-aws-0007:Can't enforce output location due to DBT requirements
-resource "aws_athena_workgroup" "spark" {
-  #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
-  #checkov:skip=CKV_AWS_82:Can't enforce output location due to DBT requirements
-
-  for_each = local.dbt_spark_workgroups
-
-  name = each.value.name
-
-  configuration {
-    bytes_scanned_cutoff_per_query  = 1099511627776
-    enforce_workgroup_configuration = true
-    engine_version {
-      selected_engine_version = "PySpark engine version 3"
     }
     result_configuration {
       output_location = "s3://dbt-query-dump/"


### PR DESCRIPTION
relates to #6640 

see: https://github.com/hashicorp/terraform-provider-aws/issues/28386 and https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/athena_workgroup#configuration for relevant information about missing `execution_role`. 

This PR is purely to revert the [failed apply](https://github.com/ministryofjustice/analytical-platform/actions/runs/13333734363). The work to fix will continue next week.

# Pull Request Objective

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
