### PR TITLE
📌 Upgrade Grafana to 12.0.0

### DIFF
--- a/terraform/cloud-platform/live/analytical-platform-development/grafana/helm-releases.tf
+++ b/terraform/cloud-platform/live/analytical-platform-development/grafana/helm-releases.tf
@@ -3,7 +3,7 @@ resource "helm_release" "grafana" {
   name       = "grafana"
   repository = "https://grafana.github.io/helm-charts"
   chart      = "grafana"
-  version    = "8.12.1"
+  version    = "9.0.0"
   namespace  = var.namespace
   values = [
     templatefile(

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
@@ -3,7 +3,7 @@ resource "helm_release" "grafana" {
   name       = "grafana"
   repository = "https://grafana.github.io/helm-charts"
   chart      = "grafana"
-  version    = "8.12.1"
+  version    = "9.0.0"
   namespace  = var.namespace
   values = [
     templatefile(


### PR DESCRIPTION
## Proposed Changes

- Upgrades Grafana Helm chart to 9.0.0 which upgrades Grafana application to 12.0.0 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>