### PR TITLE
:wrench: COAT: Remove DataSync (root account) references

### DIFF
--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -15,34 +15,6 @@ data "aws_iam_policy_document" "coat_bucket_policy" {
     ]
     resources = ["arn:aws:s3:::${local.bucket_name}/*"]
   }
-
-  statement {
-    sid    = "DataSyncCreateS3LocationAndTaskAccess"
-    effect = "Allow"
-
-    principals {
-      type        = "AWS"
-      identifiers = ["arn:aws:iam::295814833350:role/coat-datasync"]
-    }
-
-    actions = [
-      "s3:GetBucketLocation",
-      "s3:ListBucket",
-      "s3:ListBucketMultipartUploads",
-      "s3:AbortMultipartUpload",
-      "s3:DeleteObject",
-      "s3:GetObject",
-      "s3:ListMultipartUploadParts",
-      "s3:PutObject",
-      "s3:GetObjectTagging",
-      "s3:PutObjectTagging",
-    ]
-
-    resources = [
-      "arn:aws:s3:::${local.bucket_name}",
-      "arn:aws:s3:::${local.bucket_name}/*"
-    ]
-  }
 }
 
 #trivy:ignore:AVD-AWS-0089:Bucket logging not enabled currently


### PR DESCRIPTION
This PR is akin to [this](https://github.com/ministryofjustice/aws-root-account/pull/1327) PR in the root account. It removes references to DataSync which existed in the root account but no longer does. 