### PR TITLE
Drop secret  in prep for move to eu-west-1

### DIFF
--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -1,6 +1,6 @@
 #tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
 resource "aws_secretsmanager_secret" "analytical_platform_github_token" {
-  provider    = aws.analytical-platform-management-production-eu-west-1
+  provider = aws.analytical-platform-management-production-eu-west-1
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   name        = "analytical-platform-github-token"

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -1,9 +1,9 @@
-#tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
-resource "aws_secretsmanager_secret" "analytical_platform_github_token" {
-  provider = aws.analytical-platform-management-production-eu-west-1
-  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
-  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
-  name        = "analytical-platform-github-token"
-  description = "Fine grained PAT for use in Analytical Platform"
-  kms_key_id  = "alias/aws/secretsmanager"
-}
+# #tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
+# resource "aws_secretsmanager_secret" "analytical_platform_github_token" {
+#   provider = aws.analytical-platform-management-production-eu-west-1
+#   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+#   #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
+#   name        = "analytical-platform-github-token"
+#   description = "Fine grained PAT for use in Analytical Platform"
+#   kms_key_id  = "alias/aws/secretsmanager"
+# }

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -1,5 +1,6 @@
 #tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
 resource "aws_secretsmanager_secret" "analytical_platform_github_token" {
+  provider    = aws.analytical-platform-management-production-eu-west-1
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   name        = "analytical-platform-github-token"

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tf
@@ -44,3 +44,14 @@ provider "aws" {
     tags = var.tags
   }
 }
+
+provider "aws" {
+  alias  = "analytical-platform-management-production-eu-west-1"
+  region = "eu-west-1"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}


### PR DESCRIPTION
This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/5) GitHub Issue.

This will drop the  AWS Secret in eu-west-2  created in error  