### PR TITLE
dmet-prisons - give cadet runner glue permissions on external catalog

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -91,6 +91,26 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:database/*",
       "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:table/*/*",
       "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:catalog"
+
+    ]
+  }
+  # Lake formation shares - glue catalog access
+  statement {
+    sid    = "GlueAccessLFShares"
+    effect = "Allow"
+    actions = [
+      "glue:GetDatabase",
+      "glue:GetDatabases",
+      "glue:GetTable",
+      "glue:GetTables",
+      "glue:GetPartitions"
+    ]
+
+    resources = [
+      "arn:aws:glue:*:${var.account_ids["digital-prison-reporting-production"]}:schema/*",
+      "arn:aws:glue:*:${var.account_ids["digital-prison-reporting-production"]}:database/*",
+      "arn:aws:glue:*:${var.account_ids["digital-prison-reporting-production"]}:table/*/*",
+      "arn:aws:glue:*:${var.account_ids["digital-prison-reporting-production"]}:catalog"
     ]
   }
   statement {

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/terraform.tfvars
@@ -3,6 +3,7 @@ account_ids = {
   analytical-platform-data-production       = "593291632749"
   analytical-platform-management-production = "042130406152"
   analytical-platform-compute-production    = "992382429243"
+  digital-prison-reporting-production       = "004723187462"
 }
 
 tags = {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this thread](https://mojdt.slack.com/archives/C08TSQVQ5LJ/p1765895220592929?thread_ts=1764855374.523819&cid=C08TSQVQ5LJ)

Some users need access to LF-shared data via Quicksight. This is not going to be trivial. As a workaround (tactical) i'll ask users to materialise the data they need in CaDeT for onward sharing to Quicksight.

CaDeT is unable to see the catalog of the external account (this is different than for alpha users that get glue permissions on "*")

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
