### PR TITLE
Add Secretsmanager permissions to cadet role

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -40,7 +40,7 @@ data "aws_iam_policy_document" "create_a_derived_table" {
   }
   statement {
     sid = "readSecrets"
-    effect = "Allow",
+    effect = "Allow"
     actions = [
       "secretsmanager:GetSecretValue",
       "secretsmanager:DescribeSecret",

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -39,7 +39,7 @@ data "aws_iam_policy_document" "create_a_derived_table" {
     ]
   }
   statement {
-    sid = "readSecrets"
+    sid    = "readSecrets"
     effect = "Allow"
     actions = [
       "secretsmanager:GetSecretValue",

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -39,6 +39,19 @@ data "aws_iam_policy_document" "create_a_derived_table" {
     ]
   }
   statement {
+    sid = "readSecrets"
+    effect = "Allow",
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecrets",
+    ]
+    resources = [
+      "arn:aws:secretsmanager:*:*:secret:/alpha/airflow/airflow_dev_cadet_deployments/cadet-deploy-key/*",
+      "arn:aws:secretsmanager:*:*:secret:/alpha/airflow/airflow_dev_cadet_deployments/slack_bot_key/*"
+    ]
+  }
+  statement {
     sid    = "AthenaAccess"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
# Pull Request Objective

This PR backports the secretsmanager functionality we've implemented via iam_builder for the existing airflow runner role, so that users can store secret values in a way that doesn't tie us to github actions long term

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
