### PR TITLE
⏩ Add Analytical Platform Next DNS

### DIFF
--- a/terraform/aws/analytical-platform-production/route53/route53-records.tf
+++ b/terraform/aws/analytical-platform-production/route53/route53-records.tf
@@ -98,5 +98,11 @@ module "route53_records" {
         "ns-1929.awsdns-49.co.uk."
       ]
     },
+    {
+      name    = "next"
+      type    = "CNAME"
+      ttl     = 300
+      records = ["ingress.compute.development.analytical-platform.service.justice.gov.uk."]
+    },
   ]
 }


### PR DESCRIPTION
Resolves https://github.com/ministryofjustice/analytical-platform/issues/8634

## Proposed Changes

- Points `next.analytical-platform.service.justice.gov.uk` at APC development 

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>