### PR TITLE
🛠️  Create IAM Roles for DMS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -60,6 +60,7 @@ updates:
       - "terraform/aws/analytical-platform-data-production/ingestion-egress"
       - "terraform/aws/analytical-platform-data-production/ingestion-ingress"
       - "terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync-opg"
+      - "terraform/aws/analytical-platform-data-production/ingestion-ingress/dms"
       - "terraform/aws/analytical-platform-data-production/joiners-movers-leavers"
       - "terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction"
       - "terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-production"

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync-opg/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync-opg/terraform.tfvars
@@ -13,5 +13,5 @@ tags = {
   is-production          = "true"
   owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
   infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
-  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/ingestion-ingress"
+  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync-opg"
 }

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.94.1"
+  constraints = ">= 4.0.0, 5.94.1"
+  hashes = [
+    "h1:eqxPYFl9Gl+iutDyYTZKteN5v0YFDzDI7eyfoIwh/3U=",
+    "zh:14fb41e50219660d5f02b977e6f786d8ce78766cce8c2f6b8131411b087ae945",
+    "zh:3bc5d12acd5e1a5f1cf78a7f05d0d63f988b57485e7d20c47e80a0b723a99d26",
+    "zh:4835e49377f80a37c6191a092f636e227a9f086e3cc3f0c9e1b554da8793cfe8",
+    "zh:605971275adae25096dca30a94e29931039133c667c1d9b38778a09594312964",
+    "zh:8ae46b4a9a67815facf59da0c56d74ef71bcc77ae79e8bfbac504fa43f267f8e",
+    "zh:913f3f371c3e6d1f040d6284406204b049977c13cb75aae71edb0ef8361da7dd",
+    "zh:91f85ae8c73932547ad7139ce0b047a6a7c7be2fd944e51db13231cc80ce6d8e",
+    "zh:96352ae4323ce137903b9fe879941f894a3ce9ef30df1018a0f29f285a448793",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b51922c9201b1dc3d05b39f9972715db5f67297deee088793d02dea1832564b",
+    "zh:a689e82112aa71e15647b06502d5b585980cd9002c3cc8458f092e8c8a667696",
+    "zh:c3723fa3e6aff3c1cc0088bdcb1edee168fe60020f2f77161d135bf473f45ab2",
+    "zh:d6a2052b864dd394b01ad1bae32d0a7d257940ee47908d02df7fa7873981d619",
+    "zh:dda4c9c0406cc54ad8ee4f19173a32de7c6e73abb5a948ea0f342d567df26a1d",
+    "zh:f42e0fe592b97cbdf70612f0fbe2bab851835e2d1aaf8cbb87c3ab0f2c96bb27",
+  ]
+}

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-policies.tf
@@ -1,0 +1,27 @@
+data "aws_iam_policy_document" "dms_ingress_iam_policy" {
+  statement {
+    sid    = "AllowGlueAccess"
+    effect = "Allow"
+    actions = [
+      "glue:GetTable",
+      "glue:CreateTable",
+      "glue:UpdateTable",
+      "glue:CreateDatabase",
+      "glue:UpdateDatabase"
+    ]
+  }
+}
+
+module "dms_ingress_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  for_each = local.analytical_platform_ingestion_environments
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.54.1"
+
+  name_prefix = "mojap-data-production-dms-ingress-${each.key}"
+
+  policy = data.aws_iam_policy_document.dms_ingress_iam_policy.json
+}

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-policies.tf
@@ -1,13 +1,18 @@
 data "aws_iam_policy_document" "dms_ingress_iam_policy" {
   statement {
-    sid    = "AllowGlueAccess"
+    sid    = "AllowDMSGlueAccess"
     effect = "Allow"
     actions = [
       "glue:GetTable",
       "glue:CreateTable",
       "glue:UpdateTable",
-      "glue:CreateDatabase",
-      "glue:UpdateDatabase"
+      "glue:GetDatabase",
+      "glue:CreateDatabase"
+    ]
+    resources = [
+      "arn:aws:glue:eu-west-2:${var.account_ids["analytical-platform-data-production"]}:catalog",
+      "arn:aws:glue:eu-west-2:${var.account_ids["analytical-platform-data-production"]}:database/cica_tariff",
+      "arn:aws:glue:eu-west-2:${var.account_ids["analytical-platform-data-production"]}:table/cica_tariff/*"
     ]
   }
 }

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-roles.tf
@@ -1,0 +1,18 @@
+module "dms_ingress_iam_role" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  for_each = local.analytical_platform_ingestion_environments
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.54.1"
+
+  create_role = true
+
+  role_name         = "mojap-data-production-dms-ingress-${each.key}"
+  role_requires_mfa = false
+
+  trusted_role_services = ["s3.amazonaws.com"]
+
+  custom_role_policy_arns = [module.dms_ingress_iam_policy[each.key].arn]
+}

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/locals.tf
@@ -1,0 +1,8 @@
+locals {
+  analytical_platform_ingestion_environments = {
+    development = {
+    }
+    production = {
+    }
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/terraform.tf
@@ -1,0 +1,42 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-data-production/ingestion-ingress/dms/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.94.1"
+    }
+  }
+  required_version = "~> 1.5"
+}
+
+provider "aws" {
+  alias = "session"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/terraform.tfvars
@@ -6,7 +6,7 @@ account_ids = {
 }
 
 tags = {
-  business-unit          = "Platforms"
+  business-unit          = "Central Digital"
   application            = "Analytical Platform"
   component              = "ingestion-ingress/dms"
   environment            = "production"

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/terraform.tfvars
@@ -1,0 +1,17 @@
+account_ids = {
+  analytical-platform-data-production       = "593291632749"
+  analytical-platform-management-production = "042130406152"
+  analytical-platform-ingestion-development = "730335344807"
+  analytical-platform-ingestion-production  = "471112983409"
+}
+
+tags = {
+  business-unit          = "Platforms"
+  application            = "Analytical Platform"
+  component              = "ingestion-ingress/dms"
+  environment            = "production"
+  is-production          = "true"
+  owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/ingestion-ingress"
+}

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/terraform.tfvars
@@ -13,5 +13,5 @@ tags = {
   is-production          = "true"
   owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
   infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
-  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/ingestion-ingress"
+  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms"
 }

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/variables.tf
@@ -1,0 +1,9 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/terraform.tfvars
@@ -11,5 +11,5 @@ tags = {
   is-production          = "true"
   owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
   infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
-  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms"
+  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/ingestion-ingress"
 }

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/terraform.tfvars
@@ -4,12 +4,12 @@ account_ids = {
 }
 
 tags = {
-  business-unit          = "Platforms"
+  business-unit          = "Central Digital"
   application            = "Analytical Platform"
   component              = "ingestion-ingress"
   environment            = "production"
   is-production          = "true"
   owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
   infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
-  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/ingestion-ingress"
+  source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms"
 }


### PR DESCRIPTION
This PR as a result of a request from MadeTech for the CICA DMS project. 

Although roles a role was requested per environment i.e. 

- `analytical-platform-ingestion-development` -> `analytical-platform-data-development`
- `analytical-platform-ingestion-production` ->`analytical-platform-data-development`

Each role will be of the form: `mojap-data-production-dms-ingress-<environment>` and will exist in the `analytical-platform-data-production` account.