### PR TITLE
🛂 Extend ingest trusted role ARNs

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/dms/locals.tf
@@ -10,7 +10,10 @@ locals {
     }
     production = {
       ingest_trusted_role_arns = [
-        "arn:aws:iam::${var.account_ids["analytical-platform-ingestion-production"]}:role/tariff-production-metadata-generator"
+        "arn:aws:iam::${var.account_ids["analytical-platform-ingestion-production"]}:role/tariff-production-metadata-generator",
+        "arn:aws:iam::${var.account_ids["analytical-platform-ingestion-production"]}:role/tempus-cw-production-metadata-generator",
+        "arn:aws:iam::${var.account_ids["analytical-platform-ingestion-production"]}:role/tempus-spppp-production-metadata-generator",
+        "arn:aws:iam::${var.account_ids["analytical-platform-ingestion-production"]}:role/tempus-sppfj-production-metadata-generator"
       ]
     }
   }


### PR DESCRIPTION
Addresses request from https://mojdt.slack.com/archives/C4PF7QAJZ/p1746612273485849

## Proposed Changes

- Extends `production.ingest_trusted_role_arns`

## Notes

Applied locally

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>