### PR TITLE
🛂 SageMaker Service permissions

### DIFF
--- a/terraform/aws/analytical-platform-data-production/sagemaker-service/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/sagemaker-service/.terraform.lock.hcl
@@ -3,9 +3,10 @@
 
 provider "registry.terraform.io/hashicorp/aws" {
   version     = "5.91.0"
-  constraints = ">= 4.0.0, >= 5.49.0, 5.91.0"
+  constraints = ">= 5.49.0, >= 5.83.0, 5.91.0"
   hashes = [
     "h1:18BGTHTABfTZdeKcn4181ZZGVxTWt1mP52f6TZ9E0hQ=",
+    "h1:rqkcSC4Ou2D7QZTrm/VU+71Ulqqwp8mU9jx3FVYnMCo=",
     "zh:03ee14261b25aee94c735ed6ef7cce47900ab7bdf462335432ca034d0ba74ca2",
     "zh:32a3759049c9c2cd041d1257cf16cb90a5ce586e1d0a6fe5f8ebd0ec1ba8e071",
     "zh:334db69bc6d8643ec4ea432f0e54e851c2394bbe889cca29ca5029db0e4699e8",

--- a/terraform/aws/analytical-platform-data-production/sagemaker-service/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/sagemaker-service/kms-keys.tf
@@ -9,5 +9,26 @@ module "sagemaker_ai_probation_search_models_kms" {
   description           = "SageMaker AI Probation Search Models KMS Key"
   enable_default_policy = true
 
+  key_statements = [
+    {
+      sid = "AllowSageMakerAIExecutionRoles"
+      actions = [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+      ]
+      principals = [
+        {
+          type = "AWS"
+          identifiers = [
+            "arn:aws:iam::381491960855:role/hmpps-probation-search-dev-sagemaker-exec-role",
+            "arn:aws:iam::992382429243:role/hmpps-probation-search-preprod-sagemaker-exec-role",
+            "arn:aws:iam::992382429243:role/hmpps-probation-search-prod-sagemaker-exec-role"
+          ]
+        }
+      ]
+      resources = ["*"]
+    }
+  ]
+
   deletion_window_in_days = 7
 }

--- a/terraform/aws/analytical-platform-data-production/sagemaker-service/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/sagemaker-service/s3-buckets.tf
@@ -1,3 +1,20 @@
+data "aws_iam_policy_document" "sagemaker_ai_probation_search_models_s3" {
+  statement {
+    sid     = "AllowSageMakerAIExecutionRoles"
+    effect  = "Allow"
+    actions = ["s3:GetObject"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::381491960855:role/hmpps-probation-search-dev-sagemaker-exec-role",
+        "arn:aws:iam::992382429243:role/hmpps-probation-search-preprod-sagemaker-exec-role",
+        "arn:aws:iam::992382429243:role/hmpps-probation-search-prod-sagemaker-exec-role"
+      ]
+    }
+    resources = ["arn:aws:s3:::mojap-data-production-sagemaker-ai-probation-search-models/*"]
+  }
+}
+
 #tfsec:ignore:AVD-AWS-0089:Bucket logging not enabled currently
 module "sagemaker_ai_probation_search_models_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
@@ -9,6 +26,9 @@ module "sagemaker_ai_probation_search_models_s3" {
   bucket = "mojap-data-production-sagemaker-ai-probation-search-models"
 
   force_destroy = true
+
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.sagemaker_ai_probation_search_models_s3.json
 
   versioning = {
     enabled = true

--- a/terraform/aws/analytical-platform-data-production/sagemaker-service/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/sagemaker-service/s3-buckets.tf
@@ -1,6 +1,20 @@
 data "aws_iam_policy_document" "sagemaker_ai_probation_search_models_s3" {
   statement {
-    sid     = "AllowSageMakerAIExecutionRoles"
+    sid     = "AllowSageMakerAIExecutionRolesListBucket"
+    effect  = "Allow"
+    actions = ["s3:ListBucket"]
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::381491960855:role/hmpps-probation-search-dev-sagemaker-exec-role",
+        "arn:aws:iam::992382429243:role/hmpps-probation-search-preprod-sagemaker-exec-role",
+        "arn:aws:iam::992382429243:role/hmpps-probation-search-prod-sagemaker-exec-role"
+      ]
+    }
+    resources = ["arn:aws:s3:::mojap-data-production-sagemaker-ai-probation-search-models"]
+  }
+  statement {
+    sid     = "AllowSageMakerAIExecutionRolesGetObject"
     effect  = "Allow"
     actions = ["s3:GetObject"]
     principals {


### PR DESCRIPTION
## Proposed Changes

- Adds statements to KMS and S3 that allows SageMaker AI execution roles to access

## Notes

**WIP** until the following are merged: 
- https://github.com/ministryofjustice/modernisation-platform-environments/pull/9988
- https://github.com/moj-analytical-services/data-engineering-database-access/pull/5106

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>