### PR TITLE
Rename coat athena workgroup

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -100,9 +100,9 @@ locals {
       name      = "dbt-oasys-question",
       component = "dbt-oasys-question"
     },
-    "dbt-coat-daily" = {
-      name      = "dbt-coat-daily",
-      component = "dbt-coat-daily"
+    "dbt-coat" = {
+      name      = "dbt-coat",
+      component = "dbt-coat"
     },
   }
 }


### PR DESCRIPTION
The current name is too granular. This PR give a more general name to the COAT athena workgroup, which is more appropriate given how it is used.