### PR TITLE
Adding the new, deployment specific roles for OASys/Delius

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -46,7 +46,8 @@ locals {
         "create-a-derived-table",
         "github-actions-infrastructure",
         "restricted-admin",
-        "data-engineering-probation-glue"
+        "data-engineering-probation-glue",
+        "airflow-production-analytical-platform-cadet-curated-daily"
       ]
     },
     {
@@ -58,7 +59,8 @@ locals {
         "create-a-derived-table",
         "github-actions-infrastructure",
         "restricted-admin",
-        "data-engineering-probation-glue"
+        "data-engineering-probation-glue",
+        "airflow-production-analytical-platform-cadet-curated-daily"
       ]
     },
     {


### PR DESCRIPTION
# Pull Request Objective

This adds the `cadet-curated-daily` deployment workflow to the allowlist for Delius and OASys, as these are the core databases for this workflow. This mirrors the current permissions of the `create-a-derived-table` role.
## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected
