### PR TITLE
feat: add ec2:DescribeAvailabilityZones to EBS CSI driver IAM policy

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -288,6 +288,7 @@ data "aws_iam_policy_document" "ebs_csi_driver" {
       "ec2:DeleteSnapshot",
       "ec2:DeleteTags",
       "ec2:DeleteVolume",
+      "ec2:DescribeAvailabilityZones",
       "ec2:DescribeInstances",
       "ec2:DescribeSnapshots",
       "ec2:DescribeTags",

--- a/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-production/cluster/iam-policies.tf
@@ -16,6 +16,7 @@ data "aws_iam_policy_document" "ebs_csi_driver" {
       "ec2:DeleteSnapshot",
       "ec2:DeleteTags",
       "ec2:DeleteVolume",
+      "ec2:DescribeAvailabilityZones",
       "ec2:DescribeInstances",
       "ec2:DescribeSnapshots",
       "ec2:DescribeTags",


### PR DESCRIPTION
## Summary

Adds the missing `ec2:DescribeAvailabilityZones` permission to the EBS CSI Driver IAM policy for both development and production clusters.

## Problem

The EBS CSI Driver v1.54.0 now performs a health check by calling `ec2:DescribeAvailabilityZones`. Without this permission, the controller pods fail their health checks and enter `CrashLoopBackOff`:

```
E0128 16:53:12.290575       1 main.go:78] "Health check failed" err="rpc error: code = FailedPrecondition desc = Failed health check (verify network connection and IAM credentials): dry-run EC2 API call failed: operation error EC2: DescribeAvailabilityZones, https response error StatusCode: 403, RequestID: ..., api error UnauthorizedOperation: You are not authorized to perform this operation. User: arn:aws:sts::525294151996:assumed-role/EbsCsiDriver20230220165045904000000002/... is not authorized to perform: ec2:DescribeAvailabilityZones because no identity-based policy allows the ec2:DescribeAvailabilityZones action"
```

## Solution

Add `ec2:DescribeAvailabilityZones` to the EBS CSI Driver IAM policy in both:
- `terraform/aws/analytical-platform-development/cluster/iam-policies.tf`
- `terraform/aws/analytical-platform-production/cluster/iam-policies.tf`

## Testing

After applying this Terraform change:
1. The IAM policy will be updated in AWS
2. The EBS CSI controller pods will pass their health checks
3. The pods should transition from `CrashLoopBackOff` to `Running`