### PR TITLE
Adding inventory permissions to kms key

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/kms-keys.tf
@@ -55,6 +55,27 @@ module "datasync_laa_kms" {
           identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-ingestion-production"]}:role/laa-data-analysis-production-replication"]
         }
       ]
+    },
+    {
+      sid = "AllowS3InventoryToUseKMSKey"
+      actions = [
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type        = "Service"
+          identifiers = ["s3.amazonaws.com"]
+        }
+      ]
+
+      condition = {
+        test     = "StringEquals"
+        variable = "aws:SourceAccount"
+        values   = [var.account_ids["analytical-platform-data-production"]]
+      }
     }
   ]
   deletion_window_in_days = 7

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/kms-keys.tf
@@ -70,12 +70,11 @@ module "datasync_laa_kms" {
           identifiers = ["s3.amazonaws.com"]
         }
       ]
-
-      condition = {
+      condition = [{
         test     = "StringEquals"
         variable = "aws:SourceAccount"
         values   = [var.account_ids["analytical-platform-data-production"]]
-      }
+      }]
     }
   ]
   deletion_window_in_days = 7

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/kms-keys.tf
@@ -70,7 +70,7 @@ module "datasync_laa_kms" {
           identifiers = ["s3.amazonaws.com"]
         }
       ]
-      condition = [{
+      conditions = [{
         test     = "StringEquals"
         variable = "aws:SourceAccount"
         values   = [var.account_ids["analytical-platform-data-production"]]


### PR DESCRIPTION
# Pull Request Objective

This is a fix to the setup for buckets synced from LZ to allow the bucket to generate inventory. It failed with access denied because I failed to grant permissions to the KMS key.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
