### PR TITLE
Add Lake Formation permissions for account table and S3 bucket access

### DIFF
--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/data.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/data.tf
@@ -36,3 +36,12 @@ data "aws_secretsmanager_secret_version" "account_ids_version" {
   provider  = aws.session
   secret_id = data.aws_secretsmanager_secret.account_ids.id
 }
+
+
+## Data eng role
+data "aws_iam_roles" "data_engineering_team_access_role_data_engineering_production_data_eng" {
+  provider = aws.destination
+
+  name_regex  = "AWSReservedSSO_modernisation-platform-data-eng_.*"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/"
+}

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -136,7 +136,7 @@ resource "aws_glue_catalog_table" "destination_account_table_resource_link" {
 resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
   provider = aws.destination
 
-  principal   = "arn:iam::${data.aws_caller_identity.destination.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.source.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  principal   = "arn:aws:iam::${data.aws_caller_identity.destination.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.source.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["SELECT"]
   table {
     database_name = "staged_fms_test_dbt"
@@ -148,7 +148,7 @@ resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
 resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
   provider = aws.destination
 
-  principal   = "arn:iam::${data.aws_caller_identity.destination.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.source.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  principal   = "arn:aws:iam::${data.aws_caller_identity.destination.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.source.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["DESCRIBE"]
   database {
     name = "staged_fms_test_dbt_resource_link"

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -152,7 +152,7 @@ resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
   principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["DESCRIBE"]
   database {
-    name = "staged_fms_test_dbt"
+    name = "staged_fms_test_dbt_resource_link"
   }
   permissions_with_grant_option = ["DESCRIBE"]
 }

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -143,7 +143,6 @@ resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
     name          = "account"
     catalog_id    = data.aws_caller_identity.source.account_id
   }
-  permissions_with_grant_option = ["SELECT"]
 }
 
 resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
@@ -154,7 +153,6 @@ resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
   database {
     name = "staged_fms_test_dbt_resource_link"
   }
-  permissions_with_grant_option = ["DESCRIBE"]
 }
 
 # resource "aws_lakeformation_permissions" "s3_bucket_permissions_for_ap_ap_de" {

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -136,7 +136,7 @@ resource "aws_glue_catalog_table" "destination_account_table_resource_link" {
 resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
   provider = aws.destination
 
-  principal   = "arn:iam::${data.aws_caller_identity.destination.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  principal   = "arn:iam::${data.aws_caller_identity.destination.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.source.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["SELECT"]
   table {
     database_name = "staged_fms_test_dbt"

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -121,28 +121,31 @@ resource "aws_glue_catalog_table" "destination_account_table_resource_link" {
 
 
 resource "aws_lakeformation_permissions" "grant_account_table_filter_ap_de" {
+  provider    = aws.destination
   principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["SELECT"]
   data_cells_filter {
     database_name    = "staged_fms_test_dbt"
-    table_name       = "account"
-    table_catalog_id = data.aws_caller_identity.current.account_id
-    name             = module.share_current_version[0].data_filter_id[0]
+    table_name       = "account_resource_link"
+    table_catalog_id = data.aws_caller_identity.destination.account_id
+    name             = "filter-account-acfd15b3547e6c190937dabba14245cdf39af4256bc72fffdb64f9c91e0e1144"
   }
   permissions_with_grant_option = ["SELECT"]
 }
 
-resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
-  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
-  permissions = ["DESCRIBE"]
-  table {
-    database_name = "staged_fms_test_dbt"
-    name          = "account"
-  }
-  permissions_with_grant_option = ["DESCRIBE"]
-}
+# resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
+#   principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+#   permissions = ["DESCRIBE"]
+#   table {
+#     database_name = "staged_fms_test_dbt"
+#     name          = "account"
+#   }
+#   permissions_with_grant_option = ["DESCRIBE"]
+# }
 
 resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
+  provider = aws.destination
+
   principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["DESCRIBE"]
   database {
@@ -151,11 +154,11 @@ resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
   permissions_with_grant_option = ["DESCRIBE"]
 }
 
-resource "aws_lakeformation_permissions" "s3_bucket_permissions_for_ap_ap_de" {
-  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
-  permissions = ["DATA_LOCATION_ACCESS"]
+# resource "aws_lakeformation_permissions" "s3_bucket_permissions_for_ap_ap_de" {
+#   principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+#   permissions = ["DATA_LOCATION_ACCESS"]
 
-  data_location {
-    arn = aws_lakeformation_resource.data_bucket.arn
-  }
-}
+#   data_location {
+#     arn = aws_lakeformation_resource.data_bucket.arn
+#   }
+# }

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -120,28 +120,30 @@ resource "aws_glue_catalog_table" "destination_account_table_resource_link" {
 }
 
 
-resource "aws_lakeformation_permissions" "grant_account_table_filter_ap_de" {
-  provider    = aws.destination
+# resource "aws_lakeformation_permissions" "grant_account_table_filter_ap_de" {
+#   provider    = aws.destination
+#   principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+#   permissions = ["SELECT"]
+#   data_cells_filter {
+#     database_name    = "staged_fms_test_dbt"
+#     table_name       = "account_resource_link"
+#     table_catalog_id = data.aws_caller_identity.destination.account_id
+#     name             = "filter-account-acfd15b3547e6c190937dabba14245cdf39af4256bc72fffdb64f9c91e0e1144"
+#   }
+#   permissions_with_grant_option = ["SELECT"]
+# }
+
+resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
+  provider = aws.destination
+
   principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
-  permissions = ["SELECT"]
-  data_cells_filter {
-    database_name    = "staged_fms_test_dbt"
-    table_name       = "account_resource_link"
-    table_catalog_id = data.aws_caller_identity.destination.account_id
-    name             = "filter-account-acfd15b3547e6c190937dabba14245cdf39af4256bc72fffdb64f9c91e0e1144"
+  permissions = ["DESCRIBE"]
+  table {
+    database_name = "staged_fms_test_dbt"
+    name          = "account_resource_link"
   }
   permissions_with_grant_option = ["SELECT"]
 }
-
-# resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
-#   principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
-#   permissions = ["DESCRIBE"]
-#   table {
-#     database_name = "staged_fms_test_dbt"
-#     name          = "account"
-#   }
-#   permissions_with_grant_option = ["DESCRIBE"]
-# }
 
 resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
   provider = aws.destination

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -136,7 +136,7 @@ resource "aws_glue_catalog_table" "destination_account_table_resource_link" {
 resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
   provider = aws.destination
 
-  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.source.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["DESCRIBE"]
   table {
     database_name = "staged_fms_test_dbt"
@@ -148,7 +148,7 @@ resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
 resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
   provider = aws.destination
 
-  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.source.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["DESCRIBE"]
   database {
     name = "staged_fms_test_dbt"

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -118,3 +118,44 @@ resource "aws_glue_catalog_table" "destination_account_table_resource_link" {
 
   depends_on = [aws_lakeformation_permissions.share_filtered_data_with_role]
 }
+
+
+resource "aws_lakeformation_permissions" "grant_account_table_filter_ap_de" {
+  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  permissions = ["SELECT"]
+  data_cells_filter {
+    database_name    = "staged_fms_test_dbt"
+    table_name       = "account"
+    table_catalog_id = data.aws_caller_identity.current.account_id
+    name             = module.share_current_version[0].data_filter_id[0]
+  }
+  permissions_with_grant_option = ["SELECT"]
+}
+
+resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
+  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  permissions = ["DESCRIBE"]
+  table {
+    database_name = "staged_fms_test_dbt"
+    name          = "account"
+  }
+  permissions_with_grant_option = ["DESCRIBE"]
+}
+
+resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
+  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  permissions = ["DESCRIBE"]
+  database {
+    name = "staged_fms_test_dbt"
+  }
+  permissions_with_grant_option = ["DESCRIBE"]
+}
+
+resource "aws_lakeformation_permissions" "s3_bucket_permissions_for_ap_ap_de" {
+  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  permissions = ["DATA_LOCATION_ACCESS"]
+
+  data_location {
+    arn = aws_lakeformation_resource.data_bucket.arn
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -137,7 +137,7 @@ resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
   provider = aws.destination
 
   principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
-  permissions = ["DESCRIBE"]
+  permissions = ["SELECT"]
   table {
     database_name = "staged_fms_test_dbt"
     name          = "account_resource_link"

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -140,7 +140,8 @@ resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
   permissions = ["SELECT"]
   table {
     database_name = "staged_fms_test_dbt"
-    name          = "account_resource_link"
+    name          = "account"
+    catalog_id    = data.aws_caller_identity.source.account_id
   }
   permissions_with_grant_option = ["SELECT"]
 }

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-test/main.tf
@@ -136,7 +136,7 @@ resource "aws_glue_catalog_table" "destination_account_table_resource_link" {
 resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
   provider = aws.destination
 
-  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  principal   = "arn:iam::${data.aws_caller_identity.destination.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.current.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["SELECT"]
   table {
     database_name = "staged_fms_test_dbt"
@@ -149,7 +149,7 @@ resource "aws_lakeformation_permissions" "grant_account_table_ap_de" {
 resource "aws_lakeformation_permissions" "grant_account_database_ap_de" {
   provider = aws.destination
 
-  principal   = "arn:iam::${local.environment_management.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.source.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
+  principal   = "arn:iam::${data.aws_caller_identity.destination.account_id}:role/aws-reserved/sso.amazonaws.com/${data.aws_region.source.name}/${one(data.aws_iam_roles.data_engineering_team_access_role_data_engineering_production_data_eng.names)}"
   permissions = ["DESCRIBE"]
   database {
     name = "staged_fms_test_dbt_resource_link"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/<your_issue_number_here>)
GitHub Issue.

Granting lf permissions for the test table

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
