### PR TITLE
Revert "🛠️ add apps-dev route53_zone to external-dns policy"

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/data.tf
+++ b/terraform/aws/analytical-platform-development/cluster/data.tf
@@ -27,11 +27,6 @@ data "aws_route53_zone" "main" {
   private_zone = false
 }
 
-data "aws_route53_zone" "apps_dev" {
-  name         = var.route53_zone_apps_dev
-  private_zone = false
-}
-
 data "aws_iam_roles" "aws_sso_administrator_access" {
   name_regex  = "AWSReservedSSO_${var.aws_sso_role_prefix}_.*"
   path_prefix = "/aws-reserved/sso.amazonaws.com/"

--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -136,10 +136,7 @@ data "aws_iam_policy_document" "external_dns" {
       "route53:ChangeResourceRecordSets",
       "route53:ListResourceRecordSets",
     ]
-    resources = [
-      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.main.zone_id}",
-      "arn:aws:route53:::hostedzone/${data.aws_route53_zone.apps_dev.zone_id}"
-    ]
+    resources = ["arn:aws:route53:::hostedzone/${data.aws_route53_zone.main.zone_id}"]
   }
 }
 

--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -29,8 +29,7 @@ tags = {
 # Route53
 ##################################################
 
-route53_zone          = "dev.analytical-platform.service.justice.gov.uk"
-route53_zone_apps_dev = "apps-dev.analytical-platform.service.justice.gov.uk"
+route53_zone = "dev.analytical-platform.service.justice.gov.uk"
 
 ##################################################
 # VPC

--- a/terraform/aws/analytical-platform-development/cluster/variables.tf
+++ b/terraform/aws/analytical-platform-development/cluster/variables.tf
@@ -31,11 +31,6 @@ variable "route53_zone" {
   description = "Name of the Route53 zone"
 }
 
-variable "route53_zone_apps_dev" {
-  type        = string
-  description = "Name of the Route53 apps-dev zone"
-}
-
 ##################################################
 # VPC
 ##################################################


### PR DESCRIPTION
Reverts ministryofjustice/analytical-platform#9493

We think this "apps-dev" hosted zone does not need to be added to the policy here as it is not managed via analytical-platfrom-flux see https://github.com/moj-analytical-services/analytical-platform-flux/pull/1503