### PR TITLE
:wrench: Remove 'reviewers' from `dependabot.yml`

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
     commit-message:
       prefix: ":dependabot: github-actions"
       include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
   - package-ecosystem: "pip"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
     commit-message:
       prefix: ":dependabot: github-actions"
       include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
   - package-ecosystem: "pip"
     schedule:
       interval: "daily"
@@ -24,8 +22,6 @@ updates:
     commit-message:
       prefix: ":dependabot: pip"
       include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
     directories:
       - "terraform/aws/analytical-platform-data-production/airflow/files/dev"
       - "terraform/aws/analytical-platform-data-production/airflow/files/prod"
@@ -37,8 +33,6 @@ updates:
     commit-message:
       prefix: ":dependabot: terraform"
       include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
     directories:
       - "terraform/auth0/alpha-analytics-moj"
       - "terraform/auth0/dev-analytics-moj"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,6 +14,8 @@ updates:
     commit-message:
       prefix: ":dependabot: github-actions"
       include: "scope"
+    reviewers:
+      - "ministryofjustice/analytical-platform"
   - package-ecosystem: "pip"
     schedule:
       interval: "daily"
@@ -22,6 +24,8 @@ updates:
     commit-message:
       prefix: ":dependabot: pip"
       include: "scope"
+    reviewers:
+      - "ministryofjustice/analytical-platform"
     directories:
       - "terraform/aws/analytical-platform-data-production/airflow/files/dev"
       - "terraform/aws/analytical-platform-data-production/airflow/files/prod"
@@ -33,6 +37,8 @@ updates:
     commit-message:
       prefix: ":dependabot: terraform"
       include: "scope"
+    reviewers:
+      - "ministryofjustice/analytical-platform"
     directories:
       - "terraform/auth0/alpha-analytics-moj"
       - "terraform/auth0/dev-analytics-moj"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
     commit-message:
       prefix: ":dependabot: pip"
       include: "scope"
+    reviewers:
+      - "ministryofjustice/analytical-platform"
     directories:
       - "terraform/aws/analytical-platform-data-production/airflow/files/dev"
       - "terraform/aws/analytical-platform-data-production/airflow/files/prod"
@@ -33,6 +35,8 @@ updates:
     commit-message:
       prefix: ":dependabot: terraform"
       include: "scope"
+    reviewers:
+      - "ministryofjustice/analytical-platform"
     directories:
       - "terraform/auth0/alpha-analytics-moj"
       - "terraform/auth0/dev-analytics-moj"

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -20,8 +20,6 @@ updates:
     commit-message:
       prefix: ":dependabot: github-actions"
       include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
 EOL
 
 for package_ecosystem in pip terraform; do


### PR DESCRIPTION
This removes `reviewers` from dependabot.yml as per [this](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) blog.

[This PR](https://github.com/ministryofjustice/analytical-platform/pull/7749#issuecomment-2879221872) will stop these comments being added to dependabots.