### PR TITLE
Keep delius prod storage at 500, revert instance only

### DIFF
--- a/terraform/aws/analytical-platform-data-engineering-production/dms-prod/dms.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/dms-prod/dms.tf
@@ -65,7 +65,7 @@ module "prod_dms_delius" {
     replication_instance_id    = "delius-prod"
     subnet_ids                 = module.vpc.private_subnets
     subnet_group_name          = "delius-prod"
-    allocated_storage          = 200
+    allocated_storage          = 500
     availability_zone          = data.aws_availability_zones.available.names[0]
     engine_version             = "3.5.4"
     kms_key_arn                = module.dms_prod_kms.key_arn


### PR DESCRIPTION
Now only changing instance, not storage

# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/<your_issue_number_here>)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
