### PR TITLE
🔧 Tooling Production Cluster: Upgrade EKS add-ons

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -134,10 +134,10 @@ eks_versions = {
   node-group = "1.29"
 }
 eks_addon_versions = {
-  coredns        = "v1.11.3-eksbuild.1"
-  ebs-csi-driver = "v1.35.0-eksbuild.1"
-  kube-proxy     = "v1.29.7-eksbuild.9"
-  vpc-cni        = "v1.18.5-eksbuild.1"
+  coredns        = "v1.11.4-eksbuild.28"
+  ebs-csi-driver = "v1.54.0-eksbuild.1"
+  kube-proxy     = "v1.30.14-eksbuild.20"
+  vpc-cni        = "v1.21.1-eksbuild.1"
 }
 eks_node_group_name_prefix = "prod"
 eks_node_group_capacities = {

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -130,7 +130,7 @@ redis_alarm_memory_threshold_bytes = 100000
 # EKS
 ##################################################
 eks_versions = {
-  cluster    = "1.29"
+  cluster    = "1.30"
   node-group = "1.29"
 }
 eks_addon_versions = {


### PR DESCRIPTION
> [!NOTE]  
> This relates to https://github.com/ministryofjustice/analytical-platform/issues/9449

Upgrades the EKS addons to versions compatible with Kubernetes 1.30 for the production cluster.

This is the production equivalent of #9618.

## Addon Version Changes

| Addon | Current (1.29) | Target (1.30) |
|-------|----------------|---------------|
| coredns | `v1.11.3-eksbuild.1` | `v1.11.4-eksbuild.28` |
| vpc-cni | `v1.18.5-eksbuild.1` | `v1.21.1-eksbuild.1` |
| kube-proxy | `v1.29.7-eksbuild.9` | `v1.30.14-eksbuild.20` |
| ebs-csi-driver | `v1.35.0-eksbuild.1` | `v1.54.0-eksbuild.1` |

This PR should be applied **after** the control plane has been upgraded to 1.30 (#9631).