### PR TITLE
:dependabot: github-actions(deps): Bump github/codeql-action from 4.31.7 to 4.31.9

### DIFF
--- a/.github/workflows/repository-openssf-scorecard.yml
+++ b/.github/workflows/repository-openssf-scorecard.yml
@@ -43,6 +43,6 @@ jobs:
 
       - name: Upload to CodeQL
         id: upload_to_codeql
-        uses: github/codeql-action/upload-sarif@cf1bb45a277cb3c205638b2cd5c984db1c46a412 # v4.31.7
+        uses: github/codeql-action/upload-sarif@5d4e8d1aca955e8d8589aabd499c5cae939e33c7 # v4.31.9
         with:
           sarif_file: results.sarif


### PR DESCRIPTION
This PR seeks to resolve [this](https://github.com/ministryofjustice/analytical-platform/pull/9487) dependabot. It did not have a signature on it's commit for some odd reason. 