### PR TITLE
Remove Components To Be Retired

### DIFF
--- a/.github/workflows/schedule-issue-modernisation-platform-environments.yml
+++ b/.github/workflows/schedule-issue-modernisation-platform-environments.yml
@@ -42,8 +42,6 @@ jobs:
             - [ ] [analytical-platform-common](https://github.com/ministryofjustice/modernisation-platform-environments/tree/main/terraform/environments/analytical-platform-common)
             - [ ] [analytical-platform-compute](https://github.com/ministryofjustice/modernisation-platform-environments/tree/main/terraform/environments/analytical-platform-compute)
             - [ ] [analytical-platform-ingestion](https://github.com/ministryofjustice/modernisation-platform-environments/tree/main/terraform/environments/analytical-platform-ingestion)
-            - [ ] [analytical-platform-next-poc-hub](https://github.com/ministryofjustice/modernisation-platform-environments/tree/main/terraform/environments/analytical-platform-next-poc-hub)
-            - [ ] [analytical-platform-next-poc-producer](https://github.com/ministryofjustice/modernisation-platform-environments/tree/main/terraform/environments/analytical-platform-next-poc-producer)
             - [ ] Add any not included here if they are created.
 
           PINNED: false


### PR DESCRIPTION
This pull request makes a minor update to the scheduled issue checklist in the GitHub Actions workflow. Specifically, it removes two environments from the checklist, because they are no longer needed.

- Removed `analytical-platform-next-poc-hub` and `analytical-platform-next-poc-producer` from the environment checklist in `.github/workflows/schedule-issue-modernisation-platform-environments.yml` as these do not need to be maintained as soon to be retired.
