### PR TITLE
:wrench: Permit access to S3 + KMS

### DIFF
--- a/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
@@ -22,6 +22,26 @@ module "coat_kms" {
           identifiers = [local.source_replication_role]
         }
       ]
+    },
+    {
+      sid = "AllowDataSyncRole"
+      actions = [
+        "kms:Encrypt",
+        "kms:Decrypt",
+        "kms:ReEncrypt*",
+        "kms:GenerateDataKey*",
+        "kms:DescribeKey"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type = "AWS"
+          identifiers = [
+            "arn:aws:iam::295814833350:role/coat-datasync"
+          ]
+        }
+      ]
     }
   ]
   deletion_window_in_days = 7

--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -15,6 +15,34 @@ data "aws_iam_policy_document" "coat_bucket_policy" {
     ]
     resources = ["arn:aws:s3:::${local.bucket_name}/*"]
   }
+
+  statement {
+    sid    = "DataSyncCreateS3LocationAndTaskAccess"
+    effect = "Allow"
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::295814833350:role/coat-datasync"]
+    }
+
+    actions = [
+      "s3:GetBucketLocation",
+      "s3:ListBucket",
+      "s3:ListBucketMultipartUploads",
+      "s3:AbortMultipartUpload",
+      "s3:DeleteObject",
+      "s3:GetObject",
+      "s3:ListMultipartUploadParts",
+      "s3:PutObject",
+      "s3:GetObjectTagging",
+      "s3:PutObjectTagging",
+    ]
+
+    resources = [
+      "arn:aws:s3:::${local.bucket_name}",
+      "arn:aws:s3:::${local.bucket_name}/*"
+    ]
+  }
 }
 
 #trivy:ignore:AVD-AWS-0089:Bucket logging not enabled currently


### PR DESCRIPTION
This PR duplicates work done [here](https://github.com/ministryofjustice/analytical-platform/pull/8687/files) but relates to the root account permissions instead of those used in testing in the sandbox account. 