### PR TITLE
🛠️ add apps-dev route53_zone to external-dns policy

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/data.tf
+++ b/terraform/aws/analytical-platform-development/cluster/data.tf
@@ -27,6 +27,11 @@ data "aws_route53_zone" "main" {
   private_zone = false
 }
 
+data "aws_route53_zone" "apps_dev" {
+  name         = var.route53_zone_apps_dev
+  private_zone = false
+}
+
 data "aws_iam_roles" "aws_sso_administrator_access" {
   name_regex  = "AWSReservedSSO_${var.aws_sso_role_prefix}_.*"
   path_prefix = "/aws-reserved/sso.amazonaws.com/"

--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -136,7 +136,10 @@ data "aws_iam_policy_document" "external_dns" {
       "route53:ChangeResourceRecordSets",
       "route53:ListResourceRecordSets",
     ]
-    resources = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.main.zone_id}"]
+    resources = [
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.main.zone_id}",
+      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.apps_dev.zone_id}"
+    ]
   }
 }
 

--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -29,7 +29,8 @@ tags = {
 # Route53
 ##################################################
 
-route53_zone = "dev.analytical-platform.service.justice.gov.uk"
+route53_zone          = "dev.analytical-platform.service.justice.gov.uk"
+route53_zone_apps_dev = "apps-dev.analytical-platform.service.justice.gov.uk"
 
 ##################################################
 # VPC

--- a/terraform/aws/analytical-platform-development/cluster/variables.tf
+++ b/terraform/aws/analytical-platform-development/cluster/variables.tf
@@ -31,6 +31,11 @@ variable "route53_zone" {
   description = "Name of the Route53 zone"
 }
 
+variable "route53_zone_apps_dev" {
+  type        = string
+  description = "Name of the Route53 apps-dev zone"
+}
+
 ##################################################
 # VPC
 ##################################################


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/9455) GitHub Issue.

This pull request adds the apps-dev route53 zone to the external-dns policy. This is to resolves an error appearing in the external-dns pod logs, shown here:

```
time="2025-12-18T11:36:45Z" level=error msg="Failed to do run once: soft error\nfailed to list resource records sets for zone /hostedzone/Z02067303BNM3QIK0WKXX using aws profile \"default\": operation error Route 53: ListResourceRecordSets, https response error StatusCode: 403, RequestID: d6655208-9b65-4127-968e-f8332dfd883e, api error AccessDenied: User: arn:aws:sts::525294151996:assumed-role/external_dns20211205...6050000000b/1766...51399752915 is not authorized to perform: route53:ListResourceRecordSets on resource: arn:aws:route53:::hostedzone/Z02067303BNM3QIK0WKXX because no identity-based policy allows the route53:ListResourceRecordSets action (consecutive soft errors: 3958)"
```

## Checklist
- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
