### PR TITLE
🔧 Tooling Development Cluster: Upgrade EKS add-ons

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -132,10 +132,10 @@ eks_versions = {
   node-group = "1.29"
 }
 eks_addon_versions = {
-  coredns        = "v1.11.3-eksbuild.1"
-  ebs-csi-driver = "v1.35.0-eksbuild.1"
-  kube-proxy     = "v1.29.7-eksbuild.9"
-  vpc-cni        = "v1.18.5-eksbuild.1"
+  coredns        = "v1.11.4-eksbuild.28"
+  ebs-csi-driver = "v1.54.0-eksbuild.1"
+  kube-proxy     = "v1.30.14-eksbuild.20"
+  vpc-cni        = "v1.21.1-eksbuild.1"
 }
 eks_node_group_name_prefix = "dev"
 eks_node_group_capacities = {


### PR DESCRIPTION
> [!NOTE]  
> This relates to https://github.com/ministryofjustice/analytical-platform/issues/9449

Upgrades the EKS addons to versions compatible with Kubernetes 1.30 for the development cluster.

## Addon Version Changes

| Addon | Current (1.29) | Target (1.30) |
|-------|----------------|---------------|
| coredns | `v1.11.3-eksbuild.1` | `v1.11.4-eksbuild.28` |
| vpc-cni | `v1.18.5-eksbuild.1` | `v1.21.1-eksbuild.1` |
| kube-proxy | `v1.29.7-eksbuild.9` | `v1.30.14-eksbuild.20` |
| ebs-csi-driver | `v1.35.0-eksbuild.1` | `v1.54.0-eksbuild.1` |

This PR should be applied **after** the control plane has been upgraded to 1.30 (#9617).

:copilot: This description was written by Copilot and edited by @Gary-H9.