### PR TITLE
feat: migrate existing dbt workgroups across to tf

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -138,8 +138,8 @@ resource "aws_athena_workgroup" "dbt" {
 # and skips creating duplicates on apply.
 import {
   for_each = local.dbt_athena_workgroups
-  id = each.value.name # AWS workgroup name
-  to = aws_athena_workgroup.dbt[each.key]
+  id       = each.value.name # AWS workgroup name
+  to       = aws_athena_workgroup.dbt[each.key]
 }
 
 #trivy:ignore:avd-aws-0006:Not encrypting the workgroup currently

--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -28,6 +28,36 @@ locals {
     },
     "dbt-xcjs" = {
       name = "dbt-xcjs"
+    },
+    "dbt-curated-daily" = {
+      name = "dbt-curated-daily"
+    },
+    "dbt-curated-prod" = {
+      name = "dbt-curated-prod"
+    },
+    "dbt-daily" = {
+      name = "dbt-daily"
+    },
+    "dbt-monthly" = {
+      name = "dbt-monthly"
+    },
+    "dbt-nomis-daily" = {
+      name = "dbt-nomis-daily"
+    },
+    "dbt-weekly" = {
+      name = "dbt-weekly"
+    },
+    "dbt-xhibit" = {
+      name = "dbt-xhibit"
+    },
+    "dbt-bold-daily-prod" = {
+      name = "dbt-bold-daily-prod"
+    },
+    "dbt-caseman" = {
+      name = "dbt-caseman"
+    },
+    "dbt-opg" = {
+      name = "dbt-opg"
     }
   }
   dbt_spark_workgroups = {

--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -133,6 +133,15 @@ resource "aws_athena_workgroup" "dbt" {
   )
 }
 
+# Import any existing DBT Athena workgroups into Terraform state
+# This ensures Terraform recognizes workgroups already in AWS
+# and skips creating duplicates on apply.
+import {
+  for_each = local.dbt_athena_workgroups
+  id = each.value.name # AWS workgroup name
+  to = aws_athena_workgroup.dbt[each.key]
+}
+
 #trivy:ignore:avd-aws-0006:Not encrypting the workgroup currently
 #trivy:ignore:avd-aws-0007:Can't enforce output location due to DBT requirements
 resource "aws_athena_workgroup" "spark" {


### PR DESCRIPTION
- **Does not include**: `dbt-curated-dev`, `dbt-dev`, `dbt-sandpit`, `dbt-bold-daily-dev` (all run in dev)

# Pull Request Objective

Migrate the existing dbt Athena workgroups (formerly defined in Python here:  
https://github.com/ministryofjustice/create-a-derived-table-infrastructure/blob/35b55d24d9019b289cbb4b6a3ceef33fa11cb66c/create_a_derived_table_infra/__main__.py#L154)  
over to Terraform. This lays the groundwork for fully managing our Athena infra as code.

### Included workgroups and migration status

- ✅ `dbt-curated-daily`  
- ❌ `dbt-curated-dev` *(dev)*  
- ✅ `dbt-curated-prod`  
- ✅ `dbt-daily`  
- ❌ `dbt-dev` *(dev)*  
- ✅ `dbt-monthly`  
- ✅ `dbt-nomis-daily`  
- ❌ `dbt-sandpit` *(dev)*  
- ✅ `dbt-weekly`  
- ✅ `dbt-xhibit`  
- ❌ `dbt-bold-daily-dev` *(dev)*  
- ✅ `dbt-bold-daily-prod`  
- ✅ `dbt-caseman`  
- ✅ `dbt-opg`  

This change ensures all non-dev workgroups are now managed in Terraform, with consistent configuration and tagging.

## Checklist

> [!NOTE]  
> Skipping any of these checks may delay your PR review!

- [ ] I have reviewed the [Terraform style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform) and ensured compliance  
- [ ] All CI/CD checks have passed (or I’ve applied an `override-static-analysis` label with justification)  
- [ ] I have self-reviewed my code for correctness and readability  
- [ ] I have verified the new workgroups appear correctly in `terraform plan` output  

### Additional Comments

Dev-only workgroups (`*-dev`, `*-sandpit`) will be added in a follow-up PR.