### PR TITLE
👾 Diversify GPU Node Types

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -188,7 +188,7 @@ eks_node_group_disk_size      = 250
 eks_node_group_instance_types = ["r7i.2xlarge"]
 
 ### GPU-enable node group
-eks_node_group_instance_types_gpu_node = ["g5.4xlarge"]
+eks_node_group_instance_types_gpu_node = ["g5.2xlarge", "g5.4xlarge", "g5.8xlarge"]
 eks_node_group_ami_type_gpu_node       = "AL2023_x86_64_NVIDIA"
 
 eks_node_group_capacities_gpu_node = {


### PR DESCRIPTION
Relates to https://github.com/ministryofjustice/analytical-platform/issues/9035

## Proposed Changes

- Adds [2xlarge](https://instances.vantage.sh/aws/ec2/g5.2xlarge?currency=GBP) and [8xlarge](https://instances.vantage.sh/aws/ec2/g5.8xlarge?currency=GBP) to GPU node types

## Notes

GPU enabled releases have 2 vCPU and 24Gi RAM

```json
{
  ...
  "vscode.resources.limits.cpu": "2",
  "vscode.resources.requests.cpu": "2",
  "vscode.resources.limits.memory": "24Gi",
  "vscode.resources.requests.memory": "24Gi",
  ...
}
```

Therefore the estimated capacity (after overhead) of each is

| Instance class | vCPUs | Memory | GPUs | Estimated Capacity |
|:---:|:---:|:---:|:---:|:---:|
| g5.2xlarge | 8 | 32 | 1 | 1 |
| g5.4xlarge | 16 | 64 | 1 | 2 |
| g5.8xlarge | 32 | 128 | 1 | 5 |

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>