### PR TITLE
Update Trivy Ignore to New Format

### DIFF
--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -107,7 +107,7 @@ locals {
   }
 }
 
-#trivy:ignore:avd-aws-0006:Not encrypting the workgroup currently
+# trivy:ignore:avd-aws-0006 Not encrypting the workgroup currently
 resource "aws_athena_workgroup" "airflow" {
   #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
 
@@ -139,8 +139,8 @@ resource "aws_athena_workgroup" "airflow" {
   )
 }
 
-#trivy:ignore:avd-aws-0006:Not encrypting the workgroup currently
-#trivy:ignore:avd-aws-0007:Can't enforce output location due to DBT requirements
+# trivy:ignore:avd-aws-0006 Not encrypting the workgroup currently
+# trivy:ignore:avd-aws-0007 Can't enforce output location due to DBT requirements
 resource "aws_athena_workgroup" "dbt" {
   #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
   #checkov:skip=CKV_AWS_82:Can't enforce output location due to DBT requirements

--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -107,7 +107,8 @@ locals {
   }
 }
 
-# trivy:ignore:avd-aws-0006 Not encrypting the workgroup currently
+
+# trivy:ignore:AVD-AWS-0006 Not encrypting the workgroup currently
 resource "aws_athena_workgroup" "airflow" {
   #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
 
@@ -139,8 +140,8 @@ resource "aws_athena_workgroup" "airflow" {
   )
 }
 
-# trivy:ignore:avd-aws-0006 Not encrypting the workgroup currently
-# trivy:ignore:avd-aws-0007 Can't enforce output location due to DBT requirements
+# trivy:ignore:AVD-AWS-0006 Not encrypting the workgroup currently
+# trivy:ignore:AVD-AWS-0007 Can't enforce output location due to DBT requirements
 resource "aws_athena_workgroup" "dbt" {
   #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
   #checkov:skip=CKV_AWS_82:Can't enforce output location due to DBT requirements


### PR DESCRIPTION
The trivy syntax has changed. The old format `#trivy:ignore:avd-aws-0006:Not encrypting... `(with colon immediately after rule ID) is no longer supported. The new format should use a space instead of a colon

This pull request makes changes to the Trivy ignore comments in the `athena-workgroups.tf` file. The comments are now consistent with the new formart.




