### PR TITLE
🪣 NS bucket in eu-west-2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -56,6 +56,7 @@ updates:
       - "terraform/aws/analytical-platform-data-production/control-panel-message-broker"
       - "terraform/aws/analytical-platform-data-production/create-a-derived-table"
       - "terraform/aws/analytical-platform-data-production/data-engineering-pipelines"
+      - "terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2"
       - "terraform/aws/analytical-platform-data-production/github-actions-roles"
       - "terraform/aws/analytical-platform-data-production/ingestion-egress"
       - "terraform/aws/analytical-platform-data-production/ingestion-ingress"

--- a/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.96.0"
+  constraints = ">= 5.49.0, >= 5.83.0, 5.96.0"
+  hashes = [
+    "h1:W9QkmDmDqF4nT5Fa7fpEjTA4xzoQRFHhOzm0duZwVGk=",
+    "zh:3f7e734abb9d647c851f5cb987837d7c073c9cbf1f520a031027d827f93d3b68",
+    "zh:5ca9400360a803a11cf432ca203be9f09da8fff9c96110a83c9029102b18c9d5",
+    "zh:5d421f475d467af182a527b7a61d50105dc63394316edf1c775ef736f84b941c",
+    "zh:68f2328e7f3e7666835d6815b39b46b08954a91204f82a6f648c928a0b09a744",
+    "zh:6a4170e7e2764df2968d1df65efebda55273dfc36dc6741207afb5e4b7e85448",
+    "zh:73f2a15bee21f7c92a071e2520216d0a40041aca52c0f6682e540da8ffcfada4",
+    "zh:9843d6973aedfd4cbaafd7110420d0c4c1d7ef4a2eeff508294c3adcc3613145",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9d1abd6be717c42f2a6257ee227d3e9548c31f01c976ed7b32b2745a63659a67",
+    "zh:a70d642e323021d54a92f0daa81d096cb5067cb99ce116047a42eb1cb1d579a0",
+    "zh:b9a2b293208d5a0449275fae463319e0998c841e0bcd4014594a49ba54bb70d6",
+    "zh:ce0b0eb7ac24ff58c20efcb526c3f792a95be3617c795b45bbeea9f302903ae7",
+    "zh:dbbf98b3cd8003833c472bdb89321c17a9bbdc1b785e7e3d75f8af924ee5a0e4",
+    "zh:df86cf9311a4be8bb4a251196650653f97e01fbf5fe72deecc8f28a35a5352ae",
+    "zh:f92992881afd9339f3e539fcd90cfc1e9ed1356b5e760bbcc804314c3cd6837f",
+  ]
+}

--- a/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/data.tf
+++ b/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/data.tf
@@ -1,0 +1,9 @@
+data "aws_caller_identity" "session" {
+  provider = aws.session
+}
+
+data "aws_iam_session_context" "session" {
+  provider = aws.session
+
+  arn = data.aws_caller_identity.session.arn
+}

--- a/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/kms-keys.tf
@@ -1,0 +1,13 @@
+module "mojap_national_security_data_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.1"
+
+  aliases               = ["s3/mojap-data-production-national-security-data"]
+  description           = "National Security Data KMS Key"
+  enable_default_policy = true
+
+  deletion_window_in_days = 7
+}

--- a/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/s3-buckets.tf
@@ -1,0 +1,25 @@
+#tfsec:ignore:AVD-AWS-0089:Bucket logging not enabled currently
+module "mojap_national_security_data_s3" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "4.7.0"
+
+  bucket = "mojap-data-production-national-security-data"
+
+  force_destroy = true
+
+  versioning = {
+    enabled = true
+  }
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.sagemaker_ai_probation_search_models_kms.key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/s3-buckets.tf
@@ -17,7 +17,7 @@ module "mojap_national_security_data_s3" {
   server_side_encryption_configuration = {
     rule = {
       apply_server_side_encryption_by_default = {
-        kms_master_key_id = module.sagemaker_ai_probation_search_models_kms.key_arn
+        kms_master_key_id = module.mojap_national_security_data_kms.key_arn
         sse_algorithm     = "aws:kms"
       }
     }

--- a/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/terraform.tf
@@ -1,0 +1,42 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-data-production/data-warehouses-eu-west-2/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "5.96.0"
+    }
+  }
+  required_version = "~> 1.10"
+}
+
+provider "aws" {
+  alias = "session"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/terraform.tfvars
@@ -1,0 +1,15 @@
+account_ids = {
+  analytical-platform-data-production       = "593291632749"
+  analytical-platform-management-production = "042130406152"
+}
+
+tags = {
+  business-unit          = "Platforms"
+  application            = "Analytical Platform"
+  component              = "Data Warehouses (eu-west-2)"
+  environment            = "production"
+  is-production          = "true"
+  owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/analytical-platform/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2"
+}

--- a/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/data-warehouses-eu-west-2/variables.tf
@@ -1,0 +1,9 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}


### PR DESCRIPTION
Fixes #7279

## Proposed Changes

- Adds a new component for data warehousing buckets that need to reside in eu-west-2 as the Control Panel doesn't support this yet (see https://github.com/ministryofjustice/analytical-platform/issues/7277)
- Adds KMS and S3 `mojap-data-production-national-security-data`

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>