### PR TITLE
OPG fabric: Remove deny from kms

### DIFF
--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/kms.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/kms.tf
@@ -10,25 +10,6 @@ module "opg_kms_dev" {
 
   key_statements = [
     {
-      sid    = "DenyNonSecretsManagerUse"
-      effect = "Deny"
-      principals = [
-        {
-          type        = "AWS"
-          identifiers = ["*"]
-        }
-      ]
-      actions   = ["kms:Encrypt", "kms:Decrypt", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:DescribeKey"]
-      resources = ["*"]
-      conditions = [
-        {
-          test     = "StringNotEquals"
-          variable = "kms:ViaService"
-          values   = ["secretsmanager.${data.aws_region.current.name}.amazonaws.com"]
-        }
-      ]
-    },
-    {
       sid       = "AllowViaSecretsManagerForFabricRole"
       effect    = "Allow"
       actions   = ["kms:Encrypt", "kms:Decrypt", "kms:ReEncrypt*", "kms:GenerateDataKey*", "kms:DescribeKey"]


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/moj-analytical-services/airflow-opg-etl/issues/232)
GitHub Issue.

Remove deny block from OPG fabric kms, as it is throwing issues and is not strictly required.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [X] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [X] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [X] I have self-reviewed my code
- [X] I have reviewed the checks and can attest they're as expected