### PR TITLE
🔒 Development: Create Chainguard Kubernetes Secret 

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/data.tf
+++ b/terraform/aws/analytical-platform-development/cluster/data.tf
@@ -59,6 +59,11 @@ data "aws_secretsmanager_secret_version" "pagerduty_analytical_platform_storage_
   secret_id = "pagerduty/analytical-platform-storage/integration-keys/cloudwatch"
 }
 
+data "aws_secretsmanager_secret_version" "chainguard_image_pull_token" {
+  provider  = aws.analytical-platform-management-production
+  secret_id = "chainguard-image-pull-token"
+}
+
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/terraform/aws/analytical-platform-development/cluster/kubernetes-secrets.tf
+++ b/terraform/aws/analytical-platform-development/cluster/kubernetes-secrets.tf
@@ -1,12 +1,24 @@
+locals {
+  chainguard-credentials = jsondecode(data.aws_secretsmanager_secret_version.chainguard_image_pull_token.secret_string)
+}
+
 resource "kubernetes_secret_v1" "chainguard" {
   metadata {
     name      = "chainguard"
     namespace = "ingress-nginx"
   }
 
-  type = "Opaque"
+  type = "kubernetes.io/dockerconfigjson"
 
   data = {
-    "token" = data.aws_secretsmanager_secret_version.chainguard_image_pull_token.secret_string
+    ".dockerconfigjson" = jsonencode({
+      auths = {
+        "cgr.dev" = {
+          username = local.chainguard-credentials["username"]
+          password = local.chainguard-credentials["password"]
+          auth     = base64encode("${local.chainguard-credentials["username"]}:${local.chainguard-credentials["password"]}")
+        }
+      }
+    })
   }
 }

--- a/terraform/aws/analytical-platform-development/cluster/kubernetes-secrets.tf
+++ b/terraform/aws/analytical-platform-development/cluster/kubernetes-secrets.tf
@@ -1,0 +1,12 @@
+resource "kubernetes_secret_v1" "chainguard" {
+  metadata {
+    name      = "chainguard"
+    namespace = "ingress-nginx"
+  }
+
+  type = "Opaque"
+
+  data = {
+    "token" = data.aws_secretsmanager_secret_version.chainguard_image_pull_token.secret_string
+  }
+}

--- a/terraform/aws/analytical-platform-development/cluster/kubernetes-secrets.tf
+++ b/terraform/aws/analytical-platform-development/cluster/kubernetes-secrets.tf
@@ -1,5 +1,5 @@
 locals {
-  chainguard-credentials = jsondecode(data.aws_secretsmanager_secret_version.chainguard_image_pull_token.secret_string)
+  chainguard_credentials = jsondecode(data.aws_secretsmanager_secret_version.chainguard_image_pull_token.secret_string)
 }
 
 resource "kubernetes_secret_v1" "chainguard" {
@@ -14,9 +14,9 @@ resource "kubernetes_secret_v1" "chainguard" {
     ".dockerconfigjson" = jsonencode({
       auths = {
         "cgr.dev" = {
-          username = local.chainguard-credentials["username"]
-          password = local.chainguard-credentials["password"]
-          auth     = base64encode("${local.chainguard-credentials["username"]}:${local.chainguard-credentials["password"]}")
+          username = local.chainguard_credentials["username"]
+          password = local.chainguard_credentials["password"]
+          auth     = base64encode("${local.chainguard_credentials["username"]}:${local.chainguard_credentials["password"]}")
         }
       }
     })


### PR DESCRIPTION
 👷 🚧 This PR has already been applied 🚧 👷

This PR relates to [this](https://github.com/ministryofjustice/analytical-platform/issues/9751) piece of work. 

This change creates a Kubernetes secret of type `kubernetes.io/dockerconfigjson` in the `ingress-nginx` namespace, sourced from AWS Secrets Manager.

The secret stores Docker registry credentials for `cgr.dev` (Chainguard's container registry), enabling the cluster to authenticate when pulling Chainguard images.

We use the `kubernetes.io/dockerconfigjson` secret type because Kubernetes requires image pull credentials to be in the standard Docker config JSON format. This allows the secret to be referenced directly as an `imagePullSecrets` entry in pod specs or Helm chart values, which is the mechanism Kubernetes uses to authenticate against private container registries during image pulls.

The AWS Secrets Manager secret (`chainguard-image-pull-token` in `analytical-platform-management-production`) stores the credentials as JSON containing `username` and `password` fields, which are decoded and assembled into the expected Docker config structure at apply time.