### PR TITLE
Update ami_type and instance_type

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -183,13 +183,13 @@ eks_role_mappings = [
   }
 ]
 
-eks_node_group_ami_type       = "AL2_x86_64"
+eks_node_group_ami_type       = "AL2023_x86_64_STANDARD"
 eks_node_group_disk_size      = 250
-eks_node_group_instance_types = ["r5.2xlarge"]
+eks_node_group_instance_types = ["r7i.2xlarge"]
 
 ### GPU-enable node group
 eks_node_group_instance_types_gpu_node = ["g5.4xlarge"]
-eks_node_group_ami_type_gpu_node       = "AL2_x86_64_GPU"
+eks_node_group_ami_type_gpu_node       = "AL2023_x86_64_NVIDIA"
 
 eks_node_group_capacities_gpu_node = {
   desired = 1


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/9192) GitHub Issue.

`analytical-platform-production` cluster upgraded to use `ami_type = "AL2023_x86_64_STANDARD"` and `instance_type = "r7i.2xlarge"` for the main node pool, and `ami_type = AL2023_x86_64_NVIDIA` for the GPU-enabled node pool.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist
- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments
I have overridden static analysis, as the failures are not to do with changes from this PR.

PR to be merged at 12pm 20/11/25 during maintenance window.