### PR TITLE
🛂 Allow Bedrock Integration policy to pass Bedrock Inference role

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -1,4 +1,5 @@
 #trivy:ignore:aws-iam-no-policy-wildcards
+#trivy:ignore:AVD-AWS-0342 passing of role is needed for batch processing
 data "aws_iam_policy_document" "bedrock_integration" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -5,7 +5,6 @@ data "aws_iam_policy_document" "bedrock_integration" {
   statement {
     sid    = "AnalyticalPlatformBedrockIntegration"
     effect = "Allow"
-
     actions = [
       "bedrock:ListFoundationModels",
       "bedrock:GetFoundationModel",
@@ -58,7 +57,6 @@ data "aws_iam_policy_document" "bedrock_integration" {
       "bedrock:DeleteInferenceProfile",
       "bedrock:StopModelInvocationJob"
     ]
-
     resources = ["*"]
     condition {
       test     = "StringEquals"
@@ -70,6 +68,17 @@ data "aws_iam_policy_document" "bedrock_integration" {
         "eu-west-3",
         "us-east-1"
       ]
+    }
+  }
+  statement {
+    sid       = "BedrockPassBatchInferenceRole"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/bedrock-batch-inference-role"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["bedrock.amazonaws.com"]
     }
   }
 }


### PR DESCRIPTION
## Proposed Changes

- Allows `analytical-platform-bedrock-integration` to pass `bedrock-batch-inference-role` to Amazon Bedrock

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>