### PR TITLE
🔍 Add CloudWatch custom namespace

### DIFF
--- a/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
@@ -3,7 +3,7 @@ resource "helm_release" "grafana" {
   name       = "grafana"
   repository = "https://grafana.github.io/helm-charts"
   chart      = "grafana"
-  version    = "9.2.7"
+  version    = "9.2.10"
   namespace  = var.namespace
   values = [
     templatefile(

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
@@ -107,6 +107,7 @@ datasources:
           defaultRegion: eu-west-2
           assumeRoleArn: arn:aws:iam::381491960855:role/analytical-platform-observability
           tracingDatasourceUid: mojap-compute-development-xray
+          customMetricsNamespaces: "NetworkMonitor"
       ## Prometheus
       - name: analytical-platform-compute-development-prometheus
         type: grafana-amazonprometheus-datasource
@@ -141,6 +142,7 @@ datasources:
           defaultRegion: eu-west-2
           assumeRoleArn: arn:aws:iam::992382429243:role/analytical-platform-observability
           tracingDatasourceUid: mojap-compute-production-xray
+          customMetricsNamespaces: "NetworkMonitor"
       ## Prometheus
       - name: analytical-platform-compute-production-prometheus
         type: grafana-amazonprometheus-datasource
@@ -175,6 +177,7 @@ datasources:
           defaultRegion: eu-west-2
           assumeRoleArn: arn:aws:iam::767397661611:role/analytical-platform-observability
           tracingDatasourceUid: mojap-compute-test-xray
+          customMetricsNamespaces: "NetworkMonitor"
       ## Prometheus
       - name: analytical-platform-compute-test-prometheus
         type: grafana-amazonprometheus-datasource


### PR DESCRIPTION
## Proposed Changes

- Adds `customMetricsNamespaces` for `NetworkMonitor`
- Updates Grafana Helm chart to [`9.2.10`](https://artifacthub.io/packages/helm/grafana/grafana/9.2.10)

## Notes

`NetworkMonitor` isn't a custom namespace, but its not visible in Explorer... hoping this will sort it

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>