### PR TITLE
:wrench: Add `.dependabot-terraform-ignore` to airflow directory

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -48,7 +48,6 @@ updates:
       - "terraform/aws/analytical-platform-data-engineering-production/terraform-state"
       - "terraform/aws/analytical-platform-data-engineering-sandbox-a/airflow-create-a-pipeline"
       - "terraform/aws/analytical-platform-data-engineering-sandbox-a/github-actions-roles"
-      - "terraform/aws/analytical-platform-data-production/airflow"
       - "terraform/aws/analytical-platform-data-production/airflow-service"
       - "terraform/aws/analytical-platform-data-production/artifact-repos"
       - "terraform/aws/analytical-platform-data-production/athena"


### PR DESCRIPTION
The purpose of this PR is to have Dependabot ignore the Airflow directory in APDP going forward as this is going to be retired.