### PR TITLE
Create AWS secret in eu-west-1

### DIFF
--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -1,9 +1,9 @@
-# #tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
-# resource "aws_secretsmanager_secret" "analytical_platform_github_token" {
-#   provider = aws.analytical-platform-management-production-eu-west-1
-#   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
-#   #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
-#   name        = "analytical-platform-github-token"
-#   description = "Fine grained PAT for use in Analytical Platform"
-#   kms_key_id  = "alias/aws/secretsmanager"
-# }
+#tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
+resource "aws_secretsmanager_secret" "analytical_platform_github_token" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
+  name        = "analytical-platform-github-token"
+  description = "Fine grained PAT for use in Analytical Platform"
+  kms_key_id  = "alias/aws/secretsmanager"
+}


### PR DESCRIPTION
This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/5) GitHub Issue.

This will create a AWS Secret in  eu-west-1 in which we can store the new token, replacing the Data Platform Robot's PAT token.

This will be used by both Grafana and Observability 
