### PR TITLE
add trusted role arn to dms ingress policy

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-roles.tf
@@ -13,7 +13,9 @@ module "dms_ingress_iam_role" {
   role_requires_mfa = false
 
   trusted_role_services = ["s3.amazonaws.com"]
-  trusted_role_arns = ["arn:aws:iam::${var.account_ids["analytical-platform-ingestion-${each.key}"]}:role/tariff-${each.key}-metadata-generator"]
+  trusted_role_arns     = [
+    "arn:aws:iam::${var.account_ids["analytical-platform-ingestion-${each.key}"]}:role/tariff-${each.key}-metadata-generator",
+  ]
 
   custom_role_policy_arns = [module.dms_ingress_iam_policy[each.key].arn]
 }

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-roles.tf
@@ -13,6 +13,7 @@ module "dms_ingress_iam_role" {
   role_requires_mfa = false
 
   trusted_role_services = ["s3.amazonaws.com"]
+  trusted_role_arns = ["arn:aws:iam::${var.account_ids["analytical-platform-ingestion-${each.key}"]}:role/tariff-${each.key}-metadata-generator"]
 
   custom_role_policy_arns = [module.dms_ingress_iam_policy[each.key].arn]
 }

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/iam-roles.tf
@@ -13,7 +13,7 @@ module "dms_ingress_iam_role" {
   role_requires_mfa = false
 
   trusted_role_services = ["s3.amazonaws.com"]
-  trusted_role_arns     = [
+  trusted_role_arns = [
     "arn:aws:iam::${var.account_ids["analytical-platform-ingestion-${each.key}"]}:role/tariff-${each.key}-metadata-generator",
   ]
 


### PR DESCRIPTION
this is to allow the dms ingress role to be assumed by the trusted role from a different account

# Pull Request Objective

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

This PR is inteded to add a principal to the `dms_ingress_iam_role`. The principle specified is a role arn from another account (analytical platform ingestion) that is used by a lambda. The lambda needs to assume `dms_ingress_iam_role` in order to update the glue catalog in the analytical platform, which are the permissions in the policy specified for `dms_ingress_iam_role`.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
