### PR TITLE
Switch secret to analytical-platform-github-token

### DIFF
--- a/terraform/cloud-platform/live/analytical-platform-production/observability/data.tf
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/data.tf
@@ -29,7 +29,7 @@ data "aws_secretsmanager_secret_version" "cloud_platform_live_analytical_platfor
 data "aws_secretsmanager_secret_version" "github_token" {
   provider = aws.analytical-platform-management-production-eu-west-1
 
-  secret_id = "github-token"
+  secret_id = "analytical-platform-github-token"
 }
 
 data "github_team" "analytical_platform_engineers" {


### PR DESCRIPTION
This pull request makes a small update to the `data.tf` file for the analytical platform's observability infrastructure. The change updates the referenced AWS Secrets Manager secret to use a more specific secret ID.

- Changed the `secret_id` in the `aws_secretsmanager_secret_version.github_token` data source from `"github-token"` to `"analytical-platform-github-token"` to reference the correct secret.# Pull Request Objective

This piece of work is being tracked in this](https://github.com/ministryofjustice/analytical-platform/issues/5) GitHub Issue.

