### PR TITLE
🔑   Permit COAT DataSync role to access KMS key

### DIFF
--- a/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
@@ -22,6 +22,26 @@ module "coat_kms" {
           identifiers = [local.source_replication_role]
         }
       ]
+    },
+    {
+      sid = "AllowDataSyncRole"
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type = "AWS"
+          identifiers = [
+            "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/coat-datasync-iam-role"
+          ]
+        }
+      ]
     }
   ]
   deletion_window_in_days = 7

--- a/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
@@ -8,21 +8,21 @@ module "coat_kms" {
   aliases               = ["s3/${local.bucket_name}"]
   enable_default_policy = true
   key_statements = [
-    # {
-    #   sid = "AllowReplicationRole"
-    #   actions = [
-    #     "kms:Encrypt",
-    #     "kms:GenerateDataKey"
-    #   ]
-    #   resources = ["*"]
-    #   effect    = "Allow"
-    #   principals = [
-    #     {
-    #       type        = "AWS"
-    #       identifiers = [local.source_replication_role]
-    #     }
-    #   ]
-    # },
+    {
+      sid = "AllowReplicationRole"
+      actions = [
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = [local.source_replication_role]
+        }
+      ]
+    },
     {
       sid = "AllowDataSyncRole"
       actions = [

--- a/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
@@ -8,21 +8,21 @@ module "coat_kms" {
   aliases               = ["s3/${local.bucket_name}"]
   enable_default_policy = true
   key_statements = [
-    {
-      sid = "AllowReplicationRole"
-      actions = [
-        "kms:Encrypt",
-        "kms:GenerateDataKey"
-      ]
-      resources = ["*"]
-      effect    = "Allow"
-      principals = [
-        {
-          type        = "AWS"
-          identifiers = [local.source_replication_role]
-        }
-      ]
-    },
+    # {
+    #   sid = "AllowReplicationRole"
+    #   actions = [
+    #     "kms:Encrypt",
+    #     "kms:GenerateDataKey"
+    #   ]
+    #   resources = ["*"]
+    #   effect    = "Allow"
+    #   principals = [
+    #     {
+    #       type        = "AWS"
+    #       identifiers = [local.source_replication_role]
+    #     }
+    #   ]
+    # },
     {
       sid = "AllowDataSyncRole"
       actions = [

--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -1,19 +1,46 @@
 data "aws_iam_policy_document" "coat_bucket_policy" {
+  # statement {
+  #   sid    = "AllowReplicationRole"
+  #   effect = "Allow"
+  #   principals {
+  #     type        = "AWS"
+  #     identifiers = [local.source_replication_role]
+  #   }
+  #   actions = [
+  #     "s3:GetObjectVersionTagging",
+  #     "s3:ObjectOwnerOverrideToBucketOwner",
+  #     "s3:ReplicateDelete",
+  #     "s3:ReplicateObject",
+  #     "s3:ReplicateTags"
+  #   ]
+  #   resources = ["arn:aws:s3:::${local.bucket_name}/*"]
+  # }
   statement {
-    sid    = "AllowReplicationRole"
+    sid    = "DataSyncCreateS3LocationAndTaskAccess"
     effect = "Allow"
+
     principals {
       type        = "AWS"
-      identifiers = [local.source_replication_role]
+      identifiers = ["arn:aws:iam::684969100054:role/coat-datasync-iam-role"] #TODO: Change this in the root account implementation
     }
+
     actions = [
-      "s3:GetObjectVersionTagging",
-      "s3:ObjectOwnerOverrideToBucketOwner",
-      "s3:ReplicateDelete",
-      "s3:ReplicateObject",
-      "s3:ReplicateTags"
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
     ]
-    resources = ["arn:aws:s3:::${local.bucket_name}/*"]
+
+    resources = [
+      "arn:aws:s3:::${local.bucket_name}",
+      "arn:aws:s3:::${local.bucket_name}/*"
+    ]
   }
 }
 

--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -1,20 +1,20 @@
 data "aws_iam_policy_document" "coat_bucket_policy" {
-  # statement {
-  #   sid    = "AllowReplicationRole"
-  #   effect = "Allow"
-  #   principals {
-  #     type        = "AWS"
-  #     identifiers = [local.source_replication_role]
-  #   }
-  #   actions = [
-  #     "s3:GetObjectVersionTagging",
-  #     "s3:ObjectOwnerOverrideToBucketOwner",
-  #     "s3:ReplicateDelete",
-  #     "s3:ReplicateObject",
-  #     "s3:ReplicateTags"
-  #   ]
-  #   resources = ["arn:aws:s3:::${local.bucket_name}/*"]
-  # }
+  statement {
+    sid    = "AllowReplicationRole"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = [local.source_replication_role]
+    }
+    actions = [
+      "s3:GetObjectVersionTagging",
+      "s3:ObjectOwnerOverrideToBucketOwner",
+      "s3:ReplicateDelete",
+      "s3:ReplicateObject",
+      "s3:ReplicateTags"
+    ]
+    resources = ["arn:aws:s3:::${local.bucket_name}/*"]
+  }
   statement {
     sid    = "DataSyncCreateS3LocationAndTaskAccess"
     effect = "Allow"

--- a/terraform/aws/analytical-platform-data-production/coat-integration/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/terraform.tfvars
@@ -1,6 +1,7 @@
 account_ids = {
-  analytical-platform-data-production       = "593291632749"
-  analytical-platform-management-production = "042130406152"
+  analytical-platform-data-production            = "593291632749"
+  analytical-platform-management-production      = "042130406152"
+  analytical-platform-data-engineering-sandbox-a = "684969100054"
 }
 
 tags = {


### PR DESCRIPTION
This PR relates to [this](https://github.com/orgs/ministryofjustice/projects/27?pane=issue&itemId=124508041&issue=ministryofjustice%7Canalytical-platform%7C8496) piece of work. 

Work relating to the configuration of APDP resources alone is contained in this PR.

The PR: 
- updates the KMS key to allow the role in Sandbox (to be root account in finality) to consume the key