### PR TITLE
Add Dashboard Service Auth0 clients

### DIFF
--- a/terraform/auth0/alpha-analytics-moj/clients.tf
+++ b/terraform/auth0/alpha-analytics-moj/clients.tf
@@ -21,3 +21,25 @@ resource "auth0_connection_client" "visual_studio_code_github" {
   client_id     = auth0_client.visual_studio_code.id
   connection_id = "con_RWgK9R3ISqKJLcZu"
 }
+
+resource "auth0_client" "dashboard_service" {
+  name     = "Dashboard Service"
+  app_type = "regular_web"
+  callbacks = [
+    "https://dashboards.analytical-platform.service.justice.gov.uk/callback/",
+  ]
+  allowed_logout_urls = [
+    "https://dashboards.analytical-platform.service.justice.gov.uk/",
+  ]
+  oidc_conformant   = true
+  sso               = true
+  cross_origin_auth = true
+  jwt_configuration {
+    alg = "HS256"
+  }
+}
+
+resource "auth0_connection_client" "dashboard_service_email" {
+  client_id     = auth0_client.dashboard_service.id
+  connection_id = "con_6zNyH9PCyBMhbCaD"
+}

--- a/terraform/auth0/dev-analytics-moj/clients.tf
+++ b/terraform/auth0/dev-analytics-moj/clients.tf
@@ -21,3 +21,27 @@ resource "auth0_connection_client" "visual_studio_code_github" {
   client_id     = auth0_client.visual_studio_code.id
   connection_id = "con_9AZZa8FvELBflX8B"
 }
+
+resource "auth0_client" "dashboard_service" {
+  name     = "Dashboard Service"
+  app_type = "regular_web"
+  callbacks = [
+    "https://dashboards.development.analytical-platform.service.justice.gov.uk/callback/",
+    "http://localhost:8001/callback/",
+  ]
+  allowed_logout_urls = [
+    "https://dashboards.development.analytical-platform.service.justice.gov.uk/",
+    "http://localhost:8001/",
+  ]
+  oidc_conformant   = true
+  sso               = true
+  cross_origin_auth = true
+  jwt_configuration {
+    alg = "HS256"
+  }
+}
+
+resource "auth0_connection_client" "dashboard_service_email" {
+  client_id     = auth0_client.dashboard_service.id
+  connection_id = "con_nYgw0M6GJbKXJiNh"
+}


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/7535)
GitHub Issue.

Adds regular web app applications for the Dashboard Service in the dev and alpha auth0 tenants. Also setup the email (passwordless) connections

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
