### PR TITLE
:wrench: Add `mojap-land/corporate/epm/` subdirectory to `AllowAnalyticalPlatform` policy

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -567,7 +567,8 @@ locals {
                 "arn:aws:s3:::mojap-land/sscl/sscl_data_dump/*",
                 "arn:aws:s3:::mojap-land/cps/*",
                 "arn:aws:s3:::mojap-land/property/planetfm/backupfiles/*",
-                "arn:aws:s3:::mojap-land/opg/prod/ocr/*"
+                "arn:aws:s3:::mojap-land/opg/prod/ocr/*",
+                "arn:aws:s3:::mojap-land/corporate/epm/*"
               ]
             },
             {


### PR DESCRIPTION
This PR is related to [this](https://github.com/orgs/ministryofjustice/projects/27/views/18?pane=issue&itemId=110836248&issue=ministryofjustice%7Canalytical-platform%7C7760) piece of work.