### PR TITLE
feat: add dbt-xcjs to Athena workgroups

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -25,6 +25,9 @@ locals {
   dbt_athena_workgroups = {
     "dbt-avature" = {
       name = "dbt-avature"
+    },
+    "dbt-xcjs" = {
+      name = "dbt-xcjs"
     }
   }
   dbt_spark_workgroups = {


### PR DESCRIPTION
# Pull Request Objective

Setting up a new dbt workgroup to allow the following workflow deployment to run independently from other dbt builds:
- https://github.com/moj-analytical-services/create-a-derived-table/pull/4073/files

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

Adds a new Athena workgroup (`dbt-xcjs`) to enable the XCJS pipeline to run in isolation from other dbt workloads.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
