### PR TITLE
Allow celery beat to assume the Control Panel IAM role in data prod

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/variables.tf
+++ b/terraform/aws/analytical-platform-development/cluster/variables.tf
@@ -360,10 +360,10 @@ variable "control_panel_kubernetes_service_account" {
 
 variable "control_panel_celery_kubernetes_service_account" {
   type        = string
-  description = "The kubernetes service account that the control panel runs as e.g. cpanel:cpanel-celery-worker"
+  description = "The kubernetes service account that the celery worker runs as e.g. cpanel:cpanel-celery-worker"
 }
 
 variable "control_panel_celery_beat_kubernetes_service_account" {
   type        = string
-  description = "The kubernetes service account that the control panel runs as e.g. cpanel:cpanel-celery-beat"
+  description = "The kubernetes service account that celery beat runs as e.g. cpanel:cpanel-celery-beat"
 }

--- a/terraform/aws/analytical-platform-production/cluster/iam-roles.tf
+++ b/terraform/aws/analytical-platform-production/cluster/iam-roles.tf
@@ -34,7 +34,8 @@ module "iam_assumable_role_control_panel_api" {
   role_policy_arns = [aws_iam_policy.control_panel_api.arn]
   oidc_fully_qualified_subjects = [
     "system:serviceaccount:${var.control_panel_kubernetes_service_account}",
-    "system:serviceaccount:${var.control_panel_celery_kubernetes_service_account}"
+    "system:serviceaccount:${var.control_panel_celery_kubernetes_service_account}",
+    "system:serviceaccount:${var.control_panel_celery_beat_kubernetes_service_account}",
   ]
 }
 

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -200,5 +200,6 @@ eks_node_group_capacities_gpu_node = {
 # Control Panel
 ##################################################
 
-control_panel_kubernetes_service_account        = "cpanel:cpanel-frontend"
-control_panel_celery_kubernetes_service_account = "cpanel:cpanel-celery-worker"
+control_panel_kubernetes_service_account             = "cpanel:cpanel-frontend"
+control_panel_celery_kubernetes_service_account      = "cpanel:cpanel-celery-worker"
+control_panel_celery_beat_kubernetes_service_account = "cpanel:cpanel-celery-beat"

--- a/terraform/aws/analytical-platform-production/cluster/variables.tf
+++ b/terraform/aws/analytical-platform-production/cluster/variables.tf
@@ -370,5 +370,10 @@ variable "control_panel_kubernetes_service_account" {
 
 variable "control_panel_celery_kubernetes_service_account" {
   type        = string
-  description = "The kubernetes service account that the control panel runs as e.g. cpanel:cpanel-celery-worker"
+  description = "The kubernetes service account that the celery worker runs as e.g. cpanel:cpanel-celery-worker"
+}
+
+variable "control_panel_celery_beat_kubernetes_service_account" {
+  type        = string
+  description = "The kubernetes service account that celery beat runs as e.g. cpanel:cpanel-celery-beat"
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/7012)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
