### PR TITLE
⚫ Send /metrics to the blackhole

### DIFF
--- a/terraform/cloud-platform/live/analytical-platform-development/grafana/helm-releases.tf
+++ b/terraform/cloud-platform/live/analytical-platform-development/grafana/helm-releases.tf
@@ -1,36 +1,36 @@
-resource "helm_release" "grafana" {
-  /* https://artifacthub.io/packages/helm/grafana/grafana */
-  name       = "grafana"
-  repository = "https://grafana.github.io/helm-charts"
-  chart      = "grafana"
-  version    = "9.3.2"
-  namespace  = var.namespace
-  values = [
-    templatefile(
-      "${path.module}/src/helm/values/grafana/values.yml.tftpl",
-      {
-        namespace           = var.namespace,
-        github_organisation = "ministryofjustice",
-        github_admin_team   = "analytical-platform-engineers",
-        github_team_ids = join(",", [
-          data.github_team.analytical_platform_engineers.id,
-          data.github_team.analytical_platform_airflow.id,
-          data.github_team.data_engineering.id,
-          data.github_team.probation_data_science.id,
-          data.github_team.probation_integration.id
-        ])
-      }
-    )
-  ]
+# resource "helm_release" "grafana" {
+#   /* https://artifacthub.io/packages/helm/grafana/grafana */
+#   name       = "grafana"
+#   repository = "https://grafana.github.io/helm-charts"
+#   chart      = "grafana"
+#   version    = "9.3.2"
+#   namespace  = var.namespace
+#   values = [
+#     templatefile(
+#       "${path.module}/src/helm/values/grafana/values.yml.tftpl",
+#       {
+#         namespace           = var.namespace,
+#         github_organisation = "ministryofjustice",
+#         github_admin_team   = "analytical-platform-engineers",
+#         github_team_ids = join(",", [
+#           data.github_team.analytical_platform_engineers.id,
+#           data.github_team.analytical_platform_airflow.id,
+#           data.github_team.data_engineering.id,
+#           data.github_team.probation_data_science.id,
+#           data.github_team.probation_integration.id
+#         ])
+#       }
+#     )
+#   ]
 
-  set_sensitive = [
-    {
-      name  = "env.GF_AUTH_GITHUB_CLIENT_ID"
-      value = data.aws_secretsmanager_secret_version.analytical_platform_grafana_development_github_client_id.secret_string
-    },
-    {
-      name  = "env.GF_AUTH_GITHUB_CLIENT_SECRET"
-      value = data.aws_secretsmanager_secret_version.analytical_platform_grafana_development_github_client_secret.secret_string
-    }
-  ]
-}
+#   set_sensitive = [
+#     {
+#       name  = "env.GF_AUTH_GITHUB_CLIENT_ID"
+#       value = data.aws_secretsmanager_secret_version.analytical_platform_grafana_development_github_client_id.secret_string
+#     },
+#     {
+#       name  = "env.GF_AUTH_GITHUB_CLIENT_SECRET"
+#       value = data.aws_secretsmanager_secret_version.analytical_platform_grafana_development_github_client_secret.secret_string
+#     }
+#   ]
+# }

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
@@ -3,7 +3,7 @@ resource "helm_release" "grafana" {
   name       = "grafana"
   repository = "https://grafana.github.io/helm-charts"
   chart      = "grafana"
-  version    = "9.3.2"
+  version    = "10.5.13"
   namespace  = var.namespace
   values = [
     templatefile(

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
@@ -19,6 +19,14 @@ ingress:
     - secretName: observability-tls
       hosts:
         - observability.analytical-platform.service.justice.gov.uk
+  extraPaths:
+    - path: /metrics
+      pathType: Exact
+      backend:
+        service:
+          name: blackhole
+          port:
+            number: 80
 
 serviceMonitor:
   enabled: true


### PR DESCRIPTION
## Proposed Changes

- `/metrics` was publically accessible 😭 it's not anymore 👍
- Upgrades Grafana to `10.5.13`
- Turns off the development version

Signed-off-by: Jacob Woffenden <jacob.woffenden@justice.gov.uk>