### PR TITLE
Additional Bedrock regions needed for EU Claude Sonnet 4 model

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -67,7 +67,10 @@ data "aws_iam_policy_document" "bedrock_integration" {
         "eu-west-1",
         "eu-west-2",
         "eu-west-3",
-        "us-east-1"
+        "us-east-1",
+        "eu-north-1",
+        "eu-south-1",
+        "eu-south-2"
       ]
     }
   }


### PR DESCRIPTION

This is a fix for the issue raised in this slack [thread](https://mojdt.slack.com/archives/C4PF7QAJZ/p1750686168509419) 

Newer Bedrock models using  cross region inference require access to additional regions to those currently granted, see [claude-sonnet-4](https://eu-central-1.console.aws.amazon.com/bedrock/home?region=eu-central-1#/inference-profiles/eu.anthropic.claude-sonnet-4-20250514-v1:0)

Namely 
- eu-north-1 
- eu-south-1
- eu-south-2

