### PR TITLE
Increase Control Panel RDS instance size in dev

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -53,7 +53,7 @@ efs_low_credit_burst_balance_alarm_threshold = 50000
 # RDS
 ##################################################
 
-rds_instance_class       = "db.t3.micro"
+rds_instance_class       = "db.t3.small"
 rds_engine               = "postgres"
 rds_family               = "postgres17"
 rds_engine_version       = "17.4"


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/9713)
GitHub Issue.

Increase the Control Panel dev RDS instance to `db.t3.small`. See the linked ticket for full context.

This will cause some downtime, applying the change in dev first to monitor behaviour.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
