### PR TITLE
add current and expected AP-airflow DAG roles to Mags (magistrates) d…

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -20,6 +20,8 @@ locals {
         "airflow_prod_mags_data_processor",
         "restricted-admin",
         "airflow_dev_mags_data_processor",
+        "airflow-production-hmcts-dev-mags-combined-dev",
+        "airflow-production-hmcts-mags-combined"
       ]
     },
     {

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -20,8 +20,7 @@ locals {
         "airflow_prod_mags_data_processor",
         "restricted-admin",
         "airflow_dev_mags_data_processor",
-        "airflow-production-hmcts-dev-mags-combined-dev",
-        "airflow-production-hmcts-mags-combined"
+        "airflow-production-hmcts-dev-mags-combined-dev"
       ]
     },
     {


### PR DESCRIPTION
…atabase permissions

# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/moj-analytical-services/dmet-hmcts/issues/291)
GitHub Issue and referenced in [this](https://mojdt.slack.com/archives/C4PF7QAJZ/p1770127972524869) slack thread.

Add the current `dev` DAG role to allow access to databases linked to the current Magistrates databases.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
