### PR TITLE
:wrench: Permit new airflow roles access to familyman databases

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -32,6 +32,8 @@ locals {
         "alpha_user_lavmatt",
         "airflow_prod_familyman",
         "airflow_dev_familyman",
+        "airflow-test-hmcts-familyman-extraction",
+        "airflow-production-hmcts-familyman-extraction"
       ]
     },
     {


### PR DESCRIPTION
This PR has been created off of the back of [this](https://mojdt.slack.com/archives/C4PF7QAJZ/p1753346415706979) Slack thread and permits the new airflow roles access to familyman databases. 

I wasn't aware of this so very interesting. 