### PR TITLE
s3 file access added to the spark execution role

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/iam-policies.tf
@@ -21,7 +21,8 @@ data "aws_iam_policy_document" "athena_spark" {
     resources = [
       "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=development_sandpit/*",
       "arn:aws:s3:::mojap-derived-tables/sandpit/models/domain_name=development_sandpit/*",
-      "arn:aws:s3:::mojap-derived-tables/dev/models/domain_name=development_sandpit/*"
+      "arn:aws:s3:::mojap-derived-tables/dev/models/domain_name=development_sandpit/*",
+      "arn:aws:s3:::alpha-everyone/athena-spark-packages/*"
     ]
   }
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in https://github.com/ministryofjustice/analytical-platform/issues/6640#issue-2822983095 GitHub Issue.

The PR is to add s3 file access to the spark execution role

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
