### PR TITLE
Add iam:PassRole to bedrock_integration policy

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/security-groups.tf
+++ b/terraform/aws/analytical-platform-development/cluster/security-groups.tf
@@ -21,7 +21,6 @@ resource "aws_security_group" "efs" {
 ##################################################
 
 resource "aws_security_group" "aps" {
-  #checkov:skip=CKV_AWS_382: skip not atttached to ec2
   name        = "aps"
   description = "allow EKS cluster to access VPC endpoint for managed prometheus"
   vpc_id      = module.vpc.vpc_id

--- a/terraform/aws/analytical-platform-development/cluster/security-groups.tf
+++ b/terraform/aws/analytical-platform-development/cluster/security-groups.tf
@@ -21,6 +21,7 @@ resource "aws_security_group" "efs" {
 ##################################################
 
 resource "aws_security_group" "aps" {
+  #checkov:skip=CKV_AWS_382: skip not atttached to ec2
   name        = "aps"
   description = "allow EKS cluster to access VPC endpoint for managed prometheus"
   vpc_id      = module.vpc.vpc_id

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -66,6 +66,17 @@ data "aws_iam_policy_document" "bedrock_integration" {
       ]
     }
   }
+  statement {
+    sid       = "BedrockPassBatchInferenceRole"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/bedrock-batch-inference-role"]
+    condition {
+      test     = "StringEquals"
+      variable = "iam:PassedToService"
+      values   = ["bedrock.amazonaws.com"]
+    }
+  }
 }
 
 #tfsec:ignore:aws-iam-no-policy-wildcards


### PR DESCRIPTION


This pull request adds a new IAM policy statement to the `bedrock_integration` policy document, allowing the passing of a specific role to the Bedrock service for batch inference operations.

IAM policy update for Bedrock integration:

* Added a statement permitting the `iam:PassRole` action on the `bedrock-batch-inference-role`, but only when the role is being passed to `bedrock.amazonaws.com`.


This piece of work is being tracked in [this](https://github.com/ministryofjustice/analytical-platform/issues/9776) GitHub Issue.


