### PR TITLE
manually create .terraform.lock.hcl in development

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,6 +59,7 @@ updates:
       - "terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync-opg"
       - "terraform/aws/analytical-platform-data-production/ingestion-ingress/dms"
       - "terraform/aws/analytical-platform-data-production/joiners-movers-leavers"
+      - "terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-development"
       - "terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction"
       - "terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-production"
       - "terraform/aws/analytical-platform-data-production/lakeformation-external-data/electronic-monitoring-data-preproduction"

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-development/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-development/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.94.1"
+  constraints = "~> 5.0, 5.94.1"
+  hashes = [
+    "h1:flqrGxt30tS2dKz1ebDVb4R9KETEj7hIw4q4apnVl4s=",
+    "zh:14fb41e50219660d5f02b977e6f786d8ce78766cce8c2f6b8131411b087ae945",
+    "zh:3bc5d12acd5e1a5f1cf78a7f05d0d63f988b57485e7d20c47e80a0b723a99d26",
+    "zh:4835e49377f80a37c6191a092f636e227a9f086e3cc3f0c9e1b554da8793cfe8",
+    "zh:605971275adae25096dca30a94e29931039133c667c1d9b38778a09594312964",
+    "zh:8ae46b4a9a67815facf59da0c56d74ef71bcc77ae79e8bfbac504fa43f267f8e",
+    "zh:913f3f371c3e6d1f040d6284406204b049977c13cb75aae71edb0ef8361da7dd",
+    "zh:91f85ae8c73932547ad7139ce0b047a6a7c7be2fd944e51db13231cc80ce6d8e",
+    "zh:96352ae4323ce137903b9fe879941f894a3ce9ef30df1018a0f29f285a448793",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9b51922c9201b1dc3d05b39f9972715db5f67297deee088793d02dea1832564b",
+    "zh:a689e82112aa71e15647b06502d5b585980cd9002c3cc8458f092e8c8a667696",
+    "zh:c3723fa3e6aff3c1cc0088bdcb1edee168fe60020f2f77161d135bf473f45ab2",
+    "zh:d6a2052b864dd394b01ad1bae32d0a7d257940ee47908d02df7fa7873981d619",
+    "zh:dda4c9c0406cc54ad8ee4f19173a32de7c6e73abb5a948ea0f342d567df26a1d",
+    "zh:f42e0fe592b97cbdf70612f0fbe2bab851835e2d1aaf8cbb87c3ab0f2c96bb27",
+  ]
+}


### PR DESCRIPTION
Adding a copy of the `.terraform.lock.hcl` file to `development`

Files are identical (including hashes) in both `production` and `preproduction` so giving this a try...