### PR TITLE
Add new cadet deployment role to nomis deployers

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -74,7 +74,8 @@ locals {
         "airflow_dev_nomis_ao_legacy",
         "airflow_dev_nomis_derive",
         "restricted-admin",
-        "create-a-derived-table"
+        "create-a-derived-table",
+        "airflow-production-analytical-platform-cadet-nomis-daily"
       ]
     },
     {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/6639)
GitHub Issue.

This adds the new airflow nomis deployment to the collection of allowed deployers, ahead of the move of CaDeT deployments to Airflow.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected
