### PR TITLE
Switch token from DATA_PLATFORM_ROBOT_TOKEN to GITHUB_TOKEN

### DIFF
--- a/.github/workflows/repository-openssf-scorecard.yml
+++ b/.github/workflows/repository-openssf-scorecard.yml
@@ -28,7 +28,7 @@ jobs:
         id: run_analysis
         uses: ossf/scorecard-action@05b42c624433fc40578a4040d5cf5e36ddca8cde # v2.4.2
         with:
-          repo_token: ${{ secrets.DATA_PLATFORM_ROBOT_TOKEN }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
           results_file: results.sarif
           results_format: sarif
           publish_results: true


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/5) GitHub Issue.

The step `Run analysis` was using the `DATA_PLATFORM_ROBOT_TOKEN` but does not need to, so switching to the `GITHUB_TOKEN`