### PR TITLE
dmet-prisons: update key

### DIFF
--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/main.tf
@@ -4,7 +4,7 @@ module "lake_formation_analytical_platform_data_prod" {
 
 
   providers = {
-    aws.source      = aws.digital_prison_reporting_preprod_eu_west_2
+    aws.source      = aws.digital_prisons_reporting_preprod_eu_west_2
     aws.destination = aws
   }
 

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/main.tf
@@ -4,7 +4,7 @@ module "lake_formation_analytical_platform_data_prod" {
 
 
   providers = {
-    aws.source      = aws.digital_prisons_reporting_preprod_eu_west_2
+    aws.source      = aws.digital_prison_reporting_preprod_eu_west_2
     aws.destination = aws
   }
 

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/terraform.tf
@@ -27,7 +27,7 @@ provider "aws" {
   alias  = "digital_prisons_reporting_preprod_eu_west_2"
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.account_ids["digital-prisons-reporting-preproduction"]}:role/analytical-platform-data-production-share-role"
+    role_arn = "arn:aws:iam::${local.account_ids["digital-prison-reporting-preproduction"]}:role/analytical-platform-data-production-share-role"
   }
   default_tags {
     tags = var.tags

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-production/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-production/terraform.tf
@@ -27,7 +27,7 @@ provider "aws" {
   alias  = "digital_prisons_reporting_prod_eu_west_2"
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.account_ids["digital-prisons-reporting-production"]}:role/analytical-platform-data-production-share-role"
+    role_arn = "arn:aws:iam::${local.account_ids["digital-prison-reporting-production"]}:role/analytical-platform-data-production-share-role"
   }
   default_tags {
     tags = var.tags


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/moj-analytical-services/dmet-prisons/issues/380) GitHub Issue.

AP team updated secrets so that the secrets key referred to the actual AWS account name.

**This is dependent on changes made** here: https://github.com/ministryofjustice/modernisation-platform-environments/pull/12052 being deployed into DPR's preprod and prod environments

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments


