### PR TITLE
update to S3 lockfile in APDP components - 4

### DIFF
--- a/terraform/aws/analytical-platform-data-production/rds-s3-exports/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/rds-s3-exports/terraform.tf
@@ -1,11 +1,11 @@
 terraform {
   backend "s3" {
-    acl            = "private"
-    bucket         = "global-tf-state-aqsvzyd5u9"
-    encrypt        = true
-    key            = "aws/analytical-platform-data-production/rds-s3-exports/terraform.tfstate"
-    region         = "eu-west-2"
-    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+    acl          = "private"
+    bucket       = "global-tf-state-aqsvzyd5u9"
+    encrypt      = true
+    key          = "aws/analytical-platform-data-production/rds-s3-exports/terraform.tfstate"
+    region       = "eu-west-2"
+    use_lockfile = true
   }
   required_providers {
     aws = {

--- a/terraform/aws/analytical-platform-data-production/s3-glue-crawler/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-glue-crawler/terraform.tf
@@ -1,11 +1,11 @@
 terraform {
   backend "s3" {
-    acl            = "private"
-    bucket         = "global-tf-state-aqsvzyd5u9"
-    encrypt        = true
-    key            = "aws/analytical-platform-data-production/s3-glue-crawler/terraform.tfstate"
-    region         = "eu-west-2"
-    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+    acl          = "private"
+    bucket       = "global-tf-state-aqsvzyd5u9"
+    encrypt      = true
+    key          = "aws/analytical-platform-data-production/s3-glue-crawler/terraform.tfstate"
+    region       = "eu-west-2"
+    use_lockfile = true
   }
   required_providers {
     aws = {

--- a/terraform/aws/analytical-platform-data-production/sagemaker-service/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/sagemaker-service/terraform.tf
@@ -1,11 +1,11 @@
 terraform {
   backend "s3" {
-    acl            = "private"
-    bucket         = "global-tf-state-aqsvzyd5u9"
-    encrypt        = true
-    key            = "aws/analytical-platform-data-production/sagemaker-service/terraform.tfstate"
-    region         = "eu-west-2"
-    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+    acl          = "private"
+    bucket       = "global-tf-state-aqsvzyd5u9"
+    encrypt      = true
+    key          = "aws/analytical-platform-data-production/sagemaker-service/terraform.tfstate"
+    region       = "eu-west-2"
+    use_lockfile = true
   }
   required_providers {
     aws = {

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/terraform.tf
@@ -1,11 +1,11 @@
 terraform {
   backend "s3" {
-    acl            = "private"
-    bucket         = "global-tf-state-aqsvzyd5u9"
-    encrypt        = true
-    key            = "global/tooling-iam/terraform.tfstate"
-    region         = "eu-west-2"
-    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+    acl          = "private"
+    bucket       = "global-tf-state-aqsvzyd5u9"
+    encrypt      = true
+    key          = "global/tooling-iam/terraform.tfstate"
+    region       = "eu-west-2"
+    use_lockfile = true
   }
   required_providers {
     aws = {

--- a/terraform/aws/analytical-platform-data-production/transcribe/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/transcribe/terraform.tf
@@ -1,11 +1,11 @@
 terraform {
   backend "s3" {
-    acl            = "private"
-    bucket         = "global-tf-state-aqsvzyd5u9"
-    encrypt        = true
-    key            = "aws/analytical-platform-data-production/transcribe/terraform.tfstate"
-    region         = "eu-west-2"
-    dynamodb_table = "global-tf-state-aqsvzyd5u9-locks"
+    acl          = "private"
+    bucket       = "global-tf-state-aqsvzyd5u9"
+    encrypt      = true
+    key          = "aws/analytical-platform-data-production/transcribe/terraform.tfstate"
+    region       = "eu-west-2"
+    use_lockfile = true
   }
   required_providers {
     aws = {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/8274) GitHub Issue.

This pull request updates the some of the components in `analytical-platform-data-production` to `use_lockfile` instead of `dynamodb_table`. 
`terraform init -reconfigure` was run in each component to make the changes to lockfiles, and each S3 location was checked to ensure lockfiles was created during a `terraform plan`.


## Checklist
- [x]  I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

Overriding static analysis, as errors are not introduced by changes in this PR.