### PR TITLE
Add new dir for code to create AWS secret

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,6 +85,7 @@ updates:
       - "terraform/aws/analytical-platform-development/auth0-log-streams"
       - "terraform/aws/analytical-platform-development/control-panel-message-broker"
       - "terraform/aws/analytical-platform-development/tooling-iam"
+      - "terraform/aws/analytical-platform-management-production/aws-secrets-manager"
       - "terraform/aws/analytical-platform-management-production/terraform-state"
       - "terraform/aws/analytical-platform-production/route53"
       - "terraform/aws/analytical-platform/baseline"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -85,7 +85,6 @@ updates:
       - "terraform/aws/analytical-platform-development/auth0-log-streams"
       - "terraform/aws/analytical-platform-development/control-panel-message-broker"
       - "terraform/aws/analytical-platform-development/tooling-iam"
-      - "terraform/aws/analytical-platform-management-production/aws-secrets-manager"
       - "terraform/aws/analytical-platform-management-production/terraform-state"
       - "terraform/aws/analytical-platform-production/route53"
       - "terraform/aws/analytical-platform/baseline"

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/.terraform.lock.hcl
@@ -1,0 +1,48 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.14.1"
+  constraints = "6.14.1"
+  hashes = [
+    "h1:zhJy/Td/sbOHJ4SuxGYH8PCbTd+KCapfeDD/7Swd6SY=",
+    "zh:14d0b4b3dffb3368e6257136bbab1f93d419863dd65d99ef80ca2c1dd3c72a1e",
+    "zh:1de3601251f87a0a989c4b3474baa2efcaf491804f8d7afe15421b728bac5dc5",
+    "zh:2cfe42b853a3b4117bdbb73e5715035eac9b8d753d6e653fd5f30a807a36b985",
+    "zh:3dd8a0336face356928faf2396065634739ef2c3ac3dcaa655570df205559fd9",
+    "zh:42712baca386b84e089b1db8b7844038557f4039b32d8702611aa67eadef7d0f",
+    "zh:4ffc698099e4d7ffc6b0490a4e78ad66b041afd54e988b8bf8e229bcdd4b3ead",
+    "zh:52a6a3b01cb34394b0d06b273b27702fb9d795290a02e5824e198315787e8446",
+    "zh:56eae388c48a844401e44811719dc23be84de538468fd12b7265b06acbf4b51d",
+    "zh:614a918fdf27416b2ee2ce1737895b791f59f9deff3b61246c62a992eabfb8eb",
+    "zh:68605e159177b57fdc4a26bb2caff69a7b69593a601145b7ab5a86fd44b28b9f",
+    "zh:771ac00fd5f211052d735ff0e4b9ec67288abd1e22ffea4ed774aec73c7e5687",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a1355841161e5b53dc3078c88aae1972fd4a9c0d30309b18b1951137b96571fa",
+    "zh:a3c8ca40c1fa7ad76d3d4c3c0039b66a93cc96399e757d2caa0b5cdedce9d3e8",
+    "zh:c77e02a72ef9eb0eb65faaf84c33af843520622dbb51ec31d04ca371bd4d4ee8",
+  ]
+}
+
+provider "registry.terraform.io/integrations/github" {
+  version     = "6.6.0"
+  constraints = "6.6.0"
+  hashes = [
+    "h1:Fp0RrNe+w167AQkVUWC1WRAsyjhhHN7aHWUky7VkKW8=",
+    "zh:0b1b5342db6a17de7c71386704e101be7d6761569e03fb3ff1f3d4c02c32d998",
+    "zh:2fb663467fff76852126b58315d9a1a457e3b04bec51f04bf1c0ddc9dfbb3517",
+    "zh:4183e557a1dfd413dae90ca4bac37dbbe499eae5e923567371f768053f977800",
+    "zh:48b2979f88fb55cdb14b7e4c37c44e0dfbc21b7a19686ce75e339efda773c5c2",
+    "zh:5d803fb06625e0bcf83abb590d4235c117fa7f4aa2168fa3d5f686c41bc529ec",
+    "zh:6f1dd094cbab36363583cda837d7ca470bef5f8abf9b19f23e9cd8b927153498",
+    "zh:772edb5890d72b32868f9fdc0a9a1d4f4701d8e7f8acb37a7ac530d053c776e3",
+    "zh:798f443dbba6610431dcef832047f6917fb5a4e184a3a776c44e6213fb429cc6",
+    "zh:cc08dfcc387e2603f6dbaff8c236c1254185450d6cadd6bad92879fe7e7dbce9",
+    "zh:d5e2c8d7f50f91d6847ddce27b10b721bdfce99c1bbab42a68fa271337d73d63",
+    "zh:e69a0045440c706f50f84a84ff8b1df520ec9bf757de4b8f9959f2ed20c3f440",
+    "zh:efc5358573a6403cbea3a08a2fcd2407258ac083d9134c641bdcb578966d8bdf",
+    "zh:f627a255e5809ec2375f79949c79417847fa56b9e9222ea7c45a463eb663f137",
+    "zh:f7c02f762e4cf1de7f58bde520798491ccdd54a5bd52278d579c146d1d07d4f0",
+    "zh:fbd1fee2c9df3aa19cf8851ce134dea6e45ea01cb85695c1726670c285797e25",
+  ]
+}

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/data.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/data.tf
@@ -1,0 +1,14 @@
+##################################################
+# AWS
+##################################################
+
+# Calling session
+data "aws_caller_identity" "session" {
+  provider = aws.session
+}
+
+data "aws_iam_session_context" "session" {
+  provider = aws.session
+
+  arn = data.aws_caller_identity.session.arn
+}

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/main.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/main.tf
@@ -1,0 +1,8 @@
+#tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
+resource "aws_secretsmanager_secret" "ap_github_token" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
+  name        = "ap-github-token"
+  description = "Fine grained PAT for use in AP"
+  kms_key_id  = "alias/aws/secretsmanager"
+}

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
@@ -44,8 +44,3 @@ provider "aws" {
     tags = var.tags
   }
 }
-
-provider "github" {
-  token = data.aws_secretsmanager_secret_version.github_token.secret_string
-  owner = "ministryofjustice"
-}

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
@@ -26,7 +26,6 @@ provider "aws" {
 }
 
 provider "aws" {
-  alias  = "analytical-platform-management-production"
   region = "eu-west-2"
   assume_role {
     role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
@@ -35,16 +34,15 @@ provider "aws" {
     tags = var.tags
   }
 }
-
-provider "aws" {
-  alias  = "analytical-platform-management-production-eu-west-1"
-  region = "eu-west-1"
-  assume_role {
-    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
-  }
-  default_tags {
-    tags = var.tags
-  }
+  provider "aws" {
+    alias  = "analytical-platform-management-production"
+    region = "eu-west-2"
+    assume_role {
+      role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+    }
+    default_tags {
+      tags = var.tags
+    }
 }
 
 provider "github" {

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
@@ -1,0 +1,53 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-management-production/aws-secrets-manager/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.14.1"
+    }
+    github = {
+      source  = "integrations/github"
+      version = "6.6.0"
+    }
+  }
+  required_version = "~> 1.11"
+}
+
+provider "aws" {
+  alias = "session"
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "aws" {
+  alias  = "analytical-platform-management-production-eu-west-1"
+  region = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+provider "github" {
+  token = data.aws_secretsmanager_secret_version.github_token.secret_string
+  owner = "ministryofjustice"
+}

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
@@ -34,15 +34,15 @@ provider "aws" {
     tags = var.tags
   }
 }
-  provider "aws" {
-    alias  = "analytical-platform-management-production"
-    region = "eu-west-2"
-    assume_role {
-      role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
-    }
-    default_tags {
-      tags = var.tags
-    }
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
 }
 
 provider "github" {

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tfvars
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tfvars
@@ -1,0 +1,14 @@
+account_ids = {
+  analytical-platform-management-production = "042130406152"
+}
+
+tags = {
+  business-unit          = "Central Digital"
+  application            = "Analytical Platform"
+  component              = "Secret Manager"
+  environment            = "production"
+  is-production          = "true"
+  owner                  = "analytical-platform:analytical-platform@justice.gov.uk"
+  infrastructure-support = "analytical-platform:analytical-platform@justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/analytical-platform/terraform/aws/analytical-platform-management-production/aws-secrets-manager"
+}

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/variables.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/variables.tf
@@ -1,0 +1,9 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}


### PR DESCRIPTION
# Pull Request Objective

This is a new branch and PR as weird commits appearing in previous PR

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/5) GitHub Issue.

This will create a AWS Secret in which we can store the new token, replacing the Data Platform Robot's PAT token.

This will be used by both Grafana and Observability 