### PR TITLE
dmet-prisons-367-resource link tables - hardcoded for development

### DIFF
--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/lake_formation_describe.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/lake_formation_describe.tf
@@ -1,0 +1,22 @@
+resource "aws_lakeformation_permissions" "grant_describe_on_resource_link" {
+  provider    = aws.analytical-platform-data-production
+  principal   = "arn:aws:iam::593291632749:role/alpha_user_andrewc-moj"  # APDP role
+  permissions = ["DESCRIBE"]
+
+  database {
+    name = "dpr_ap_integration_test_tag_dev_dbt_resource_link"  # The resource link DB name in APDP
+  }
+}
+
+resource "aws_lakeformation_permissions" "grant_describe_on_table_link" {
+  provider    = aws.analytical-platform-data-production
+  for_each    = toset(["dev_model_1_notag", "dev_model_2_tag"])
+  
+  principal   = "arn:aws:iam::593291632749:role/alpha_user_andrewc-moj"
+  permissions = ["DESCRIBE"]
+
+  table {
+    database_name = "dpr_ap_integration_test_tag_dev_dbt_resource_link"
+    name          = each.key
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/lake_formation_describe.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/lake_formation_describe.tf
@@ -1,17 +1,17 @@
 resource "aws_lakeformation_permissions" "grant_describe_on_resource_link" {
-  provider    = aws.analytical-platform-data-production
-  principal   = "arn:aws:iam::593291632749:role/alpha_user_andrewc-moj"  # APDP role
+  provider    = aws.session
+  principal   = "arn:aws:iam::593291632749:role/alpha_user_andrewc-moj" # APDP role
   permissions = ["DESCRIBE"]
 
   database {
-    name = "dpr_ap_integration_test_tag_dev_dbt_resource_link"  # The resource link DB name in APDP
+    name = "dpr_ap_integration_test_tag_dev_dbt_resource_link" # The resource link DB name in APDP
   }
 }
 
 resource "aws_lakeformation_permissions" "grant_describe_on_table_link" {
-  provider    = aws.analytical-platform-data-production
-  for_each    = toset(["dev_model_1_notag", "dev_model_2_tag"])
-  
+  provider = aws.session
+  for_each = toset(["dev_model_1_notag", "dev_model_2_tag"])
+
   principal   = "arn:aws:iam::593291632749:role/alpha_user_andrewc-moj"
   permissions = ["DESCRIBE"]
 


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/moj-analytical-services/dmet-prisons/issues/367) and [this](https://github.com/moj-analytical-services/dmet-prisons/issues/391)
GitHub Issues.

Following [this](https://docs.amazonaws.cn/en_us/lake-formation/latest/dg/cross-account-TBAC.html) AWS guidance under `Set up required on the receiving/grantee account` says `Now grant Describe permission on the resource link to the IAM principals that you are sharing the resource.` 

This is what i'm trying with this. If hard-coded works - i'll move to a better solution

I failed doing this [here](https://github.com/moj-analytical-services/data-engineering-database-access/actions/runs/15757345467/job/44415619607) PR https://github.com/moj-analytical-services/data-engineering-database-access/pull/5531
 
## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
