### PR TITLE
switch to analytical-platform-github-token secret

### DIFF
--- a/terraform/cloud-platform/live/analytical-platform-development/grafana/data.tf
+++ b/terraform/cloud-platform/live/analytical-platform-development/grafana/data.tf
@@ -29,7 +29,7 @@ data "aws_secretsmanager_secret_version" "cloud_platform_live_analytical_platfor
 data "aws_secretsmanager_secret_version" "github_token" {
   provider = aws.analytical-platform-management-production-eu-west-1
 
-  secret_id = "github-token"
+  secret_id = "analytical-platform-github-token"
 }
 
 data "github_team" "analytical_platform_engineers" {


### PR DESCRIPTION
This pull request makes a small but important update to the secret configuration for the Grafana deployment in the Analytical Platform development environment. The change updates the `secret_id` used to fetch the GitHub token from AWS Secrets Manager to ensure it references the correct secret.

* Changed the `secret_id` in `data "aws_secretsmanager_secret_version" "github_token"` from `"github-token"` to `"analytical-platform-github-token"` in `terraform/cloud-platform/live/analytical-platform-development/grafana/data.tf`

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/5) GitHub Issue.
