### PR TITLE
Add cadet airflow role for consumtion in AP airflow

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow-service/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow-service/iam-policies.tf
@@ -314,3 +314,112 @@ module "kms_iam_policy" {
   name   = "kms"
   policy = data.aws_iam_policy_document.kms.json
 }
+
+data "aws_iam_policy_document" "create_a_derived_table" {
+  statement {
+    sid    = "BucketAccess"
+    effect = "Allow"
+    actions = [
+      "s3:List*",
+      "s3:GetObject*",
+      "s3:GetBucket*",
+      "s3:DeleteObject*",
+      "s3:PutObject*"
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-derived-tables/*",
+      "arn:aws:s3:::mojap-derived-tables",
+      "arn:aws:s3:::dbt-query-dump/*",
+      "arn:aws:s3:::dbt-query-dump",
+      "arn:aws:s3:::mojap-manage-offences/ho-offence-codes/*",
+      "arn:aws:s3:::mojap-manage-offences",
+      "arn:aws:s3:::mojap-hub-exports/probation_referrals_dump/*",
+      "arn:aws:s3:::mojap-hub-exports",
+      "arn:aws:s3:::alpha-app-opg-lpa-dashboard",
+      "arn:aws:s3:::alpha-app-opg-lpa-dashboard/dev/models/domain_name=opg/*",
+      "arn:aws:s3:::alpha-app-opg-lpa-dashboard/prod/models/domain_name=opg/*",
+      "arn:aws:s3:::alpha-bold-data-shares",
+      "arn:aws:s3:::alpha-bold-data-shares/reducing-reoffending/*"
+    ]
+  }
+  statement {
+    sid    = "DataAccess"
+    effect = "Allow"
+    actions = [
+      "s3:List*",
+      "s3:GetObject*",
+      "s3:GetBucket*"
+    ]
+    resources = [
+      "arn:aws:s3:::*",
+      "arn:aws:s3:::*/*"
+    ]
+  }
+  statement {
+    sid    = "readSecrets"
+    effect = "Allow"
+    actions = [
+      "secretsmanager:GetSecretValue",
+      "secretsmanager:DescribeSecret",
+      "secretsmanager:ListSecrets",
+    ]
+    resources = [
+      "arn:aws:secretsmanager:*:*:secret:/alpha/airflow/airflow_dev_cadet_deployments/cadet-deploy-key/*",
+      "arn:aws:secretsmanager:*:*:secret:/alpha/airflow/airflow_dev_cadet_deployments/slack_bot_key/*"
+    ]
+  }
+  statement {
+    sid    = "AthenaAccess"
+    effect = "Allow"
+    actions = [
+      "athena:List*",
+      "athena:Get*",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution"
+    ]
+    resources = [
+      "arn:aws:athena:*:${var.account_ids["analytical-platform-data-production"]}:datacatalog/*",
+      "arn:aws:athena:*:${var.account_ids["analytical-platform-data-production"]}:workgroup/*"
+    ]
+  }
+  statement {
+    sid    = "GlueAccess"
+    effect = "Allow"
+    actions = [
+      "glue:Get*",
+      "glue:DeleteTable",
+      "glue:DeleteTableVersion",
+      "glue:DeleteSchema",
+      "glue:DeletePartition",
+      "glue:DeleteDatabase",
+      "glue:UpdateTable",
+      "glue:UpdateSchema",
+      "glue:UpdatePartition",
+      "glue:UpdateDatabase",
+      "glue:CreateTable",
+      "glue:CreateSchema",
+      "glue:CreatePartition",
+      "glue:CreatePartitionIndex",
+      "glue:BatchCreatePartition",
+      "glue:CreateDatabase"
+    ]
+    resources = [
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:schema/*",
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:database/*",
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:table/*/*",
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:catalog"
+    ]
+  }
+}
+
+module "cadet_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "5.58.0"
+
+  path   = "/airflow-service/"
+  name   = "cadet"
+  policy = data.aws_iam_policy_document.create_a_derived_table.json
+}

--- a/terraform/aws/analytical-platform-data-production/airflow-service/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow-service/iam-policies.tf
@@ -356,19 +356,6 @@ data "aws_iam_policy_document" "create_a_derived_table" {
     ]
   }
   statement {
-    sid    = "readSecrets"
-    effect = "Allow"
-    actions = [
-      "secretsmanager:GetSecretValue",
-      "secretsmanager:DescribeSecret",
-      "secretsmanager:ListSecrets",
-    ]
-    resources = [
-      "arn:aws:secretsmanager:*:*:secret:/alpha/airflow/airflow_dev_cadet_deployments/cadet-deploy-key/*",
-      "arn:aws:secretsmanager:*:*:secret:/alpha/airflow/airflow_dev_cadet_deployments/slack_bot_key/*"
-    ]
-  }
-  statement {
     sid    = "AthenaAccess"
     effect = "Allow"
     actions = [


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/6639
)
GitHub Issue.

This creates a role for use in Airflow by CaDeT deployments. A matching PR is to follow in AP Airflow repo.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

This cuts the permission for assumption for the Quicksight stuff (because that's GH actions specific at least initially) as well as the `createCLItoken` permission as it's not relevant to the new platform (yet?)
