### PR TITLE
Schedule RDS instance size upgrade in prod

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/rds.tf
+++ b/terraform/aws/analytical-platform-production/cluster/rds.tf
@@ -39,7 +39,7 @@ module "rds" {
   create_monitoring_role      = true
   manage_master_user_password = false
   allow_major_version_upgrade = true
-  apply_immediately           = true
+  apply_immediately           = false
 
   parameters = var.rds_paramaters
 

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -54,7 +54,7 @@ efs_low_credit_burst_balance_alarm_threshold = 50000
 # RDS
 ##################################################
 
-rds_instance_class        = "db.t3.micro"
+rds_instance_class        = "db.t3.small"
 rds_engine                = "postgres"
 rds_family                = "postgres17"
 rds_engine_version        = "17.4"
@@ -65,7 +65,7 @@ rds_multi_az              = true
 rds_storage_encrypted     = true
 rds_db_name               = "controlpanel"
 rds_snapshot_identifier   = "eks-production-control-panelspsg-db-newly-encrypted"
-rds_maintenance_window    = "Mon:00:00-Mon:03:00"
+rds_maintenance_window    = "Wed:00:00-Wed:03:00"
 rds_backup_window         = "03:00-06:00"
 rds_ca_cert_identifier    = "rds-ca-rsa2048-g1"
 rds_monitoring_interval   = 30


### PR DESCRIPTION

# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/9713)
GitHub Issue.

Set production RDS maintenance window to Wed 00:00-03:00 and schedule upgrade instance class to db.t3.small. This will be applied during the next maintenance window.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
