### PR TITLE
Switch from Data Platform Robot's PAT to Fine Grained Token

### DIFF
--- a/.github/workflows/repository-dependabot-configuration-generator.yml
+++ b/.github/workflows/repository-dependabot-configuration-generator.yml
@@ -45,4 +45,4 @@ jobs:
           repo: ${{ github.repository }}
           branch: ${{ github.head_ref || github.ref_name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.DATA_PLATFORM_ROBOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.AP_DEPENDABOT_COMMIT_TOKEN }}


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/5) GitHub Issue.

Switching to fine grained token restricted to this repository as the curent Data Platform Robot's PAT  is highly empowered. 
