### PR TITLE
🔧 Tooling Development Cluster: Upgrade Node Groups

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -129,7 +129,7 @@ redis_alarm_memory_threshold_bytes = 100000
 
 eks_versions = {
   cluster    = "1.29"
-  node-group = "1.29"
+  node-group = "1.30"
 }
 eks_addon_versions = {
   coredns        = "v1.11.3-eksbuild.1"


### PR DESCRIPTION
> [!NOTE]  
> This relates to https://github.com/ministryofjustice/analytical-platform/issues/9449

Upgrades the EKS node groups from 1.29 to 1.30 for the development cluster.

## Notes

This PR should be applied **after** the following have been completed:
1. Control plane upgrade to 1.30 (#9617)
2. Addon upgrades for 1.30 compatibility (#9618)

Once applied, nodes will be replaced with new 1.30 nodes via a rolling update.

:copilot: This description was written by Copilot and edited by @Gary-H9.