### PR TITLE
🪣 Add destination bucket for SSCT project

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/kms-keys.tf
@@ -27,3 +27,33 @@ module "production_cica_dms_kms" {
   ]
   deletion_window_in_days = 7
 }
+
+module "shared_services_client_team_gov_29148_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "3.1.1"
+
+  aliases               = ["s3/mojap-data-production-shared-services-client-team-gov-29148"]
+  description           = "Shared Services Client Team GOV-29148"
+  enable_default_policy = true
+  key_statements = [
+    {
+      sid    = "AllowAnalyticalPlatformIngestionService"
+      effect = "Allow"
+      actions = [
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = ["*"]
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = ["arn:aws:iam::471112983409:role/transfer"]
+        }
+      ]
+    }
+  ]
+  deletion_window_in_days = 7
+}


### PR DESCRIPTION
Part of https://github.com/ministryofjustice/analytical-platform/issues/8015

## Proposed Changes

- Adds an KMS and S3 for storing data from SOP for SSCT

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>