### PR TITLE
6640 athena spark workgroup

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -114,7 +114,7 @@ resource "aws_athena_workgroup" "pyathena" {
     bytes_scanned_cutoff_per_query  = 1099511627776000
     enforce_workgroup_configuration = true
     engine_version {
-      selected_engine_version = "Athena engine version 3"
+      selected_engine_version = "PySpark engine version 3"
     }
     execution_role = aws_iam_role.athena_spark_execution_role.arn
     result_configuration {

--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -27,9 +27,9 @@ locals {
       name = "dbt-avature"
     }
   }
-  dbt_pyathena_workgroups = {
-    "dbt-pyathena" = {
-      name = "dbt-pyathena"
+  dbt_spark_workgroups = {
+    "dbt-spark" = {
+      name = "dbt-spark"
     }
   }
 }
@@ -102,11 +102,11 @@ resource "aws_athena_workgroup" "dbt" {
 
 #trivy:ignore:avd-aws-0006:Not encrypting the workgroup currently
 #trivy:ignore:avd-aws-0007:Can't enforce output location due to DBT requirements
-resource "aws_athena_workgroup" "pyathena" {
+resource "aws_athena_workgroup" "spark" {
   #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
   #checkov:skip=CKV_AWS_82:Can't enforce output location due to DBT requirements
 
-  for_each = local.dbt_pyathena_workgroups
+  for_each = local.dbt_spark_workgroups
 
   name = each.value.name
 


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in https://github.com/ministryofjustice/analytical-platform/issues/6640#issue-2822983095 GitHub Issue.

Got this airflow error while testing the DAG for the above spike.
`[2025-02-25, 14:57:43 UTC] {{pod_manager.py:228}} INFO - �[0m14:57:43  dbt.adapters.athena.constants adapter: Encountered client error: An error occurred (InvalidRequestException) when calling the StartSession operation: Workgroup EngineVersion is not Spark.`
So, this PR is to change selected_engine_version from Athena Engine to use Spark Engine instead.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
