### PR TITLE
:construction: COAT: DataSync (Sandbox -> APDP)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,6 +57,7 @@ updates:
       - "terraform/aws/analytical-platform-data-engineering-production/ppud-preprod"
       - "terraform/aws/analytical-platform-data-engineering-production/terraform-state"
       - "terraform/aws/analytical-platform-data-engineering-sandbox-a/airflow-create-a-pipeline"
+      - "terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing"
       - "terraform/aws/analytical-platform-data-engineering-sandbox-a/github-actions-roles"
       - "terraform/aws/analytical-platform-data-engineering-sandbox-a/ppud-sandbox"
       - "terraform/aws/analytical-platform-data-production/airflow-service"

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.10.0"
+  constraints = ">= 6.5.0, 6.10.0"
+  hashes = [
+    "h1:Ukz833hY+KoxjTmaTeVO2R0ZUM8VQnGBQP8HWl3Ws7Q=",
+    "zh:3c92efebaf635372bf7283e04fc667d59b0ff3cf1aacd011fc484a11f70954d9",
+    "zh:404b2a1d360851e63f25945406f2d0c2cb9c20b361552ce01bf7fe3df516a5bf",
+    "zh:523b1640e2b9e2b548876a1dccc627c290f342255d727568fe4becfd9a8f5689",
+    "zh:697adf10c76384195303650555229129d64135f5be3abf95da0bf4b6de742054",
+    "zh:69d6177e3e106518844373871d4e6377003336761aab884da32f66b034229b5c",
+    "zh:6a41899ce8ab9cdd6f706160fd350951e5f3fc1432a37e638d3576a780c686fd",
+    "zh:6e8fd28299d6bf0ab6922cf987757e578f357a45ac45abc312688580dbde3bee",
+    "zh:7ca4bfb5a8f89586dd0c8dd9c1e638a03bc7c6f456bcc29be57cfb7bdc90fc30",
+    "zh:8fe1f6e0a2718318bae3f53a4fb77bc9eaef0fc4131145996f48482b135830c6",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b221cfbc9f19ad30719b773f05f45571e88b124c15c35ac230021df1bb1110f5",
+    "zh:b458c357b5f38092e374957e51827d9113447696deccf0cb01f5684d976e7725",
+    "zh:b7fbb1b05972d73d72af58a2179ac124c6d69a4f0392aa2ce4dc855e78f52268",
+    "zh:d95da0dc45df0f30005e17c5206addbd62b0471c265d9855fe8039bf6f2adef7",
+    "zh:db5dd4120c6ab6ae13df67353a9bc902ac34d01c1d297812d628ebf61dc6f681",
+  ]
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/cloudwatch-log-groups.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/cloudwatch-log-groups.tf
@@ -1,0 +1,9 @@
+module "datasync_events_log_group" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
+  version = "5.7.1"
+
+  name              = "datasync-events"
+  retention_in_days = 400
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/cloudwatch-log-groups.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/cloudwatch-log-groups.tf
@@ -1,9 +1,0 @@
-module "datasync_events_log_group" {
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-
-  source  = "terraform-aws-modules/cloudwatch/aws//modules/log-group"
-  version = "5.7.1"
-
-  name              = "datasync-events"
-  retention_in_days = 400
-}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/data.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/data.tf
@@ -7,9 +7,3 @@ data "aws_iam_session_context" "session" {
 
   arn = data.aws_caller_identity.session.arn
 }
-
-data "aws_secretsmanager_secret_version" "analytical_platform_compute_cluster_data" {
-  provider = aws.analytical-platform-management-production
-
-  secret_id = "analytical-platform-compute/cluster-data"
-}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/data.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/data.tf
@@ -1,0 +1,15 @@
+data "aws_caller_identity" "session" {
+  provider = aws.session
+}
+
+data "aws_iam_session_context" "session" {
+  provider = aws.session
+
+  arn = data.aws_caller_identity.session.arn
+}
+
+data "aws_secretsmanager_secret_version" "analytical_platform_compute_cluster_data" {
+  provider = aws.analytical-platform-management-production
+
+  secret_id = "analytical-platform-compute/cluster-data"
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
@@ -6,17 +6,17 @@ resource "aws_datasync_location_s3" "root_account" {
   subdirectory  = "/"
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role"
+    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role" #TODO: Update call
   }
 }
 
 # DESTINATION - APDP
 resource "aws_datasync_location_s3" "apdp_account" {
-  provider      = aws.analytical-platform-data-production-eu-west-1
+  region        = "eu-west-1"
   s3_bucket_arn = "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly" #TODO: Update how this is derived in the root account
   subdirectory  = "/"
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role"
+    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role" #TODO: Update call
   }
 }

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
@@ -1,0 +1,21 @@
+### This represents the root account datasync setup
+
+# SOURCE - Root account S3 location - i.e. sandbox for testing
+resource "aws_datasync_location_s3" "root_account" {
+  s3_bucket_arn = module.coat_s3.s3_bucket_arn
+  subdirectory  = "/"
+
+  s3_config {
+    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role" #TODO: Update this
+  }
+}
+
+# DESTINATION - APDP
+resource "aws_datasync_location_s3" "apdp_account" {
+  s3_bucket_arn = "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly" #TODO: Update how this is derived in the root account
+  subdirectory  = "/"
+
+  s3_config {
+    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role" #TODO: I don't have a role defined here so this is wrong
+  }
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
@@ -6,16 +6,17 @@ resource "aws_datasync_location_s3" "root_account" {
   subdirectory  = "/"
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role" #TODO: Update this
+    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role"
   }
 }
 
 # DESTINATION - APDP
 resource "aws_datasync_location_s3" "apdp_account" {
+  provider      = aws.analytical-platform-data-production-eu-west-1
   s3_bucket_arn = "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly" #TODO: Update how this is derived in the root account
   subdirectory  = "/"
 
   s3_config {
-    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role" #TODO: I don't have a role defined here so this is wrong
+    bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role"
   }
 }

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
@@ -20,3 +20,9 @@ resource "aws_datasync_location_s3" "apdp_account" {
     bucket_access_role_arn = "arn:aws:iam::684969100054:role/coat-datasync-iam-role" #TODO: Update call
   }
 }
+
+resource "aws_datasync_task" "coat_to_apdp_task" {
+  destination_location_arn = aws_datasync_location_s3.apdp_account.arn
+  name                     = "COAT to APDP"
+  source_location_arn      = aws_datasync_location_s3.root_account.arn
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
@@ -25,4 +25,13 @@ resource "aws_datasync_task" "coat_to_apdp_task" {
   destination_location_arn = aws_datasync_location_s3.apdp_account.arn
   name                     = "COAT to APDP"
   source_location_arn      = aws_datasync_location_s3.root_account.arn
+
+  cloudwatch_log_group_arn = module.datasync_events_log_group.cloudwatch_log_group_arn
+
+  options {
+    log_level         = "BASIC"
+    posix_permissions = "NONE"
+    uid               = "NONE"
+    gid               = "NONE"
+  }
 }

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/datasync.tf
@@ -25,13 +25,5 @@ resource "aws_datasync_task" "coat_to_apdp_task" {
   destination_location_arn = aws_datasync_location_s3.apdp_account.arn
   name                     = "COAT to APDP"
   source_location_arn      = aws_datasync_location_s3.root_account.arn
-
-  cloudwatch_log_group_arn = module.datasync_events_log_group.cloudwatch_log_group_arn
-
-  options {
-    log_level         = "BASIC"
-    posix_permissions = "NONE"
-    uid               = "NONE"
-    gid               = "NONE"
-  }
+  task_mode                = "ENHANCED"
 }

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
@@ -81,23 +81,6 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "arn:aws:kms:eu-west-1:593291632749:key/*" #TODO: Update call
     ]
   }
-
-  statement {
-    sid    = "CloudWatchLogsPermissions"
-    effect = "Allow"
-    actions = [
-      "logs:CreateLogStream",
-      "logs:PutLogEvents",
-      "logs:DescribeLogStreams",
-      "logs:CreateLogGroup",
-      "logs:DeleteLogGroup"
-    ]
-    resources = [
-      "${module.datasync_events_log_group.cloudwatch_log_group_arn}",
-      "${module.datasync_events_log_group.cloudwatch_log_group_arn}:*",
-      "${module.datasync_events_log_group.cloudwatch_log_group_arn}/*"
-    ]
-  }
 }
 
 module "coat_datasync_iam_policy" {

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
@@ -1,6 +1,6 @@
 data "aws_iam_policy_document" "coat_datasync_iam_policy" {
   statement {
-    sid    = "coat-datasync-dms-permissions"
+    sid    = "CoatDatasyncDmsPermissions"
     effect = "Allow"
     actions = [
       "dms:DescribeEndpoints",
@@ -13,7 +13,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
   }
 
   statement {
-    sid    = "coat-datasync-s3-bucket-permissions"
+    sid    = "CoatDatasyncS3BucketPermissions"
     effect = "Allow"
     actions = [
       "s3:GetBucketLocation",
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "s3:ListBucketMultipartUploads",
     ]
     resources = [
-      "arn:aws:s3:::<DESTINATION_BUCKET_NAME>"
+      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly"
     ]
     condition {
       test     = "StringEquals"
@@ -31,7 +31,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
   }
 
   statement {
-    sid    = "coat-datasync-s3-object-permissions"
+    sid    = "CoatDatasyncS3ObjectPermissions"
     effect = "Allow"
     actions = [
       "s3:AbortMultipartUpload",
@@ -45,7 +45,7 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "s3:PutObjectTagging",
     ]
     resources = [
-      "arn:aws:s3:::<DESTINATION_BUCKET_NAME>/*"
+      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly/*"
     ]
     condition {
       test     = "StringEquals"

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
@@ -1,0 +1,68 @@
+data "aws_iam_policy_document" "coat_datasync_iam_policy" {
+  statement {
+    sid    = "coat-datasync-dms-permissions"
+    effect = "Allow"
+    actions = [
+      "dms:DescribeEndpoints",
+      "dms:DescribeReplicationInstances",
+      "dms:DescribeReplicationTasks",
+      "dms:StartReplicationTask",
+      "dms:StopReplicationTask",
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "coat-datasync-s3-bucket-permissions"
+    effect = "Allow"
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+    ]
+    resources = [
+      "arn:aws:s3:::<DESTINATION_BUCKET_NAME>"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceAccount"
+      values   = [data.aws_caller_identity.session.account_id]
+    }
+  }
+
+  statement {
+    sid    = "coat-datasync-s3-object-permissions"
+    effect = "Allow"
+    actions = [
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:GetObjectTagging",
+      "s3:GetObjectVersion",
+      "s3:GetObjectVersionTagging",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:PutObjectTagging",
+    ]
+    resources = [
+      "arn:aws:s3:::<DESTINATION_BUCKET_NAME>/*"
+    ]
+    condition {
+      test     = "StringEquals"
+      variable = "aws:ResourceAccount"
+      values   = ["123456789012"]
+    }
+  }
+}
+
+module "coat_datasync_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.2.1"
+
+  name_prefix = "coat-datasync-iam-policy"
+
+  policy = data.aws_iam_policy_document.coat_datasync_iam_policy.json
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
@@ -21,12 +21,12 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "s3:ListBucketMultipartUploads",
     ]
     resources = [
-      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly"
+      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly" #TODO: Update call
     ]
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceAccount"
-      values   = [data.aws_caller_identity.session.account_id]
+      values   = ["593291632749"] #TODO: Update call
     }
   }
 
@@ -45,12 +45,12 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "s3:PutObjectTagging",
     ]
     resources = [
-      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly/*"
+      "arn:aws:s3:::mojap-data-production-coat-cur-reports-v2-hourly/*" #TODO: Update call
     ]
     condition {
       test     = "StringEquals"
       variable = "aws:ResourceAccount"
-      values   = ["123456789012"]
+      values   = ["593291632749"] #TODO: Update
     }
   }
 }

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
@@ -53,6 +53,34 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       values   = ["593291632749"] #TODO: Update
     }
   }
+
+  statement {
+    sid    = "SourceKeyPermissions"
+    effect = "Allow"
+    actions = [
+      "kms:Decrypt",
+      "kms:DescribeKey",
+      "kms:GenerateDataKey",
+    ]
+    resources = [
+      module.coat_kms.key_arn
+    ]
+  }
+
+  statement {
+    sid    = "DestinationKeyPermissions"
+    effect = "Allow"
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+    resources = [
+      "arn:aws:kms:eu-west-1:593291632749:key/*" #TODO: Update call
+    ]
+  }
 }
 
 module "coat_datasync_iam_policy" {

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-policies.tf
@@ -81,6 +81,23 @@ data "aws_iam_policy_document" "coat_datasync_iam_policy" {
       "arn:aws:kms:eu-west-1:593291632749:key/*" #TODO: Update call
     ]
   }
+
+  statement {
+    sid    = "CloudWatchLogsPermissions"
+    effect = "Allow"
+    actions = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents",
+      "logs:DescribeLogStreams",
+      "logs:CreateLogGroup",
+      "logs:DeleteLogGroup"
+    ]
+    resources = [
+      "${module.datasync_events_log_group.cloudwatch_log_group_arn}",
+      "${module.datasync_events_log_group.cloudwatch_log_group_arn}:*",
+      "${module.datasync_events_log_group.cloudwatch_log_group_arn}/*"
+    ]
+  }
 }
 
 module "coat_datasync_iam_policy" {

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-roles.tf
@@ -1,0 +1,31 @@
+
+module "coat_datasync_iam_role" {
+  #checkov:skip=CKV_TF_1:Module is from Terraform registry
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.2.1"
+
+  name            = "coat-datasync-iam-role"
+  use_name_prefix = false
+
+  trust_policy_permissions = {
+    DataSync = {
+      actions = [
+        "sts:AssumeRole",
+      ]
+      principals = concat(
+        [
+          {
+            type        = "Service"
+            identifiers = ["datasync.amazonaws.com"]
+          }
+        ]
+      )
+    }
+  }
+
+  policies = {
+    custom = module.coat_datasync_iam_policy.arn
+  }
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/iam-roles.tf
@@ -1,4 +1,3 @@
-
 module "coat_datasync_iam_role" {
   #checkov:skip=CKV_TF_1:Module is from Terraform registry
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/kms.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/kms.tf
@@ -5,7 +5,7 @@ module "coat_kms" {
   source  = "terraform-aws-modules/kms/aws"
   version = "4.0.0"
 
-  aliases               = ["s3/coat-testing-bucket-"]
+  aliases               = ["s3/coat-testing-bucket"]
   enable_default_policy = true
   #   key_statements = [
   #     {

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/kms.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/kms.tf
@@ -1,0 +1,28 @@
+module "coat_kms" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/kms/aws"
+  version = "4.0.0"
+
+  aliases               = ["s3/coat-testing-bucket-"]
+  enable_default_policy = true
+  #   key_statements = [
+  #     {
+  #       sid = "AllowReplicationRole"
+  #       actions = [
+  #         "kms:Encrypt",
+  #         "kms:GenerateDataKey"
+  #       ]
+  #       resources = ["*"]
+  #       effect    = "Allow"
+  #       principals = [
+  #         {
+  #           type        = "AWS"
+  #           identifiers = [local.source_replication_role]
+  #         }
+  #       ]
+  #     }
+  #   ]
+  deletion_window_in_days = 7
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/s3-buckets.tf
@@ -1,3 +1,33 @@
+data "aws_iam_policy_document" "coat_bucket_policy" {
+  statement {
+    sid    = "DataSyncCreateS3LocationAndTaskAccess"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::684969100054:role/coat-datasync-iam-role"] #TODO: Change this in the root account implementation
+    }
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
+    ]
+
+    resources = [
+      "arn:aws:s3:::coat-testing-bucket",  #TODO: Update call
+      "arn:aws:s3:::coat-testing-bucket/*" #TODO: Update call
+    ]
+  }
+}
+
 #trivy:ignore:AVD-AWS-0089:Bucket logging not enabled currently
 module "coat_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
@@ -14,8 +44,8 @@ module "coat_s3" {
     enabled = true
   }
 
-  # attach_policy = true
-  # policy        = data.aws_iam_policy_document.coat_bucket_policy.json
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.coat_bucket_policy.json
 
   server_side_encryption_configuration = {
     bucket_key_enabled = true

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/s3-buckets.tf
@@ -1,0 +1,29 @@
+#trivy:ignore:AVD-AWS-0089:Bucket logging not enabled currently
+module "coat_s3" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "5.6.0"
+
+  bucket = "coat-testing-bucket"
+
+  force_destroy = true
+
+  versioning = {
+    enabled = true
+  }
+
+  # attach_policy = true
+  # policy        = data.aws_iam_policy_document.coat_bucket_policy.json
+
+  server_side_encryption_configuration = {
+    bucket_key_enabled = true
+    rule = {
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.coat_kms.key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/terraform.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/terraform.tf
@@ -1,0 +1,42 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.10.0"
+    }
+  }
+  required_version = "~> 1.10"
+}
+
+provider "aws" {
+  alias = "session"
+}
+
+provider "aws" {
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/terraform.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/terraform.tf
@@ -40,3 +40,14 @@ provider "aws" {
     tags = var.tags
   }
 }
+
+provider "aws" {
+  alias  = "analytical-platform-data-production-eu-west-1"
+  region = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/terraform.tfvars
@@ -6,6 +6,7 @@ account_ids = {
   analytical-platform-data-engineering-sandbox-a = "684969100054"
   analytical-platform-management-production      = "042130406152"
   analytical-platform-compute-production         = "992382429243"
+  analytical-platform-data-production            = "593291632749"
 
 }
 

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/terraform.tfvars
@@ -1,0 +1,21 @@
+##################################################
+# General
+##################################################
+
+account_ids = {
+  analytical-platform-data-engineering-sandbox-a = "684969100054"
+  analytical-platform-management-production      = "042130406152"
+  analytical-platform-compute-production         = "992382429243"
+
+}
+
+tags = {
+  business-unit          = "Central Digital"
+  application            = "Analytical Platform"
+  component              = "COAT DataSync Testing"
+  environment            = "sandbox"
+  is-production          = "false"
+  owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/analytical-platform/tree/main/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing"
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/variables.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/coat-datasync-testing/variables.tf
@@ -1,0 +1,13 @@
+##################################################
+# General
+##################################################
+
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}

--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -60,7 +60,6 @@ module "coat_s3" {
   acl              = "private"             # Ensures no public ACLs are applied
   object_ownership = "BucketOwnerEnforced" # Disables ACLs
 
-
   versioning = {
     enabled = true
   }

--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -15,6 +15,34 @@ data "aws_iam_policy_document" "coat_bucket_policy" {
     ]
     resources = ["arn:aws:s3:::${local.bucket_name}/*"]
   }
+
+  statement {
+    sid    = "DataSyncCreateS3LocationAndTaskAccess"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::684969100054:role/coat-datasync-iam-role"] #TODO: Change this in the root account implementation
+    }
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.bucket_name}",
+      "arn:aws:s3:::${local.bucket_name}/*"
+    ]
+  }
 }
 
 #trivy:ignore:AVD-AWS-0089:Bucket logging not enabled currently
@@ -23,11 +51,15 @@ module "coat_s3" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.6.0"
+  version = "5.7.0"
 
   bucket = local.bucket_name
 
   force_destroy = true
+
+  acl              = "private"             # Ensures no public ACLs are applied
+  object_ownership = "BucketOwnerEnforced" # Disables ACLs
+
 
   versioning = {
     enabled = true


### PR DESCRIPTION
This PR is related to [this](https://github.com/orgs/ministryofjustice/projects/27/views/18?pane=issue&itemId=124508041&issue=ministryofjustice%7Canalytical-platform%7C8496) piece of work. I wanted to simulate S3 to S3 datasync. This method allows me to test fully without pestering the admins of the root account.

> [!WARNING]  
> 🚧  I've hardcoded stuff that won't be hardcoded in production. 

 > [!NOTE]  
> This PR specifically relates to resources in the Sandbox account. The PR for APDP is [here](https://github.com/ministryofjustice/analytical-platform/pull/8687).

Source: Sandbox account
Destination: APDP

📝  Instructions [here](https://docs.aws.amazon.com/datasync/latest/userguide/tutorial_s3-s3-cross-account-transfer.html).



~I've hit an issue whereby the `aws_datasync_location_s3` resource expects an IAM role in the destination, though this isn't specified in the instructions from what I can see. So I need to do some research there.~ I believe the same role should be specified in both the source and destination.