### PR TITLE
Create AWS Secret for Container Test Slack Webhook

### DIFF
--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -18,3 +18,12 @@ resource "aws_secretsmanager_secret" "moj_analytical_services_github_token" {
   kms_key_id  = "alias/aws/secretsmanager"
 }
 
+#tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
+resource "aws_secretsmanager_secret" "container_test_slack_webhook_url" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
+  name        = "container-test-slack-webhook-url"
+  description = "Slack webhook URL for container test notifications"
+  kms_key_id  = "alias/aws/secretsmanager"
+}


### PR DESCRIPTION
This pull request introduces a new secret to AWS Secrets Manager for container test Slack notifications. The change is straightforward and primarily involves Terraform configuration.

Secret management:

* Added a new `aws_secretsmanager_secret` resource named `container_test_slack_webhook_url` in `secrets.tf` to store the Slack webhook URL for container test notifications. Included comments to skip certain security checks, noting that automatic rotation and CMK encryption are not required for this secret.

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/9151) GitHub Issue.


