### PR TITLE
OPG: Add oidc connector for fabric

### DIFF
--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/buckets.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/buckets.tf
@@ -1,0 +1,26 @@
+#trivy:ignore:AVD-AWS-0089
+module "opg_fabric_store" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source        = "terraform-aws-modules/s3-bucket/aws"
+  version       = "5.8.2"
+  bucket        = "alpha-opg-fabric-sandbox"
+  force_destroy = false
+  versioning = {
+    enabled = true
+  }
+  server_side_encryption_configuration = {
+    rule = {
+      bucket_key_enabled = false
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/data.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/data.tf
@@ -1,0 +1,26 @@
+data "aws_iam_policy_document" "bucket_access" {
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = [module.opg_fabric_store.s3_bucket_arn]
+  }
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:GetObject"]
+    resources = ["${module.opg_fabric_store.s3_bucket_arn}/*"]
+  }
+}
+
+resource "aws_iam_role_policy" "entra_bucket_access" {
+  name   = "entra-bucket-access"
+  role   = aws_iam_role.opg_fabric_access.id
+  policy = data.aws_iam_policy_document.bucket_access.json
+}
+
+
+data "aws_secretsmanager_secret_version" "tenant_id_secret" {
+  secret_id = module.tenant_id_secret.secret_arn
+}
+data "aws_secretsmanager_secret_version" "object_id_secret" {
+  secret_id = module.object_id_secret.secret_arn
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/iam-policies.tf
@@ -1,0 +1,20 @@
+data "aws_iam_policy_document" "opg_fabric_trust" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+    principals {
+      type        = "Federated"
+      identifiers = [aws_iam_openid_connect_provider.opg_fabric_connector.arn]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "sts.windows.net/${local.tenant_id}/:aud"
+      values   = ["https://analysis.windows.net/powerbi/connector/AmazonS3"]
+    }
+    condition {
+      test     = "StringEquals"
+      variable = "sts.windows.net/${local.tenant_id}/:sub"
+      values   = [local.object_id]
+    }
+  }
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/iam-roles.tf
@@ -1,0 +1,4 @@
+resource "aws_iam_role" "opg_fabric_access" {
+  name               = "opg-fabric-s3"
+  assume_role_policy = data.aws_iam_policy_document.opg_fabric_trust.json
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/locals.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/locals.tf
@@ -1,0 +1,4 @@
+locals {
+  tenant_id = data.aws_secretsmanager_secret_version.tenant_id_secret.secret_string
+  object_id = data.aws_secretsmanager_secret_version.object_id_secret.secret_string
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/oidc.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/oidc.tf
@@ -1,0 +1,11 @@
+resource "aws_iam_openid_connect_provider" "opg_fabric_connector" {
+  url = "https://sts.windows.net/${local.tenant_id}/"
+
+  client_id_list = [
+    "https://analysis.windows.net/powerbi/connector/AmazonS3",
+  ]
+
+  tags = {
+    Name = "opg-fabric-oidc-connector"
+  }
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/secrets.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/secrets.tf
@@ -1,0 +1,23 @@
+module "tenant_id_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.0.1"
+
+  name                  = "opg-fabric-connector/tenant-id"
+  description           = "Tenant ID for OPG Fabric application"
+  ignore_secret_changes = true
+  secret_string         = var.default_tenant_value
+}
+
+module "object_id_secret" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "2.0.1"
+
+  name                  = "opg-fabric-connector/object-id"
+  description           = "Object ID for OPG Fabric application"
+  ignore_secret_changes = true
+  secret_string         = var.default_object_value
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/terraform.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/terraform.tf
@@ -10,14 +10,17 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "6.11.0"
+      version = "6.21.0"
     }
   }
   required_version = "~> 1.5"
 }
 
 provider "aws" {
-  region = "eu-west-2"
+  region = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-sandbox-a"]}:role/GlobalGitHubActionAdmin"
+  }
 
   default_tags {
     tags = {

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/terraform.tfvars
@@ -1,0 +1,3 @@
+account_ids = {
+  analytical-platform-data-engineering-sandbox-a = "684969100054"
+}

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/variables.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/variables.tf
@@ -1,0 +1,17 @@
+variable "default_tenant_value" {
+  type      = string
+  sensitive = true
+  default   = "CHANGEME"
+}
+
+variable "default_object_value" {
+  type      = string
+  sensitive = true
+  default   = "CHANGEME"
+}
+
+
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/moj-analytical-services/airflow-opg-etl/issues/232) GitHub Issue.

Re-create full fabric connector for OPG in the correct account.

OIDC connector, with iam roles & policies for providing access to Azure Fabric to created s3 bucket.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected