### PR TITLE
Change dashboard service signing algo to RS256

### DIFF
--- a/terraform/auth0/alpha-analytics-moj/clients.tf
+++ b/terraform/auth0/alpha-analytics-moj/clients.tf
@@ -35,7 +35,7 @@ resource "auth0_client" "dashboard_service" {
   sso               = true
   cross_origin_auth = true
   jwt_configuration {
-    alg = "HS256"
+    alg = "RS256"
   }
 }
 

--- a/terraform/auth0/dev-analytics-moj/clients.tf
+++ b/terraform/auth0/dev-analytics-moj/clients.tf
@@ -37,7 +37,7 @@ resource "auth0_client" "dashboard_service" {
   sso               = true
   cross_origin_auth = true
   jwt_configuration {
-    alg = "HS256"
+    alg = "RS256"
   }
 }
 


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/7535)
GitHub Issue.

Using HS256 broke login in testing, and RS256 is the algo that [auth0 recommends](https://auth0.com/blog/rs256-vs-hs256-whats-the-difference/#RS256-or-HS256--Which-Should-You-Use-). Therefore reverting to RS256.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
