### PR TITLE
Import and Create AWS secret github-token  in code

### DIFF
--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -27,3 +27,23 @@ resource "aws_secretsmanager_secret" "release_failure_webhook_url" {
   description = "Slack webhook URL for release failure notifications"
   kms_key_id  = "alias/aws/secretsmanager"
 }
+
+
+import {
+  to = aws_secretsmanager_secret.github_token
+  identity = {
+    "arn" = "arn:aws:secretsmanager:eu-west-1:042130406152:secret:github-token-SAag9J"
+  }
+}
+#tfsec:ignore:AVD-AWS-0098 CMK encryption is not required for this secret
+resource "aws_secretsmanager_secret" "github_token" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
+  name        = "github-token"
+  description = "Token for use in Analytical Platform/MOJ Analytical Services"
+  kms_key_id  = "alias/aws/secretsmanager"
+  tags = {
+    credential-expiration = "2027-01-06"
+  }
+}


### PR DESCRIPTION
This pull request adds a new AWS Secrets Manager secret for a GitHub token to the Terraform configuration. The secret is imported into the state, and appropriate provider, encryption, and tagging settings are included, along with compliance check skips and documentation.

**Infrastructure additions:**

* Added a new `aws_secretsmanager_secret` resource for `github_token`, including description, KMS key, provider, and tags for credential expiration.
* Imported the existing GitHub token secret (`github-token-SAag9J`) into Terraform state for management.

**Compliance and documentation:**

* Added comments to skip specific tfsec and checkov compliance checks, documenting why CMK encryption and automatic rotation are not required for this secret.# Pull Request Objective

This piece of work is being tracked in [this](https://github.com/orgs/ministryofjustice/projects/27/views/18?pane=issue&itemId=122529996&issue=ministryofjustice%7Canalytical-platform-security%7C5) GitHub Issue.

