### PR TITLE
🔧 Tooling Development Cluster: Upgrade EKS control plane 1.29 -> 1.30

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -128,7 +128,7 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 
 eks_versions = {
-  cluster    = "1.29"
+  cluster    = "1.30"
   node-group = "1.29"
 }
 eks_addon_versions = {


### PR DESCRIPTION
> [!NOTE]  
> This relates to https://github.com/ministryofjustice/analytical-platform/issues/9449

Upgrades the EKS control plane from 1.29 to 1.30 for the tooling development cluster.

**Note:** Node groups remain on 1.29. They will be upgraded in a subsequent PR after the control plane upgrade is complete.


:copilot: This description was written by Copilot and edited by @Gary-H9.