### PR TITLE
🔧 Permit new airflow roles access to pcol databases

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -113,6 +113,8 @@ locals {
         "cc-data-engineer",
         "data-first-data-engineer",
         "airflow_dev_civil",
+        "airflow-test-hmcts-pcol",
+        "airflow-production-hmcts-pcol-extraction"
       ]
     }
   ]


### PR DESCRIPTION
This PR permits new Airflow permissions on `pcol` databases.

Further to [this](https://mojdt.slack.com/archives/C4PF7QAJZ/p1753350119339139?thread_ts=1753346415.706979&cid=C4PF7QAJZ) thread. Yes the DAG names are non-uniform.