### PR TITLE
fix: add EM account id and glue perms to airflow runner

### DIFF
--- a/terraform/aws/analytical-platform-data-production/airflow-service/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/airflow-service/iam-policies.tf
@@ -378,7 +378,11 @@ data "aws_iam_policy_document" "create_a_derived_table" {
       "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:schema/*",
       "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:database/*",
       "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:table/*/*",
-      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:catalog"
+      "arn:aws:glue:*:${var.account_ids["analytical-platform-data-production"]}:catalog",
+      "arn:aws:glue:*:${var.account_ids["electronic-monitoring-data-production"]}:schema/*",
+      "arn:aws:glue:*:${var.account_ids["electronic-monitoring-data-production"]}:database/*",
+      "arn:aws:glue:*:${var.account_ids["electronic-monitoring-data-production"]}:table/*/*",
+      "arn:aws:glue:*:${var.account_ids["electronic-monitoring-data-production"]}:catalog"
     ]
   }
   statement {

--- a/terraform/aws/analytical-platform-data-production/airflow-service/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/airflow-service/terraform.tfvars
@@ -1,6 +1,7 @@
 account_ids = {
   analytical-platform-data-production       = "593291632749"
   analytical-platform-management-production = "042130406152"
+  electronic-monitoring-data-production     = "976799291502"
 }
 
 tags = {


### PR DESCRIPTION
# Pull Request Objective

To automate the pull of data from em data factory to ap - add perms to get glue databases.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
