### PR TITLE
:wrench: Increase `open-pull-requests-limit` to 15

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,4 +87,3 @@ updates:
       - "terraform/cloud-platform/live/analytical-platform-development/grafana"
       - "terraform/cloud-platform/live/analytical-platform-production/observability"
       - "terraform/pagerduty"
-    open-pull-requests-limit: 15

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,6 +15,7 @@ updates:
       prefix: ":dependabot: github-actions"
       include: "scope"
   - package-ecosystem: "pip"
+    open-pull-requests-limit: "15"
     schedule:
       interval: "daily"
       time: "09:00"
@@ -23,10 +24,10 @@ updates:
       prefix: ":dependabot: pip"
       include: "scope"
     directories:
-    open-pull-requests-limit: "15"
       - "terraform/aws/analytical-platform-data-production/airflow/files/dev"
       - "terraform/aws/analytical-platform-data-production/airflow/files/prod"
   - package-ecosystem: "terraform"
+    open-pull-requests-limit: "15"
     schedule:
       interval: "daily"
       time: "09:00"
@@ -35,7 +36,6 @@ updates:
       prefix: ":dependabot: terraform"
       include: "scope"
     directories:
-    open-pull-requests-limit: "15"
       - "terraform/auth0/alpha-analytics-moj"
       - "terraform/auth0/dev-analytics-moj"
       - "terraform/auth0/ministryofjustice-data-platform"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,11 +15,11 @@ updates:
       prefix: ":dependabot: github-actions"
       include: "scope"
   - package-ecosystem: "pip"
-    open-pull-requests-limit: 15
     schedule:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    open-pull-requests-limit: 15
     commit-message:
       prefix: ":dependabot: pip"
       include: "scope"
@@ -27,11 +27,11 @@ updates:
       - "terraform/aws/analytical-platform-data-production/airflow/files/dev"
       - "terraform/aws/analytical-platform-data-production/airflow/files/prod"
   - package-ecosystem: "terraform"
-    open-pull-requests-limit: 15
     schedule:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
+    open-pull-requests-limit: 15
     commit-message:
       prefix: ":dependabot: terraform"
       include: "scope"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,7 +15,8 @@ updates:
       prefix: ":dependabot: github-actions"
       include: "scope"
   - package-ecosystem: "pip"
-    open-pull-requests-limit: 15    schedule:
+    open-pull-requests-limit: 15
+    schedule:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
@@ -26,7 +27,8 @@ updates:
       - "terraform/aws/analytical-platform-data-production/airflow/files/dev"
       - "terraform/aws/analytical-platform-data-production/airflow/files/prod"
   - package-ecosystem: "terraform"
-    open-pull-requests-limit: 15    schedule:
+    open-pull-requests-limit: 15
+    schedule:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -87,3 +87,4 @@ updates:
       - "terraform/cloud-platform/live/analytical-platform-development/grafana"
       - "terraform/cloud-platform/live/analytical-platform-production/observability"
       - "terraform/pagerduty"
+    open-pull-requests-limit: 15

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -23,6 +23,7 @@ updates:
       prefix: ":dependabot: pip"
       include: "scope"
     directories:
+    open-pull-requests-limit: "15"
       - "terraform/aws/analytical-platform-data-production/airflow/files/dev"
       - "terraform/aws/analytical-platform-data-production/airflow/files/prod"
   - package-ecosystem: "terraform"
@@ -34,6 +35,7 @@ updates:
       prefix: ":dependabot: terraform"
       include: "scope"
     directories:
+    open-pull-requests-limit: "15"
       - "terraform/auth0/alpha-analytics-moj"
       - "terraform/auth0/dev-analytics-moj"
       - "terraform/auth0/ministryofjustice-data-platform"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -15,8 +15,7 @@ updates:
       prefix: ":dependabot: github-actions"
       include: "scope"
   - package-ecosystem: "pip"
-    open-pull-requests-limit: "15"
-    schedule:
+    open-pull-requests-limit: 15    schedule:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"
@@ -27,8 +26,7 @@ updates:
       - "terraform/aws/analytical-platform-data-production/airflow/files/dev"
       - "terraform/aws/analytical-platform-data-production/airflow/files/prod"
   - package-ecosystem: "terraform"
-    open-pull-requests-limit: "15"
-    schedule:
+    open-pull-requests-limit: 15    schedule:
       interval: "daily"
       time: "09:00"
       timezone: "Europe/London"

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -38,7 +38,7 @@ for package_ecosystem in pip terraform; do
   esac
 
   printf "  - package-ecosystem: \"%s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-  printf "    open-pull-requests-limit: 15" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    open-pull-requests-limit: 15\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "    schedule:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      interval: \"daily\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      time: \"09:00\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -46,6 +46,7 @@ for package_ecosystem in pip terraform; do
   printf "      prefix: \":dependabot: %s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      include: \"scope\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "    directories:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    open-pull-requests-limit: \"15\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
 
 
   folders=$(find . -type f -name "${SEARCH_PATTERN}" -exec dirname {} \; | sort -h | uniq | cut -c 3-)

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -38,11 +38,11 @@ for package_ecosystem in pip terraform; do
   esac
 
   printf "  - package-ecosystem: \"%s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-  printf "    open-pull-requests-limit: 15\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "    schedule:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      interval: \"daily\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      time: \"09:00\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      timezone: \"Europe/London\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    open-pull-requests-limit: 15\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "    commit-message:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      prefix: \":dependabot: %s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      include: \"scope\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -38,7 +38,7 @@ for package_ecosystem in pip terraform; do
   esac
 
   printf "  - package-ecosystem: \"%s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-  printf "    open-pull-requests-limit: \"15\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    open-pull-requests-limit: 15" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "    schedule:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      interval: \"daily\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      time: \"09:00\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"

--- a/scripts/dependabot/configuration-generator.sh
+++ b/scripts/dependabot/configuration-generator.sh
@@ -38,6 +38,7 @@ for package_ecosystem in pip terraform; do
   esac
 
   printf "  - package-ecosystem: \"%s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
+  printf "    open-pull-requests-limit: \"15\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "    schedule:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      interval: \"daily\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      time: \"09:00\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
@@ -46,7 +47,6 @@ for package_ecosystem in pip terraform; do
   printf "      prefix: \":dependabot: %s\"\n" "${package_ecosystem}" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "      include: \"scope\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
   printf "    directories:\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
-  printf "    open-pull-requests-limit: \"15\"\n" >>"${DEPENDABOT_CONFIGURATION_FILE}"
 
 
   folders=$(find . -type f -name "${SEARCH_PATTERN}" -exec dirname {} \; | sort -h | uniq | cut -c 3-)


### PR DESCRIPTION
I suspect that the [long running dependabots](https://github.com/orgs/ministryofjustice/projects/27?pane=issue&itemId=118789410&issue=ministryofjustice%7Canalytical-platform%7C8084) have backed up a number of other dependabots from coming to our attention. The purpose of this PR is to increase the limit, even temporarily, to allow these to flow in and be rectified. It does add it to the pip ecosystem but this is preferable to having to re-engineer the script.

The default value is 5.