### PR TITLE
Create/Rename AWS Secret for Slack Webhook

### DIFF
--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -19,11 +19,11 @@ resource "aws_secretsmanager_secret" "moj_analytical_services_github_token" {
 }
 
 #tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
-resource "aws_secretsmanager_secret" "container_test_slack_webhook_url" {
+resource "aws_secretsmanager_secret" "release_failure_webhook_url" {
   provider = aws.analytical-platform-management-production-eu-west-1
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
-  name        = "container-test-slack-webhook-url"
-  description = "Slack webhook URL for container test notifications"
+  name        = "release-failure-webhook-url"
+  description = "Slack webhook URL for release failure notifications"
   kms_key_id  = "alias/aws/secretsmanager"
 }


### PR DESCRIPTION
This pull request updates the configuration for a Slack webhook secret in AWS Secrets Manager to improve clarity and better reflect its purpose. The main change is renaming the secret resource and updating its description to indicate it is used for release failure notifications rather than container test notifications.

Secret management update:

* Renamed the `aws_secretsmanager_secret` resource from `container_test_slack_webhook_url` to `release_failure_webhook_url`, and updated both the `name` and `description` fields to specify its use for release failure notifications instead of container test notifications.

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/9151) GitHub Issue.
