### PR TITLE
DMET-prisons-351 add tables to share explicitly

### DIFF
--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/locals.tf
@@ -18,5 +18,26 @@ locals {
     }
   ]
 
+  tables_to_share = [
+    {
+      source_database = "dpr_ap_integration_test_tag_dev_dbt"
+      source_table    = "dev_model_1_notag"
+      destination_database = {
+        database_name   = "dpr_ap_integration_test_tag_dev_dbt_resource_link"
+        create_database = false
+      }
+      permissions = ["DESCRIBE", "SELECT"]
+    },
+    {
+      source_database = "dpr_ap_integration_test_tag_dev_dbt"
+      source_table    = "dev_model_2_tag"
+      destination_database = {
+        database_name   = "dpr_ap_integration_test_tag_dev_dbt_resource_link"
+        create_database = false
+      }
+      permissions = ["DESCRIBE", "SELECT"]
+    }
+  ]
+
   account_ids = jsondecode(data.aws_secretsmanager_secret_version.account_ids_version.secret_string)
 }

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/locals.tf
@@ -18,7 +18,7 @@ locals {
     }
   ]
 
-  tables_to_share = [
+  tables = [
     {
       source_database = "dpr_ap_integration_test_tag_dev_dbt"
       source_table    = "dev_model_1_notag"

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prison-reporting-development/main.tf
@@ -10,4 +10,5 @@ module "lake_formation_analytical_platform_data_prod" {
 
   data_locations     = local.data_locations
   databases_to_share = local.databases
+  tables_to_share    = local.tables
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/moj-analytical-services/dmet-prisons/issues/351) GitHub issue

I'v been using the AP AWS terraform lake formation module but thought that the 'share_all_tables' was being used in the 'resource links'.  It is not.. so updating the locals.tf to define the two def tables I want to share.

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
