### PR TITLE
:wrench: Remove reviewers parameter from configuration generator

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,6 @@ updates:
     commit-message:
       prefix: ":dependabot: github-actions"
       include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
   - package-ecosystem: "pip"
     schedule:
       interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,8 +22,6 @@ updates:
     commit-message:
       prefix: ":dependabot: pip"
       include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
     directories:
       - "terraform/aws/analytical-platform-data-production/airflow/files/dev"
       - "terraform/aws/analytical-platform-data-production/airflow/files/prod"
@@ -35,8 +33,6 @@ updates:
     commit-message:
       prefix: ":dependabot: terraform"
       include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
     directories:
       - "terraform/auth0/alpha-analytics-moj"
       - "terraform/auth0/dev-analytics-moj"

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -20,8 +20,6 @@ updates:
     commit-message:
       prefix: ":dependabot: github-actions"
       include: "scope"
-    reviewers:
-      - "ministryofjustice/analytical-platform"
 EOL
 
 for package_ecosystem in pip terraform; do

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -45,8 +45,6 @@ for package_ecosystem in pip terraform; do
   printf "    commit-message:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      prefix: \":dependabot: %s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      include: \"scope\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-  printf "    reviewers:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-  printf "      - \"ministryofjustice/analytical-platform\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "    directories:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
 
 


### PR DESCRIPTION
This removes `reviewers` from dependabot.yml as per [this](https://github.blog/changelog/2025-04-29-dependabot-reviewers-configuration-option-being-replaced-by-code-owners/) blog.

[This PR](https://github.com/ministryofjustice/analytical-platform/pull/7749#issuecomment-2879221872) will stop these comments being added to dependabots.