### PR TITLE
🌐 Create Data Platform Route53 zone

### DIFF
--- a/terraform/aws/analytical-platform-production/route53/route53-zones.tf
+++ b/terraform/aws/analytical-platform-production/route53/route53-zones.tf
@@ -10,6 +10,9 @@ module "route53_zones" {
   zones = {
     "analytical-platform.service.justice.gov.uk" = {
       comment = "Managed by Terraform"
+    },
+    "data-platform.service.justice.gov.uk" = {
+      comment = "Managed by Terraform"
     }
   }
 }


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/analytical-platform/issues/7693

## Proposed Changes

- Creates an empty zone `data-platform.service.justice.gov.uk"`

## Notes

Applied manually

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>