### PR TITLE
6640 mojap development bucket access added

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
@@ -20,7 +20,7 @@ data "aws_iam_policy_document" "athena_spark" {
     actions = ["s3:List*", "s3:*Object"]
     resources = [
       "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=development_sandpit/*",
-      "arn:aws:s3:::mojap-derived-tables/sandpit/models/domain_name=development_sandpit/*"
+      "arn:aws:s3:::mojap-derived-tables/sandpit/models/domain_name=development_sandpit/*",
       "arn:aws:s3:::mojap-derived-tables/dev/models/domain_name=development_sandpit/*"
     ]
   }

--- a/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
@@ -5,25 +5,16 @@ data "aws_iam_policy_document" "athena_spark" {
   #checkov:skip=CKV_AWS_111:We are going to revisit this https://github.com/ministryofjustice/data-platform/issues/2179
   #checkov:skip=CKV_AWS_356:We are going to revisit this https://github.com/ministryofjustice/data-platform/issues/2179
 
-  {
-      "Version": "2012-10-17",
-      "Statement": [
-          {
-              "Sid": "ListObjectsInBucket",
-              "Effect": "Allow",
-              "Action": ["s3:ListBucket"],
-              "Resource": ["arn:aws:s3:::dbt-query-dump"]
-          },
-          {
-              "Sid": "AllObjectActions",
-              "Effect": "Allow",
-              "Action": "s3:*Object",
-              "Resource": ["arn:aws:s3:::dbt-query-dump/*"]
-          }
-      ]
+  statement {
+    sid     = ""
+    effect  = "Allow"
+    actions = ["s3:List*", "s3:*Object"]
+    resources = [
+      "arn:aws:s3:::dbt-query-dump/*",
+      "arn:aws:s3:::dbt-query-dump"
+    ]
   }
 }
-
 module "athena_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 

--- a/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
@@ -14,7 +14,18 @@ data "aws_iam_policy_document" "athena_spark" {
       "arn:aws:s3:::dbt-query-dump"
     ]
   }
+  statement {
+    sid     = "MojapBucketAccess"
+    effect  = "Allow"
+    actions = ["s3:List*", "s3:*Object"]
+    resources = [
+      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=development_sandpit/*",
+      "arn:aws:s3:::mojap-derived-tables/sandpit/models/domain_name=development_sandpit/*"
+      "arn:aws:s3:::mojap-derived-tables/dev/models/domain_name=development_sandpit/*"
+    ]
+  }
 }
+
 module "athena_iam_policy" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 

--- a/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
@@ -6,7 +6,7 @@ data "aws_iam_policy_document" "athena_spark" {
   #checkov:skip=CKV_AWS_356:We are going to revisit this https://github.com/ministryofjustice/data-platform/issues/2179
 
   statement {
-    sid     = ""
+    sid     = "DumpBucketAccess"
     effect  = "Allow"
     actions = ["s3:List*", "s3:*Object"]
     resources = [

--- a/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
@@ -1,0 +1,36 @@
+data "aws_iam_policy_document" "athena_spark" {
+  #checkov:skip=CKV_AWS_108:We are going to revisit this https://github.com/ministryofjustice/data-platform/issues/2179
+  #checkov:skip=CKV_AWS_109:We are going to revisit this https://github.com/ministryofjustice/data-platform/issues/2179
+  #checkov:skip=CKV_AWS_110:We are going to revisit this https://github.com/ministryofjustice/data-platform/issues/2179
+  #checkov:skip=CKV_AWS_111:We are going to revisit this https://github.com/ministryofjustice/data-platform/issues/2179
+  #checkov:skip=CKV_AWS_356:We are going to revisit this https://github.com/ministryofjustice/data-platform/issues/2179
+
+  {
+      "Version": "2012-10-17",
+      "Statement": [
+          {
+              "Sid": "ListObjectsInBucket",
+              "Effect": "Allow",
+              "Action": ["s3:ListBucket"],
+              "Resource": ["arn:aws:s3:::dbt-query-dump"]
+          },
+          {
+              "Sid": "AllObjectActions",
+              "Effect": "Allow",
+              "Action": "s3:*Object",
+              "Resource": ["arn:aws:s3:::dbt-query-dump/*"]
+          }
+      ]
+  }
+}
+
+module "athena_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "~> 5.0"
+
+  name_prefix = "athena_spark"
+
+  policy = data.aws_iam_policy_document.athena_spark.json
+}

--- a/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
@@ -16,4 +16,8 @@ resource "aws_iam_role" "athena_spark_execution_role" {
 resource "aws_iam_role_policy_attachment" "athena_spark_s3_access" {
   role       = aws_iam_role.athena_spark_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
+  inline_policy {
+    name   = "athena-spark-role-policy"
+    policy = data.aws_iam_policy_document.athena_spark.json
+  }
 }

--- a/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
@@ -20,6 +20,6 @@ resource "aws_iam_role_policy_attachment" "athena_spark_s3_access" {
 
 resource "aws_iam_role_policy" "inline_policy" {
   role   = aws_iam_role.athena_spark_execution_role.name
-  name   = "athena-spark-role-policy"
+  name   = "athena-spark-dump-bucket-access"
   policy = data.aws_iam_policy_document.athena_spark.json
 }

--- a/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
@@ -20,8 +20,6 @@ resource "aws_iam_role_policy_attachment" "athena_spark_s3_access" {
 
 resource "aws_iam_role_policy" "inline_policy" {
   role       = aws_iam_role.athena_spark_execution_role.name
-  inline_policy {
-    name   = "athena-spark-role-policy"
-    policy = data.aws_iam_policy_document.athena_spark.json
-  }
+  name   = "athena-spark-role-policy"
+  policy = data.aws_iam_policy_document.athena_spark.json
 }

--- a/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
@@ -16,6 +16,10 @@ resource "aws_iam_role" "athena_spark_execution_role" {
 resource "aws_iam_role_policy_attachment" "athena_spark_s3_access" {
   role       = aws_iam_role.athena_spark_execution_role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonAthenaFullAccess"
+}
+
+resource "aws_iam_role_policy" "inline_policy" {
+  role       = aws_iam_role.athena_spark_execution_role.name
   inline_policy {
     name   = "athena-spark-role-policy"
     policy = data.aws_iam_policy_document.athena_spark.json

--- a/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-roles.tf
@@ -19,7 +19,7 @@ resource "aws_iam_role_policy_attachment" "athena_spark_s3_access" {
 }
 
 resource "aws_iam_role_policy" "inline_policy" {
-  role       = aws_iam_role.athena_spark_execution_role.name
+  role   = aws_iam_role.athena_spark_execution_role.name
   name   = "athena-spark-role-policy"
   policy = data.aws_iam_policy_document.athena_spark.json
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in https://github.com/ministryofjustice/analytical-platform/issues/6640#issue-2822983095 GitHub Issue.

The PR is to create a new Athena Workgroup for Athena Spark testing

A new DBT workgroup for Spark is added.
This workgroup would be used to built new python dbt models which will run on Spark3.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
