### PR TITLE
Add ListRoles permission to Bedrock policy

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -72,6 +72,12 @@ data "aws_iam_policy_document" "bedrock_integration" {
     }
   }
   statement {
+    sid       = "BedrockBatchInferenceListRoles"
+    effect    = "Allow"
+    actions   = ["iam:ListRoles"]
+    resources = ["*"]
+  }
+  statement {
     sid       = "BedrockPassBatchInferenceRole"
     effect    = "Allow"
     actions   = ["iam:PassRole"]


### PR DESCRIPTION
 Pull Request Objective

This piece of work is being tracked in the [🐞 Unable to create Bedrock batch inference job](https://github.com/ministryofjustice/analytical-platform/issues/7637) GitHub Issue.

This Pull Request adds an IAM permission that will allow roles with the attached policy to list IAM roles. This ensure that Bedrock Batch Inference jobs can confirm that the role entered into the web console is available for use.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
