### PR TITLE
CADET role perms for COAT greenops KMS key

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -125,7 +125,8 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "kms:Decrypt"
     ]
     resources = [
-      "arn:aws:kms:eu-west-1:${var.account_ids["analytical-platform-data-production"]}:key/0409ddbc-b6a2-46c4-a613-6145f6a16215"
+      "arn:aws:kms:eu-west-1:${var.account_ids["analytical-platform-data-production"]}:key/0409ddbc-b6a2-46c4-a613-6145f6a16215",
+      "arn:aws:kms:eu-west-1:${var.account_ids["analytical-platform-data-production"]}:key/0d21d1cf-b9da-43f3-999b-da7f0d376bfd"
     ]
   }
 }


### PR DESCRIPTION
Error in CADET: https://github.com/moj-analytical-services/create-a-derived-table/actions/runs/20135323302/job/57786955969?pr=5424#step:19:50 

Where the KMS keys are defined in AP: https://github.com/ministryofjustice/analytical-platform/blob/main/terraform/aws/analytical-platform-data-production/coat-integration/kms-keys.tf

We need to give the CADET role assumed by GitHub Actions, permission to use the KMS key that our GreenOps data in APDP S3 is encrypted with, so that it can access data in that bucket.