### PR TITLE
Pre-prod cadet setup and dev update

### DIFF
--- a/terraform/aws/analytical-platform-data-engineering-production/data-engineering-pipelines/athena.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/data-engineering-pipelines/athena.tf
@@ -19,3 +19,25 @@ resource "aws_athena_workgroup" "create_a_derived_table_dev" {
     }
   )
 }
+
+resource "aws_athena_workgroup" "create_a_derived_table_preprod" {
+  name = "dbt-probation-preprod"
+
+  configuration {
+    bytes_scanned_cutoff_per_query  = 1099511627776000
+    enforce_workgroup_configuration = false
+    engine_version {
+      selected_engine_version = "Athena engine version 3"
+    }
+    result_configuration {
+      output_location = "s3://${module.query_results_preprod.bucket.id}/"
+    }
+  }
+
+  tags = merge(var.tags,
+    {
+      "environment"   = "preprod"
+      "is_production" = "false"
+    }
+  )
+}

--- a/terraform/aws/analytical-platform-data-engineering-production/data-engineering-pipelines/s3.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/data-engineering-pipelines/s3.tf
@@ -44,8 +44,11 @@ module "datalake_dev" {
 
   lifecycle_rule = [
     {
-      "id"      = "default"
-      "enabled" = "Disabled"
+      "id"      = "main"
+      "enabled" = "Enabled"
+      "expiration" = {
+        "days" = 30
+      }
     }
   ]
 
@@ -54,6 +57,70 @@ module "datalake_dev" {
   tags = merge(var.tags,
     {
       "environment"   = "dev"
+      "is_production" = "false"
+    }
+  )
+}
+
+module "query_results_preprod" {
+  source        = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399"
+  bucket_prefix = "probation-query-results-preprod-"
+
+  versioning_enabled = false
+  ownership_controls = "BucketOwnerEnforced"
+
+  replication_enabled = false
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  lifecycle_rule = [
+    {
+      "id"      = "main"
+      "enabled" = "Enabled"
+      "expiration" = {
+        "days" = 1
+      }
+    }
+  ]
+
+  sse_algorithm = "AES256"
+
+  tags = merge(var.tags,
+    {
+      "environment"   = "preprod"
+      "is_production" = "false"
+    }
+  )
+}
+
+module "datalake_preprod" {
+  source        = "github.com/ministryofjustice/modernisation-platform-terraform-s3-bucket?ref=9facf9fc8f8b8e3f93ffbda822028534b9a75399"
+  bucket_prefix = "probation-datalake-preprod-"
+
+  versioning_enabled = false
+  ownership_controls = "BucketOwnerEnforced"
+
+  replication_enabled = false
+  providers = {
+    aws.bucket-replication = aws
+  }
+
+  lifecycle_rule = [
+    {
+      "id"      = "main"
+      "enabled" = "Enabled"
+      "expiration" = {
+        "days" = 30
+      }
+    }
+  ]
+
+  sse_algorithm = "AES256"
+
+  tags = merge(var.tags,
+    {
+      "environment"   = "preprod"
       "is_production" = "false"
     }
   )

--- a/terraform/aws/analytical-platform-data-engineering-production/github-actions-roles/iam.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/github-actions-roles/iam.tf
@@ -132,3 +132,128 @@ resource "aws_iam_openid_connect_provider" "analytical_platform_compute_cluster_
   ]
 
 }
+
+data "aws_iam_policy_document" "create_a_derived_table_preprod" {
+  statement {
+    sid    = "BucketAccess"
+    effect = "Allow"
+    actions = [
+      "s3:List*",
+      "s3:Get*",
+      "s3:DeleteObject*",
+      "s3:PutObject*"
+    ]
+    resources = [
+      "arn:aws:s3:::probation-datalake-preprod*/*",
+      "arn:aws:s3:::probation-datalake-preprod*",
+      "arn:aws:s3:::probation-query-results-preprod*/*",
+      "arn:aws:s3:::probation-query-results-preprod*",
+    ]
+  }
+  statement {
+    sid    = "DataAccess"
+    effect = "Allow"
+    actions = [
+      "s3:List*",
+      "s3:GetObject*",
+      "s3:GetBucket*"
+    ]
+    resources = [
+      "arn:aws:s3:::ppud-parquet-exports-preprod*",
+      "arn:aws:s3:::ppud-parquet-exports-preprod*/*"
+    ]
+  }
+  statement {
+    sid    = "AthenaAccess"
+    effect = "Allow"
+    actions = [
+      "athena:List*",
+      "athena:Get*",
+      "athena:StartQueryExecution",
+      "athena:StopQueryExecution"
+    ]
+    resources = [
+      "arn:aws:athena:*:${var.account_ids["analytical-platform-data-engineering-production"]}:datacatalog/*",
+      "arn:aws:athena:*:${var.account_ids["analytical-platform-data-engineering-production"]}:workgroup/dbt-probation-preprod"
+    ]
+  }
+  statement {
+    sid    = "GlueAccess"
+    effect = "Allow"
+    actions = [
+      "glue:Get*",
+      "glue:DeleteTable",
+      "glue:DeleteTableVersion",
+      "glue:DeleteSchema",
+      "glue:DeletePartition",
+      "glue:DeleteDatabase",
+      "glue:UpdateTable",
+      "glue:UpdateSchema",
+      "glue:UpdatePartition",
+      "glue:UpdateDatabase",
+      "glue:CreateTable",
+      "glue:CreateSchema",
+      "glue:CreatePartition",
+      "glue:CreatePartitionIndex",
+      "glue:BatchCreatePartition",
+      "glue:BatchDeletePartition",
+      "glue:CreateDatabase"
+    ]
+    resources = [
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-engineering-production"]}:schema/*",
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-engineering-production"]}:database/*",
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-engineering-production"]}:table/*/*",
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-engineering-production"]}:catalog"
+    ]
+  }
+}
+
+module "create_a_derived_table_preprod_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.2.3"
+
+  name_prefix = "probation-cadet-preprod"
+  policy      = data.aws_iam_policy_document.create_a_derived_table_preprod.json
+
+  tags = merge(var.tags,
+    {
+      "environment"   = "preprod"
+      "is_production" = "false"
+    }
+  )
+}
+
+module "create_a_derived_table_preprod_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts"
+  version = "6.2.3"
+
+  name                 = "probation-cadet-preprod"
+  max_session_duration = 10800
+
+  policies = {
+    policy = module.create_a_derived_table_preprod_iam_policy.arn
+  }
+
+  oidc_providers = {
+    analytical-platform-compute-production = {
+      provider_arn = format(
+        "arn:aws:iam::${var.account_ids["analytical-platform-data-engineering-production"]}:oidc-provider/%s",
+        trimprefix(jsondecode(data.aws_secretsmanager_secret_version.analytical_platform_compute_cluster_data.secret_string)["analytical-platform-compute-production-oidc-endpoint"], "https://")
+      )
+      namespace_service_accounts = ["actions-runner-mojas-cadt-probation-preprod"]
+    }
+  }
+
+  tags = merge(var.tags,
+    {
+      "environment"   = "preprod"
+      "is_production" = "false"
+    }
+  )
+}


### PR DESCRIPTION
# Pull Request Objective

- Github Action Runner role for pre-prod.
- CaDeT bucket setup for pre-prod.
- Update dev lifecycle rule for CaDeT data bucket.

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/<your_issue_number_here>)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
