### PR TITLE
Create client grant dashboard-service Auth0 clients

### DIFF
--- a/terraform/auth0/alpha-analytics-moj/clients.tf
+++ b/terraform/auth0/alpha-analytics-moj/clients.tf
@@ -39,7 +39,13 @@ resource "auth0_client" "dashboard_service" {
   }
 }
 
-resource "auth0_connection_client" "dashboard_service_email" {
+resource "auth0_connection_client" "dashboard_service_passwordless" {
   client_id     = auth0_client.dashboard_service.id
   connection_id = "con_6zNyH9PCyBMhbCaD"
+}
+
+resource "auth0_client_grant" "control_panel_api" {
+  client_id = auth0_client.dashboard_service.id
+  audience  = "urn:control-panel-prod-api"
+  scopes    = ["list:dashboard", "retrieve:dashboard"]
 }

--- a/terraform/auth0/dev-analytics-moj/clients.tf
+++ b/terraform/auth0/dev-analytics-moj/clients.tf
@@ -45,3 +45,9 @@ resource "auth0_connection_client" "dashboard_service_email" {
   client_id     = auth0_client.dashboard_service.id
   connection_id = "con_nYgw0M6GJbKXJiNh"
 }
+
+resource "auth0_client_grant" "control_panel_api" {
+  client_id = auth0_client.dashboard_service.id
+  audience = "urn:control-panel-dev-api"
+  scopes = ["list:dashboard", "retrieve:dashboard"]
+}

--- a/terraform/auth0/dev-analytics-moj/clients.tf
+++ b/terraform/auth0/dev-analytics-moj/clients.tf
@@ -41,7 +41,7 @@ resource "auth0_client" "dashboard_service" {
   }
 }
 
-resource "auth0_connection_client" "dashboard_service_email" {
+resource "auth0_connection_client" "dashboard_service_passwordless" {
   client_id     = auth0_client.dashboard_service.id
   connection_id = "con_nYgw0M6GJbKXJiNh"
 }

--- a/terraform/auth0/dev-analytics-moj/clients.tf
+++ b/terraform/auth0/dev-analytics-moj/clients.tf
@@ -48,6 +48,6 @@ resource "auth0_connection_client" "dashboard_service_email" {
 
 resource "auth0_client_grant" "control_panel_api" {
   client_id = auth0_client.dashboard_service.id
-  audience = "urn:control-panel-dev-api"
-  scopes = ["list:dashboard", "retrieve:dashboard"]
+  audience  = "urn:control-panel-dev-api"
+  scopes    = ["list:dashboard", "retrieve:dashboard"]
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/7535)
GitHub Issue.

This PR does two things:
1. Add a client grant for the Dashboard Service Auth0 clients in the dev and alpha tenants. This will allow the dashboard service to get an access token for the Control Panel API with the correct API permissions
2. Rename the Dashboard Service passwordless connection resource definitions, as the old name was misleading.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
