### PR TITLE
dmet-prisons - turn off old LF shares

### DIFF
--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/main.tf
@@ -1,13 +1,13 @@
-# Module: lake_formation_analytical_platform_data_prod
-module "lake_formation_analytical_platform_data_prod" {
-  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=6fab8677e457c2e276fa1feec8ee83bbccc1220a"
+# # Module: lake_formation_analytical_platform_data_prod
+# module "lake_formation_analytical_platform_data_prod" {
+#   source = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=6fab8677e457c2e276fa1feec8ee83bbccc1220a"
 
 
-  providers = {
-    aws.source      = aws.digital_prisons_reporting_preprod_eu_west_2
-    aws.destination = aws
-  }
+#   providers = {
+#     aws.source      = aws.digital_prisons_reporting_preprod_eu_west_2
+#     aws.destination = aws
+#   }
 
-  data_locations     = local.data_locations
-  databases_to_share = local.databases
-}
+#   data_locations     = local.data_locations
+#   databases_to_share = local.databases
+# }

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-preproduction/terraform.tf
@@ -27,7 +27,7 @@ provider "aws" {
   alias  = "digital_prisons_reporting_preprod_eu_west_2"
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.account_ids["digital-prisons-reporting-preproduction"]}:role/analytical-platform-data-production-share-role"
+    role_arn = "arn:aws:iam::${local.account_ids["digital-prison-reporting-preproduction"]}:role/analytical-platform-data-production-share-role"
   }
   default_tags {
     tags = var.tags

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-production/main.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-production/main.tf
@@ -1,13 +1,13 @@
-# Module: lake_formation_analytical_platform_data_prod
-module "lake_formation_analytical_platform_data_prod" {
-  source = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=6fab8677e457c2e276fa1feec8ee83bbccc1220a"
+# # Module: lake_formation_analytical_platform_data_prod
+# module "lake_formation_analytical_platform_data_prod" {
+#   source = "github.com/ministryofjustice/terraform-aws-analytical-platform-lakeformation?ref=6fab8677e457c2e276fa1feec8ee83bbccc1220a"
 
 
-  providers = {
-    aws.source      = aws.digital_prisons_reporting_prod_eu_west_2
-    aws.destination = aws
-  }
+#   providers = {
+#     aws.source      = aws.digital_prisons_reporting_prod_eu_west_2
+#     aws.destination = aws
+#   }
 
-  data_locations     = local.data_locations
-  databases_to_share = local.databases
-}
+#   data_locations     = local.data_locations
+#   databases_to_share = local.databases
+# }

--- a/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-production/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/lakeformation-external-data/digital-prisons-reporting-production/terraform.tf
@@ -27,7 +27,7 @@ provider "aws" {
   alias  = "digital_prisons_reporting_prod_eu_west_2"
   region = "eu-west-2"
   assume_role {
-    role_arn = "arn:aws:iam::${local.account_ids["digital-prisons-reporting-production"]}:role/analytical-platform-data-production-share-role"
+    role_arn = "arn:aws:iam::${local.account_ids["digital-prison-reporting-production"]}:role/analytical-platform-data-production-share-role"
   }
   default_tags {
     tags = var.tags


### PR DESCRIPTION
# Pull Request Objective

Old Lakeformation shares were created in August 2024.  These are being replaced by data-engineerign-datalake-access: https://github.com/moj-analytical-services/data-engineering-datalake-access

I think the retention of these 'shares' is causing some unexpected behaviour in the tag based cross-account shares I'm setting up

## Checklist

The [terraform plan](https://github.com/ministryofjustice/analytical-platform/actions/runs/18341412467/job/52237666027) looks good to me (destroying resources)

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

None, thanks