### PR TITLE
Create-a-derived-table [airflow deployer] add data locations for hybrid s3 paths

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -221,15 +221,22 @@ locals {
     "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=sirius_derived/table_name=opg_annual_report",
     "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=prison/database_name=calculate_release_dates_api"
   ]
+
+  lf_data_location_roles = [
+    "arn:aws:iam::593291632749:role/airflow_prod_cadet_deploy_nomis_daily",
+    "arn:aws:iam::593291632749:role/create-a-derived-table"
+  ]
 }
 
-resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
-  for_each = toset(local.create_a_derived_table_data_locations)
 
-  principal   = "arn:aws:iam::593291632749:role/create-a-derived-table"
+
+resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
+  for_each = setproduct(local.lf_data_location_roles, local.create_a_derived_table_data_locations)
+
+  principal   = each.value[0]
   permissions = ["DATA_LOCATION_ACCESS"]
 
   data_location {
-    arn = each.value
+    arn = each.value[1]
   }
 }

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -228,13 +228,24 @@ locals {
   ]
 }
 
+# Give all s3 locations to each role
 resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
-  for_each = setproduct(local.lf_data_location_roles, local.create_a_derived_table_data_locations)
 
-  principal   = each.value[0]
+  for_each = {
+    for pair in setproduct(
+      local.lf_data_location_roles,
+      local.create_a_derived_table_data_locations
+    ) :
+    "${pair[0]}|${pair[1]}" => {
+      principal = pair[0]
+      location  = pair[1]
+    }
+  }
+
+  principal   = each.value.principal
   permissions = ["DATA_LOCATION_ACCESS"]
 
   data_location {
-    arn = each.value[1]
+    arn = each.value.location
   }
 }

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -228,8 +228,6 @@ locals {
   ]
 }
 
-
-
 resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
   for_each = setproduct(local.lf_data_location_roles, local.create_a_derived_table_data_locations)
 

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -226,7 +226,7 @@ locals {
 resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
   for_each = toset(local.create_a_derived_table_data_locations)
 
-  principal = module.create_a_derived_table_iam_role.role_arn
+  principal = arn:aws:iam::593291632749:role/create-a-derived-table
   permissions = ["DATA_LOCATION_ACCESS"]
 
   data_location {

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -135,7 +135,7 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=prison/database_name=calculate_release_dates_api"
     ]
   }
-  
+
   statement {
     sid    = "AirflowAccess"
     effect = "Allow"

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -122,6 +122,21 @@ data "aws_iam_policy_document" "create_a_derived_table" {
     resources = ["*"]
   }
   statement {
+    sid    = "LakeFormationDataLocationAccess"
+    effect = "Allow"
+    actions = [
+      "lakeformation:GrantPermissions"
+    ]
+    resources = [
+      "arn:aws:s3:::alpha-app-opg-lpa-dashboard/prod/models/domain_name=opg/database_name=sirius_derived",
+      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=guardianship_derived",
+      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=sirius_derived",
+      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=sirius_derived/table_name=opg_annual_report",
+      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=prison/database_name=calculate_release_dates_api"
+    ]
+  }
+  
+  statement {
     sid    = "AirflowAccess"
     effect = "Allow"
     actions = [
@@ -194,5 +209,27 @@ module "create_a_derived_table_iam_role" {
       provider_arn               = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/F147414004D7C4CF820F21F453AF80F1"
       namespace_service_accounts = ["actions-runners:actions-runner-mojas-create-a-derived-table"]
     }
+  }
+}
+
+# Lake formation hybrid locations
+locals {
+  create_a_derived_table_data_locations = [
+    "arn:aws:s3:::alpha-app-opg-lpa-dashboard/prod/models/domain_name=opg/database_name=sirius_derived",
+    "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=guardianship_derived",
+    "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=sirius_derived",
+    "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=sirius_derived/table_name=opg_annual_report",
+    "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=prison/database_name=calculate_release_dates_api"
+  ]
+}
+
+resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
+  for_each = toset(local.create_a_derived_table_data_locations)
+
+  principal   = module.create_a_derived_table_iam_role.iam_role_arn
+  permissions = ["DATA_LOCATION_ACCESS"]
+
+  data_location {
+    arn = each.value
   }
 }

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -232,13 +232,11 @@ locals {
 resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
 
   for_each = {
-    for pair in setproduct(
-      local.lf_data_location_roles,
-      local.create_a_derived_table_data_locations
-    ) :
-    "${pair[0]}|${pair[1]}" => {
-      principal = pair[0]
-      location  = pair[1]
+    for role in local.lf_data_location_roles :
+    for location in local.create_a_derived_table_data_locations :
+    "${role}|${location}" => {
+      principal = role
+      location  = location
     }
   }
 

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -226,7 +226,7 @@ locals {
 resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
   for_each = toset(local.create_a_derived_table_data_locations)
 
-  principal   = module.create_a_derived_table_iam_role.iam_role_arn
+  principal = module.create_a_derived_table_iam_role.role_arn
   permissions = ["DATA_LOCATION_ACCESS"]
 
   data_location {

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -226,7 +226,7 @@ locals {
 resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
   for_each = toset(local.create_a_derived_table_data_locations)
 
-  principal = "arn:aws:iam::593291632749:role/create-a-derived-table"
+  principal   = "arn:aws:iam::593291632749:role/create-a-derived-table"
   permissions = ["DATA_LOCATION_ACCESS"]
 
   data_location {

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -227,18 +227,20 @@ locals {
     "arn:aws:iam::593291632749:role/create-a-derived-table"
   ]
 }
-
-# Give all s3 locations to each role
-resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
-
-  for_each = {
-    for role in local.lf_data_location_roles :
-    for location in local.create_a_derived_table_data_locations :
-    "${role}|${location}" => {
-      principal = role
-      location  = location
+# Combinations of paths and roles
+locals {
+  lf_data_location_pairs = merge([
+    for role in local.lf_data_location_roles : {
+      for location in local.create_a_derived_table_data_locations :
+      "${role}|${location}" => {
+        principal = role
+        location  = location
+      }
     }
-  }
+  ]...)
+}
+resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
+  for_each = local.lf_data_location_pairs
 
   principal   = each.value.principal
   permissions = ["DATA_LOCATION_ACCESS"]

--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table.tf
@@ -226,7 +226,7 @@ locals {
 resource "aws_lakeformation_permissions" "create_a_derived_table_data_locations" {
   for_each = toset(local.create_a_derived_table_data_locations)
 
-  principal = arn:aws:iam::593291632749:role/create-a-derived-table
+  principal = "arn:aws:iam::593291632749:role/create-a-derived-table"
   permissions = ["DATA_LOCATION_ACCESS"]
 
   data_location {


### PR DESCRIPTION
# Pull Request Objective

New airflow cadet deployer lacks DATA_LOCATION_ACCESS for s3 paths - mentioned in [this thread](https://mojdt.slack.com/archives/C4PF7QAJZ/p1770889254253929?thread_ts=1770281795.537679&cid=C4PF7QAJZ).

I've replicated the s3 paths noted in AWS LF console

<img width="1516" height="508" alt="image" src="https://github.com/user-attachments/assets/e4d9c856-6c66-4a17-aeb3-cd639329a433" />

The intention is by specifying the permissions here that the airflow roles will inherit them.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
