### PR TITLE
Use the family in the redis parameter group name

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/redis.tf
+++ b/terraform/aws/analytical-platform-development/cluster/redis.tf
@@ -34,5 +34,5 @@ module "control_panel_redis" {
   allowed_security_groups    = [module.eks.worker_security_group_id]
 
   create_parameter_group = true
-  parameter_group_name   = "control-panel-${var.environment}"
+  parameter_group_name   = "control-panel-${var.environment}-${var.redis_family}"
 }


### PR DESCRIPTION
Try to force a new parameter group to be created when we update the redis family

# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/<your_issue_number_here>)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
