### PR TITLE
role exemption for xhibit to enable running of OneCrown models in Airflow

### DIFF
--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/locals.tf
@@ -6,7 +6,8 @@ locals {
       database_string_pattern = ["xhibit", "xhibit_derived"]
       role_names_to_exempt = [
         "create-a-derived-table",
-        "airflow_prod_cadet_deploy_xhibit"
+        "airflow_prod_cadet_deploy_xhibit",
+        "airflow-production-analytical-platform-cadet-onecrown-prod"
       ]
     },
     {


### PR DESCRIPTION
# Pull Request Objective

Adding a role exemption for Xhibit, so we can run OneCrown models, which xhibit is part of, in Airflow. This specifically addresses the below issue we encountered in Airflow:

```
Runtime Error in model xhibit__address_filter (models/courts/xhibit/xhibit__address_filter.sql)
[2026-03-10, 08:00:24 UTC] {pod_manager.py:471} INFO - [base]   User: arn:aws:sts::593291632749:assumed-role/airflow-production-analytical-platform-cadet-onecrown-prod/botocore-session-1773129554 is not authorized to perform: glue:UpdateTable on resource: arn:aws:glue:eu-west-1:593291632749:database/xhibit with an explicit deny in a resource-based policy (Service: AmazonDataCatalog; Status Code: 400; Error Code: AccessDeniedException; Request ID: 7a755997-b8d9-43df-96e4-51f9817cad66; Proxy: null)
```

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected
