### PR TITLE
DMET-prisons-351: create resource link - one table only

### DIFF
--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/main.tf
@@ -1,4 +1,6 @@
 # Module: lake_formation_analytical_platform_data_prod
+# This created a share from the DPR dev account to the AP prod account 
+# Shares were created for "data_locations" and "databases" in locals.tf
 module "lake_formation_analytical_platform_data_prod" {
   source = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=6fab8677e457c2e276fa1feec8ee83bbccc1220a"
 
@@ -10,4 +12,13 @@ module "lake_formation_analytical_platform_data_prod" {
 
   data_locations     = local.data_locations
   databases_to_share = local.databases
+}
+
+
+resource "aws_lakeformation_resource_link" "dpr_ap_integration_test_link" {
+  provider        = aws.eu_west_1  
+  name            = "test_table_1"            
+  database_name   = "dpr_ap_integration_test_resource_link"
+  target_table    = "test_table_1"                 
+  target_database = "dpr-ap-integration-test"  
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/moj-analytical-services/dmet-prisons/issues/351)
GitHub Issue.

Just trying to create a resource link database from London to Ireland - the resource share is already in place.

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
