### PR TITLE
:wrench: Alter DMS roles in `analytical-platform-data-production` 

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-policies.tf
@@ -1,6 +1,8 @@
 data "aws_iam_policy_document" "dms_ingress_iam_policy" {
+  for_each = local.analytical_platform_ingestion_environments
+
   statement {
-    sid    = "AllowDMSGlueAccess"
+    sid    = "Allow${title(each.key)}DMSGlueAccess"
     effect = "Allow"
     actions = [
       "glue:GetTable",
@@ -11,8 +13,8 @@ data "aws_iam_policy_document" "dms_ingress_iam_policy" {
     ]
     resources = [
       "arn:aws:glue:eu-west-2:${var.account_ids["analytical-platform-data-production"]}:catalog",
-      "arn:aws:glue:eu-west-2:${var.account_ids["analytical-platform-data-production"]}:database/cica_tariff",
-      "arn:aws:glue:eu-west-2:${var.account_ids["analytical-platform-data-production"]}:table/cica_tariff/*"
+      "arn:aws:glue:eu-west-2:${var.account_ids["analytical-platform-data-production"]}:database/cica_tariff_${each.key}",
+      "arn:aws:glue:eu-west-2:${var.account_ids["analytical-platform-data-production"]}:table/cica_tariff_${each.key}/*"
     ]
   }
 }
@@ -28,5 +30,5 @@ module "dms_ingress_iam_policy" {
 
   name_prefix = "mojap-data-production-dms-ingress-${each.key}"
 
-  policy = data.aws_iam_policy_document.dms_ingress_iam_policy.json
+  policy = data.aws_iam_policy_document.dms_ingress_iam_policy[each.key].json
 }


### PR DESCRIPTION
This PR is an update to the roles as per a request from MadeTech on the CICA project. 