### PR TITLE
Adding comprehend integration policy and batch processing policy and role similar to bedrock

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -396,7 +396,10 @@ data "aws_iam_policy_document" "comprehend_batch_processing_s3_access" {
       "s3:ListBucket",
     ]
     resources = [
-      "arn:aws:s3:::*"
+      "arn:aws:s3:::alpha-*",
+      "arn:aws:s3:::mojap-*",
+      "arn:aws:s3:::alpha-*/*",
+      "arn:aws:s3:::mojap-*/*",
     ]
 
     condition {

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -278,6 +278,7 @@ resource "aws_iam_policy" "lake_formation_data_access" {
 }
 
 #trivy:ignore:aws-iam-no-policy-wildcards
+#trivy:ignore:AVD-AWS-0342
 data "aws_iam_policy_document" "comprehend_integration" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/7333>) GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->
This created a policy to be attached to the `alpha` user roles to give them access to AWS Comprehend.
Additionally, it also adds the role Comprehend service can assume to run asynchronous tasks.
## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [X] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [X] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
