### PR TITLE
:copilot: :memo: Add Copilot Instructions

### DIFF
--- a/.github/agents/cve.agent.md
+++ b/.github/agents/cve.agent.md
@@ -1,0 +1,7 @@
+---
+description: Agent to patch Terraform module versions on environments in the analytical-platform repository.
+
+tools: ["runCommands", "edit", "search", "fetch"]
+---
+
+# Terraform Maintenance Agent

--- a/.github/agents/cve.agent.md
+++ b/.github/agents/cve.agent.md
@@ -1,7 +1,0 @@
----
-description: Agent to patch Terraform module versions on environments in the analytical-platform repository.
-
-tools: ["runCommands", "edit", "search", "fetch"]
----
-
-# Terraform Maintenance Agent

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,18 @@
+# GitHub Copilot Instructions
+
+## Language and Style
+
+- Use British English spelling throughout
+- Follow conventional commit message format
+
+## Ministry of Justice Standards
+
+- Adhere to guidance published under [ministryofjustice/.github](https://github.com/ministryofjustice/.github)
+- Follow security best practices for government services
+
+## Terraform
+
+- Follow the Modernisation Platform's [Terraform Style Guide](https://user-guide.modernisation-platform.service.justice.gov.uk/team/terraform-style-guide)
+- Do not append the resource type to the resource name (e.g., use `my-resource` instead of `my-resource-s3-bucket`)
+- Use kebab case for resource names (e.g., `my-resource-name`)
+- Include comments for complex logic or non-obvious decisions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -12,7 +12,7 @@
 
 ## Terraform
 
-- Follow the Modernisation Platform's [Terraform Style Guide](https://user-guide.modernisation-platform.service.justice.gov.uk/team/terraform-style-guide)
+- Follow the Analytical Platform's [Terraform Style Guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#style-guide)
 - Do not append the resource type to the resource name (e.g., use `my-resource` instead of `my-resource-s3-bucket`)
 - Use kebab case for resource names (e.g., `my-resource-name`)
 - Include comments for complex logic or non-obvious decisions

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -14,5 +14,5 @@
 
 - Follow the Analytical Platform's [Terraform Style Guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#style-guide)
 - Do not append the resource type to the resource name (e.g., use `my-resource` instead of `my-resource-s3-bucket`)
-- Use kebab case for resource names (e.g., `my-resource-name`)
+- Use kebab-case for resource names (e.g., `my-resource-name`)
 - Include comments for complex logic or non-obvious decisions


### PR DESCRIPTION
This is pretty much identical to the MPE copilot instructions however it references our style guide [here](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#style-guide).