### PR TITLE
added provider for plat engineer admin role

### DIFF
--- a/terraform/aws/analytical-platform/baseline/infrastructure-access.tf
+++ b/terraform/aws/analytical-platform/baseline/infrastructure-access.tf
@@ -6,6 +6,7 @@ module "data_production_infrastructure_access" {
   source = "./modules/infrastructure-access"
 
   providers = {
-    aws = aws.analytical-platform-data-production-eu-west-2
+    aws                                = aws.analytical-platform-data-production-eu-west-2
+    aws.platform_engineer_admin_source = aws.platform-engineer-admin-source-eu-west-2
   }
 }

--- a/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/main.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/main.tf
@@ -1,3 +1,11 @@
+data "aws_iam_roles" "platform_engineer_admin" {
+  provider = aws.platform_engineer_admin_source
+
+  # AWS Identity Centre role names include a generated suffix; match by stable prefix.
+  name_regex  = "^AWSReservedSSO_platform-engineer-admin_.*$"
+  path_prefix = "/aws-reserved/sso.amazonaws.com/eu-west-2/"
+}
+
 module "analytical_platform_infrastructure_access_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
@@ -17,6 +25,16 @@ module "analytical_platform_infrastructure_access_iam_role" {
       principals = [{
         type        = "AWS"
         identifiers = ["arn:aws:iam::509399598587:role/analytical-platform-github-actions"]
+      }]
+    }
+    platformEngineerAssumeRole = {
+      actions = [
+        "sts:AssumeRole",
+        "sts:TagSession"
+      ]
+      principals = [{
+        type        = "AWS"
+        identifiers = [one(data.aws_iam_roles.platform_engineer_admin.arns)]
       }]
     }
   }

--- a/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/providers.tf
+++ b/terraform/aws/analytical-platform/baseline/modules/infrastructure-access/providers.tf
@@ -3,6 +3,7 @@ terraform {
     aws = {
       source  = "hashicorp/aws"
       version = "~> 6.0"
+      configuration_aliases = [aws.platform_engineer_admin_source]
     }
   }
   required_version = "~> 1.10"

--- a/terraform/aws/analytical-platform/baseline/terraform.tf
+++ b/terraform/aws/analytical-platform/baseline/terraform.tf
@@ -25,6 +25,21 @@ provider "aws" {
 }
 
 ##################################################
+# Platform Engineer Admin Source
+##################################################
+
+provider "aws" {
+  alias  = "platform-engineer-admin-source-eu-west-2"
+  region = "eu-west-2"
+  assume_role {
+    role_arn = "arn:aws:iam::509399598587:role/analytical-platform-infrastructure-access"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}
+
+##################################################
 # Data Development
 ##################################################
 


### PR DESCRIPTION
# Pull Request Objective

This piece of work helps resolve [this dependabot ](https://github.com/ministryofjustice/analytical-platform-airflow/pull/2875)

In order to approve the dependabot PR we need to first run some terraform import commands, currently it is not possible to run terraform locally in the Airflow repo. 
This PR adds a new provider to facilitate adding the platform engineer admin role as a trusted entity to the infrastructure access role, which will then enable us to run terraform locally in the Analytical Platform Airflow repo.

The other option would be to use the root user and a condition block - as shown [here](https://github.com/ministryofjustice/analytical-platform/pull/9746/changes)

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
