### PR TITLE
dmet-prisons: add get lakeformation access

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -93,7 +93,6 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:catalog"
     ]
   }
-  
   statement {
     sid    = "LakeFormationGetDataAccess"
     effect = "Allow"
@@ -102,7 +101,6 @@ data "aws_iam_policy_document" "create_a_derived_table" {
     ]
     resources = ["*"]
   }
-
   statement {
     sid    = "AirflowAccess"
     effect = "Allow"

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -93,6 +93,16 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:catalog"
     ]
   }
+  
+  statement {
+    sid    = "LakeFormationGetDataAccess"
+    effect = "Allow"
+    actions = [
+      "lakeformation:GetDataAccess"
+    ]
+    resources = ["*"]
+  }
+
   statement {
     sid    = "AirflowAccess"
     effect = "Allow"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this Slack thread](https://mojdt.slack.com/archives/C08TSQVQ5LJ/p1765276121197359?thread_ts=1764855374.523819&cid=C08TSQVQ5LJ)

This allows create-a-derived-table role to query LF-shared resources which have been shared with the role.
DMET-prisons are currently providing the role with LF permissions [here](https://github.com/moj-analytical-services/data-engineering-datalake-access/blob/main/data_hub_accounts/digital_prison_reporting/production/projects/performance_learning_and_work.yml)

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
