### PR TITLE
🚨 hotfix trust policy SID

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/de-role.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/de-role.tf
@@ -10,7 +10,7 @@ module "data_engineering_probation_glue_access_iam_role" {
   use_name_prefix = false
 
   trust_policy_permissions = {
-    trusted_role_arns = {
+    TrustRoleAndServiceToAssume = {
       actions = [
         "sts:AssumeRole",
         "sts:TagSession"

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/data-engineering-datalake-access.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/data-engineering-datalake-access.tf
@@ -98,14 +98,14 @@ module "data_engineering_datalake_access_iam_role" {
   use_name_prefix = false
 
   trust_policy_permissions = {
-    trusted_role_arns = {
+    TrustRoleAndServiceToAssume = {
       actions = [
         "sts:AssumeRole",
         "sts:TagSession"
       ]
       principals = [{
         type        = "AWS"
-        identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-commons-production"]}:role/data-engineering-datalake-access-github-actions"]
+        identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-common-production"]}:role/data-engineering-datalake-access-github-actions"]
       }]
     }
   }

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/terraform.tfvars
@@ -1,5 +1,5 @@
 account_ids = {
-  analytical-platform-commons-production    = "509399598587"
+  analytical-platform-common-production     = "509399598587"
   analytical-platform-data-production       = "593291632749"
   analytical-platform-management-production = "042130406152"
   analytical-platform-compute-production    = "992382429243"


### PR DESCRIPTION
## Proposed Changes

- `trusted_role_arns` -> `TrustRoleAndServiceToAssume`
  - This string is used for the Sid, and doesn't allow snake casing
 
Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>