### PR TITLE
🪣  Add OPG OCR Permissions to mojap-land S3 buckets

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -712,7 +712,8 @@ locals {
                 "arn:aws:s3:::mojap-land/bold/essex-police/*",
                 "arn:aws:s3:::mojap-land/sscl/sscl_data_dump/*",
                 "arn:aws:s3:::mojap-land/cps/*",
-                "arn:aws:s3:::mojap-land/property/planetfm/backupfiles/*"
+                "arn:aws:s3:::mojap-land/property/planetfm/backupfiles/*",
+                "arn:aws:s3:::mojap-land/opg/prod/ocr/*"
               ]
             },
             {
@@ -1038,6 +1039,7 @@ locals {
                 "arn:aws:s3:::mojap-land-dev/bold/essex-police/*",
                 "arn:aws:s3:::mojap-land-dev/sscl/sscl_data_dump/*",
                 "arn:aws:s3:::mojap-land-dev/cps/*",
+                "arn:aws:s3:::mojap-land-dev/opg/dev/ocr/*"
               ]
             },
             {


### PR DESCRIPTION
This PR is in aid of [this](https://github.com/ministryofjustice/analytical-platform/issues/7954) piece of work. It will allow both  the destination folders to be created.