### PR TITLE
Amend github-data-engineering-cleanup role

### DIFF
--- a/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
+++ b/terraform/aws/analytical-platform/oidc/configuration/assumable-roles.json
@@ -234,7 +234,8 @@
     "repositories": ["ministryofjustice/data-engineering-cleanup"],
     "targets": [
       "analytical-platform-data-engineering-production",
-      "analytical-platform-data-production"
+      "analytical-platform-data-production",
+      "analytical-platform-data-engineering-sandbox-a"
     ],
     "stateLockingDetails": [],
     "ssmParameterConfig": [


### PR DESCRIPTION
# Pull Request Objective
User raised an issue while working  on  Migration from self-hosted runners to GitHub runners.

The role `github-data-engineering-cleanup`  used by the workflow  is missing `analytical-platform-data-engineering-sandbox-a` as a target

This piece of work was raised in this slack [thread](https://mojdt.slack.com/archives/C4PF7QAJZ/p1747903400064639)

