### PR TITLE
Implement temporary AWS transcribe access

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -79,6 +79,7 @@ updates:
       - "terraform/aws/analytical-platform-data-production/s3-glue-crawler"
       - "terraform/aws/analytical-platform-data-production/sagemaker-service"
       - "terraform/aws/analytical-platform-data-production/tooling-iam"
+      - "terraform/aws/analytical-platform-data-production/transcribe"
       - "terraform/aws/analytical-platform-development/auth0-log-streams"
       - "terraform/aws/analytical-platform-development/control-panel-message-broker"
       - "terraform/aws/analytical-platform-development/tooling-iam"

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/locals.tf
@@ -17,4 +17,11 @@ locals {
     formatlist("arn:aws:s3:::%s/*", var.data_buckets),
     formatlist("arn:aws:s3:::%s", var.data_buckets)
   )
+
+  transcribe_users = [
+    "alpha_user_rogerbrownmoj",
+    "alpha_user_laura-auburn",
+    "alpha_user_rob-mcnaughter"
+  ]
+
 }

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/transcribe-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/transcribe-iam.tf
@@ -1,0 +1,59 @@
+data "aws_iam_policy_document" "transcribe_service_access" {
+  statement {
+    sid    = "transcribeGenericAccess"
+    effect = "Allow"
+    actions = [
+      "transcribe:List*",
+      "transcribe:Get*",
+      "transcribe:Describe*",
+      "transcribe:StartStreamTranscription",
+      "transcribe:StartStreamTranscriptionWebSocket",
+    ]
+    resources = ["*"]
+  }
+  statement {
+    sid    = "transcribeServiceAccess"
+    effect = "Allow"
+    actions = [
+      "transcribe:GetTranscriptionJob",
+      "transcribe:GetVocabulary",
+      "transcribe:CreateVocabulary",
+      "transcribe:StartTranscriptionJob",
+      "transcribe:DeleteTranscriptionJob",
+      "transcribe:UpdateVocabulary",
+      "transcribe:CreateLanguageModel",
+    ]
+    resources = [
+      "arn:aws:transcribe:eu-west-1:${var.account_ids["analytical-platform-data-production"]}:vocabulary/*",
+      "arn:aws:transcribe:eu-west-1:${var.account_ids["analytical-platform-data-production"]}:transcription-job/*",
+      "arn:aws:transcribe:eu-west-1:${var.account_ids["analytical-platform-data-production"]}:language-model/*"
+    ]
+  }
+  statement {
+    sid    = "AllowS3ReadWrite"
+    effect = "Allow"
+    actions = [
+      "s3:PutObject",
+      "s3:PutObjectAcl",
+      "s3:GetObject",
+      "s3:GetObjectAcl",
+      "s3:List*",
+      "s3:DeleteObject",
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-transcribe-spike/*",
+      "arn:aws:s3:::mojap-transcribe-spike",
+    ]
+  }
+}
+
+resource "aws_iam_policy" "transcribe_service_access" {
+  name   = "transcribe-service-access"
+  policy = data.aws_iam_policy_document.transcribe_service_access.json
+}
+
+resource "aws_iam_role_policy_attachment" "transcribe_service_access_attachment" {
+  for_each   = toset(local.transcribe_users)
+  policy_arn = aws_iam_policy.transcribe_service_access.arn
+  role       = each.value
+}

--- a/terraform/aws/analytical-platform-data-production/transcribe/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/transcribe/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.20.0"
+  constraints = ">= 6.5.0, 6.20.0"
+  hashes = [
+    "h1:HFhl5gnWQ7m26BNWT2KLJvGApRMWmI4d/uz2tDx3NJk=",
+    "zh:05173910d3031e6ba7b985188cff620bbe48cc6bb35ffc30238b9dcd9201c0d4",
+    "zh:0fd36a822e15c473593b5ca826ddfabe248a89833721960781aac65f05a55bc1",
+    "zh:13f478b843ef1fb52780e2771098ae42d6aaceab50d56bc31fdb02ddce6f4621",
+    "zh:16c5a17af7d0fc5329957bc48b5d10b987240076203453a108190132622d40bf",
+    "zh:290342af2da821383b8b5a897920cde2ae01f25768fe5e2df80b80bcc34421cb",
+    "zh:4cfe46a2ed6324467b896aa0dd7fbcf74a94a046d963c8a8fb865e817bcfb955",
+    "zh:78c243a5ec47f6d7066104191480fb13eb85995000cc7c80bc92383baea286a5",
+    "zh:88004fb58967b32061120d1d668e1af1f988da694994cddd11d2d4f7726f5054",
+    "zh:94184d7f00ec5e30d572d56979110e6cf6d5071583713b0e357cca72785e5365",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:b219d9c012db507a761c3f3a9147573f25d81d524a076e7c13099f87a50ae386",
+    "zh:beee1b49f414d1d8c03c9c4264725e288d77a676c093e3017de7d10a8ac45582",
+    "zh:e2e76be18ff4c2bf7cfcea9898475ec320b5574c01181581d76d047a2ee7be5c",
+    "zh:fa9afad49b0b2586032afcda2a5813da6e4ba9e56a8a25167b8f659b68e3983d",
+    "zh:fd284feb9f95a20ba848a9027f3c4298d75be6e882df40f075d60955f7bcf170",
+  ]
+}

--- a/terraform/aws/analytical-platform-data-production/transcribe/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/transcribe/buckets.tf
@@ -1,0 +1,54 @@
+#trivy:ignore:avd-aws-0132:Replicating existing bucket that does not encrypt data with a customer managed key
+#trivy:ignore:avd-aws-0090:Bucket versioning is not preferred for this bucket for now as data is produced on-demand (and versioning is expensive)
+module "mojap_transcribe_spike" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "5.8.2"
+
+  bucket              = "mojap-transcribe-spike"
+  force_destroy       = false
+  object_lock_enabled = false
+  versioning = {
+    status     = "Suspended"
+    mfa_delete = false
+  }
+  server_side_encryption_configuration = {
+    rule = {
+      bucket_key_enabled = false
+
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.mojap_transcribe_spike.json
+
+  tags = var.tags
+}
+
+data "aws_iam_policy_document" "mojap_transcribe_spike" {
+  statement {
+    sid     = "DenyInsecureTransport"
+    effect  = "Deny"
+    actions = ["s3:*"]
+
+    resources = [
+      "arn:aws:s3:::mojap-transcribe-spike/*",
+      "arn:aws:s3:::mojap-transcribe-spike"
+    ]
+
+    principals {
+      type        = "*"
+      identifiers = ["*"]
+    }
+
+    condition {
+      test     = "Bool"
+      variable = "aws:SecureTransport"
+      values   = ["false"]
+    }
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/transcribe/data.tf
+++ b/terraform/aws/analytical-platform-data-production/transcribe/data.tf
@@ -1,0 +1,3 @@
+data "aws_caller_identity" "current" {}
+
+data "aws_canonical_user_id" "current" {}

--- a/terraform/aws/analytical-platform-data-production/transcribe/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/transcribe/terraform.tf
@@ -1,0 +1,49 @@
+terraform {
+  backend "s3" {
+    acl            = "private"
+    bucket         = "global-tf-state-aqsvzyd5u9"
+    encrypt        = true
+    key            = "aws/analytical-platform-data-production/transcribe/terraform.tfstate"
+    region         = "eu-west-2"
+    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "6.20.0"
+    }
+  }
+  required_version = "~> 1.5"
+}
+provider "aws" {
+  alias = "session"
+}
+provider "aws" {
+  region = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+provider "aws" {
+  alias  = "analytical-platform-data-production-eu-west-2"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+provider "aws" {
+  alias  = "analytical-platform-management-production"
+  region = "eu-west-1"
+  assume_role {
+    role_arn = can(regex("AdministratorAccess", data.aws_iam_session_context.session.issuer_arn)) ? null : "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/transcribe/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/transcribe/terraform.tfvars
@@ -1,0 +1,16 @@
+account_ids = {
+  analytical-platform-data-production       = "593291632749"
+  analytical-platform-management-production = "042130406152"
+  analytical-platform-compute-development   = "381491960855"
+  analytical-platform-compute-production    = "992382429243"
+}
+tags = {
+  business-unit          = "Platforms"
+  application            = "Analytical Platform"
+  component              = "transcribe"
+  environment            = "production"
+  is-production          = "true"
+  owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/analytical-platform/terraform/aws/analytical-platform-data-production/transcribe"
+}

--- a/terraform/aws/analytical-platform-data-production/transcribe/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/transcribe/variables.tf
@@ -1,0 +1,8 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}

--- a/terraform/aws/analytical-platform-data-production/transcribe/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/transcribe/variables.tf
@@ -1,8 +1,0 @@
-variable "account_ids" {
-  type        = map(string)
-  description = "Map of account names to account IDs"
-}
-variable "tags" {
-  type        = map(string)
-  description = "Map of tags to apply to resources"
-}


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/[#9157])
GitHub Issue.

<!-- Please describe the purpose of this pull request.
This adds temporary access to AWS Transcribe for a spike.

## Checklist

> [!NOTE]

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments
