### PR TITLE
added glue catalog db resource

### DIFF
--- a/terraform/aws/analytical-platform-data-engineering-production/data-engineering-pipelines/glue.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/data-engineering-pipelines/glue.tf
@@ -1,0 +1,7 @@
+# required for the hmpps_probation_data_tables cadet project
+# the schema in the profiles.yml becomes the default database
+# for the connection so if it doesn't exist schema changes
+# error
+resource "aws_glue_catalog_database" "cadet_probation_schema" {
+  name = "probation"
+}


### PR DESCRIPTION
For incremental models that have append new columns config for on schema change, when CaDeT runs the alter query it needs the default schema/database that is specified in the profiles.yml to exist other wise it errors. This is since the connection uses the default value. Changing it to a database that did exist meant the query then worked so creating a the database specified in the profiles.yaml file. https://docs.aws.amazon.com/athena/latest/APIReference/API_StartQueryExecution.html

# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/<your_issue_number_here>)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
