### PR TITLE
🔧 Tooling Production Cluster: Upgrade Node Groups

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -130,8 +130,8 @@ redis_alarm_memory_threshold_bytes = 100000
 # EKS
 ##################################################
 eks_versions = {
-  cluster    = "1.29"
-  node-group = "1.29"
+  cluster    = "1.30"
+  node-group = "1.30"
 }
 eks_addon_versions = {
   coredns        = "v1.11.3-eksbuild.1"

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -134,10 +134,10 @@ eks_versions = {
   node-group = "1.30"
 }
 eks_addon_versions = {
-  coredns        = "v1.11.3-eksbuild.1"
-  ebs-csi-driver = "v1.35.0-eksbuild.1"
-  kube-proxy     = "v1.29.7-eksbuild.9"
-  vpc-cni        = "v1.18.5-eksbuild.1"
+  coredns        = "v1.11.4-eksbuild.28"
+  ebs-csi-driver = "v1.54.0-eksbuild.1"
+  kube-proxy     = "v1.30.14-eksbuild.20"
+  vpc-cni        = "v1.21.1-eksbuild.1"
 }
 eks_node_group_name_prefix = "prod"
 eks_node_group_capacities = {


### PR DESCRIPTION
> [!NOTE]  
> This relates to https://github.com/ministryofjustice/analytical-platform/issues/9449

Upgrades the EKS node groups from 1.29 to 1.30 for the production cluster.

Additionally this PR subsumes 

This is the production equivalent of #9619.

## Notes

This PR should be applied **after** the following have been completed:
1. Control plane upgrade to 1.30 (#9631)
2. Addon upgrades for 1.30 compatibility (#9632)

Once applied, nodes will be replaced with new 1.30 nodes via a rolling update.