### PR TITLE
Create AWS secret for MOJ Analytical Services token

### DIFF
--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -7,3 +7,13 @@ resource "aws_secretsmanager_secret" "analytical_platform_github_token" {
   description = "Fine grained PAT for use in Analytical Platform"
   kms_key_id  = "alias/aws/secretsmanager"
 }
+
+#tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
+resource "aws_secretsmanager_secret" "moj_analytical_services_github_token" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
+  name        = "moj-analytical-services-github-token-"
+  description = "Fine grained PAT for use in Analytical Platform for MOJ Analytical Services"
+  kms_key_id  = "alias/aws/secretsmanager"
+}

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -13,7 +13,8 @@ resource "aws_secretsmanager_secret" "moj_analytical_services_github_token" {
   provider = aws.analytical-platform-management-production-eu-west-1
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
-  name        = "moj-analytical-services-github-token-"
+  name        = "moj-analytical-services-github-token"
   description = "Fine grained PAT for use in Analytical Platform for MOJ Analytical Services"
   kms_key_id  = "alias/aws/secretsmanager"
 }
+


### PR DESCRIPTION
This pull request adds a new AWS Secrets Manager secret for MOJ Analytical Services to the Terraform configuration. The new secret is configured similarly to an existing secret, with explicit comments to skip certain security checks that are not required for this use case.

Secrets management:

* Added a new resource `aws_secretsmanager_secret.moj_analytical_services_github_token` in `secrets.tf` to store a fine-grained GitHub PAT for MOJ Analytical Services, including provider specification and description.

Security and compliance annotations:

* Included comments to skip tfsec and checkov checks for CMK encryption and automatic rotation, clarifying that these are not required for this secret.

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/5) GitHub Issue.