### PR TITLE
COAT Integration: Add S3 bucket for enriched CUR data

### DIFF
--- a/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
@@ -26,7 +26,7 @@ module "coat_kms_keys" {
       principals = [
         {
           type        = "AWS"
-          identifiers = [ each.value.source_replication_role ]
+          identifiers = [each.value.source_replication_role]
         }
       ]
     }

--- a/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
@@ -1,3 +1,8 @@
+moved {
+  from = module.coat_kms
+  to   = module.coat_kms_keys["coat_cur_reports_v2_hourly"]
+}
+
 module "coat_kms_keys" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
@@ -5,7 +5,7 @@ module "coat_kms" {
   source  = "terraform-aws-modules/kms/aws"
   version = "4.0.0"
 
-  aliases               = ["s3/${local.bucket_name}"]
+  aliases               = ["s3/${local.buckets.coat_cur_reports_v2_hourly.bucket_name}"]
   enable_default_policy = true
   key_statements = [
     {
@@ -19,7 +19,7 @@ module "coat_kms" {
       principals = [
         {
           type        = "AWS"
-          identifiers = [local.source_replication_role]
+          identifiers = [ for bucket in local.buckets : bucket.source_replication_role ]
         }
       ]
     }

--- a/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf
@@ -1,11 +1,13 @@
-module "coat_kms" {
+module "coat_kms_keys" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  for_each = local.buckets
 
   source  = "terraform-aws-modules/kms/aws"
   version = "4.0.0"
 
-  aliases               = ["s3/${local.buckets.coat_cur_reports_v2_hourly.bucket_name}"]
+  aliases               = ["s3/${each.value.bucket_name}"]
   enable_default_policy = true
   key_statements = [
     {
@@ -19,7 +21,7 @@ module "coat_kms" {
       principals = [
         {
           type        = "AWS"
-          identifiers = [ for bucket in local.buckets : bucket.source_replication_role ]
+          identifiers = [ each.value.source_replication_role ]
         }
       ]
     }

--- a/terraform/aws/analytical-platform-data-production/coat-integration/local.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/local.tf
@@ -1,14 +1,14 @@
 locals {
-  root_account_id       = jsondecode(data.aws_secretsmanager_secret_version.analytical_platform_platform_account_ids.secret_string)["moj-master"]
+  root_account_id = jsondecode(data.aws_secretsmanager_secret_version.analytical_platform_platform_account_ids.secret_string)["moj-master"]
 
   buckets = {
     coat_cur_reports_v2_hourly = {
-      bucket_name = "mojap-data-production-coat-cur-reports-v2-hourly"
+      bucket_name             = "mojap-data-production-coat-cur-reports-v2-hourly"
       source_replication_role = "arn:aws:iam::${local.root_account_id}:role/moj-cur-reports-v2-hourly-replication-role"
     }
 
     coat_cur_reports_v2_hourly_enriched = {
-      bucket_name = "mojap-data-production-coat-cur-reports-v2-hourly-enriched"
+      bucket_name             = "mojap-data-production-coat-cur-reports-v2-hourly-enriched"
       source_replication_role = "arn:aws:iam::${var.account_ids["coat-production"]}:role/moj-cur-v2-hourly-enriched-replication-role"
     }
   }

--- a/terraform/aws/analytical-platform-data-production/coat-integration/local.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/local.tf
@@ -1,5 +1,15 @@
 locals {
-  bucket_name             = "mojap-data-production-coat-cur-reports-v2-hourly"
-  source_account_id       = jsondecode(data.aws_secretsmanager_secret_version.analytical_platform_platform_account_ids.secret_string)["moj-master"]
-  source_replication_role = "arn:aws:iam::${local.source_account_id}:role/moj-cur-reports-v2-hourly-replication-role"
+  root_account_id       = jsondecode(data.aws_secretsmanager_secret_version.analytical_platform_platform_account_ids.secret_string)["moj-master"]
+
+  buckets = {
+    coat_cur_reports_v2_hourly = {
+      bucket_name = "mojap-data-production-coat-cur-reports-v2-hourly"
+      source_replication_role = "arn:aws:iam::${local.root_account_id}:role/moj-cur-reports-v2-hourly-replication-role"
+    }
+
+    coat_cur_reports_v2_hourly_enriched = {
+      bucket_name = "mojap-data-production-coat-cur-reports-v2-hourly-enriched"
+      source_replication_role = "arn:aws:iam::${var.account_ids["coat_production"]}:role/moj-cur-v2-hourly-enriched-replication-role"
+    }
+  }
 }

--- a/terraform/aws/analytical-platform-data-production/coat-integration/local.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/local.tf
@@ -9,7 +9,7 @@ locals {
 
     coat_cur_reports_v2_hourly_enriched = {
       bucket_name = "mojap-data-production-coat-cur-reports-v2-hourly-enriched"
-      source_replication_role = "arn:aws:iam::${var.account_ids["coat_production"]}:role/moj-cur-v2-hourly-enriched-replication-role"
+      source_replication_role = "arn:aws:iam::${var.account_ids["coat-production"]}:role/moj-cur-v2-hourly-enriched-replication-role"
     }
   }
 }

--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -24,6 +24,8 @@ module "coat_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
+  for_each = local.buckets
+
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "5.8.2"
 

--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -19,8 +19,13 @@ data "aws_iam_policy_document" "coat_bucket_policies" {
   }
 }
 
+moved {
+  from = module.coat_s3
+  to   = module.coat_s3_buckets.coat_cur_reports_v2_hourly
+}
+
 #trivy:ignore:AVD-AWS-0089:Bucket logging not enabled currently
-module "coat_s3" {
+module "coat_s3_buckets" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
@@ -44,7 +49,7 @@ module "coat_s3" {
     bucket_key_enabled = true
     rule = {
       apply_server_side_encryption_by_default = {
-        kms_master_key_id = module.coat_kms.key_arn
+        kms_master_key_id = module.coat_kms_keys[each.key].key_arn
         sse_algorithm     = "aws:kms"
       }
     }

--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -21,7 +21,7 @@ data "aws_iam_policy_document" "coat_bucket_policies" {
 
 moved {
   from = module.coat_s3
-  to   = module.coat_s3_buckets.coat_cur_reports_v2_hourly
+  to   = module.coat_s3_buckets["coat_cur_reports_v2_hourly"]
 }
 
 #trivy:ignore:AVD-AWS-0089:Bucket logging not enabled currently

--- a/terraform/aws/analytical-platform-data-production/coat-integration/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/terraform.tfvars
@@ -1,6 +1,7 @@
 account_ids = {
   analytical-platform-data-production       = "593291632749"
   analytical-platform-management-production = "042130406152"
+  coat-production = "279191903737"
 }
 
 tags = {

--- a/terraform/aws/analytical-platform-data-production/coat-integration/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/terraform.tfvars
@@ -1,7 +1,7 @@
 account_ids = {
   analytical-platform-data-production       = "593291632749"
   analytical-platform-management-production = "042130406152"
-  coat-production = "279191903737"
+  coat-production                           = "279191903737"
 }
 
 tags = {


### PR DESCRIPTION
**Summary**
Refactor coat-integration Terraform module to use for loops to create 2nd enriched CUR S3 bucket.

**Why**
We would like to replicate enriched CUR GreenOps data from a bucket in the coat-production MP account into APDP, so that the data is accessible to airflow, so we can begin to ingest GreenOps data for our dashboards.

**How**
- locals has been refactored to include a map of our S3 buckets.
- This map is used with for loops to create kms and s3 resources from the same configuration.
- A moved block has been added to remap the original cur hourly bucket address to the new module address, accounting for use of the for loop.