### PR TITLE
added route53 resolver firewall

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/data.tf
+++ b/terraform/aws/analytical-platform-development/cluster/data.tf
@@ -64,6 +64,10 @@ data "aws_secretsmanager_secret_version" "chainguard_image_pull_token" {
   secret_id = "chainguard-image-pull-token"
 }
 
+data "aws_secretsmanager_secret_version" "route53_resolver_firewall_blocked_domains_current" {
+  secret_id = aws_secretsmanager_secret.route53_resolver_firewall_blocked_domains.id
+}
+
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
+++ b/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
@@ -1,4 +1,5 @@
 resource "aws_secretsmanager_secret" "route53_resolver_firewall_blocked_domains" {
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret#checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   name        = "development/route53-resolver-firewall-blocked-domains"
   description = "Blocked domains for the Route53 resolver firewall"

--- a/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
+++ b/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
@@ -1,5 +1,5 @@
 resource "aws_secretsmanager_secret" "route53_resolver_firewall_blocked_domains" {
-  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret#checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   name        = "development/route53-resolver-firewall-blocked-domains"
   description = "Blocked domains for the Route53 resolver firewall"

--- a/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
+++ b/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
@@ -1,0 +1,48 @@
+resource "aws_secretsmanager_secret" "route53_resolver_firewall_blocked_domains" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  name        = "development/route53-resolver-firewall-blocked-domains"
+  description = "Blocked domains for the Route53 resolver firewall"
+  kms_key_id  = "alias/aws/secretsmanager"
+}
+
+resource "aws_secretsmanager_secret_version" "route53_resolver_firewall_blocked_domains" {
+  secret_id = aws_secretsmanager_secret.route53_resolver_firewall_blocked_domains.id
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+
+  secret_string = "CHANGE_ME"
+}
+
+locals {
+  route53_resolver_firewall_blocked_domains = distinct(compact([
+    for domain in try(jsondecode(data.aws_secretsmanager_secret_version.route53_resolver_firewall_blocked_domains_current.secret_string).domains, []) :
+    trimspace(tostring(domain))
+  ]))
+}
+
+resource "aws_route53_resolver_firewall_domain_list" "blocked_domains" {
+  name    = "development-route53-resolver-firewall-blocked-domains"
+  domains = local.route53_resolver_firewall_blocked_domains
+}
+
+resource "aws_route53_resolver_firewall_rule_group" "blocked_domains" {
+  name = "development-route53-resolver-firewall"
+}
+
+resource "aws_route53_resolver_firewall_rule" "blocked_domains" {
+  action                  = "BLOCK"
+  block_response          = "NXDOMAIN"
+  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.blocked_domains.id
+  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.blocked_domains.id
+  name                    = "development-blocked-domains"
+  priority                = 100
+}
+
+resource "aws_route53_resolver_firewall_rule_group_association" "vpc" {
+  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.blocked_domains.id
+  name                   = "development-route53-resolver-firewall"
+  priority               = 100
+  vpc_id                 = module.vpc.vpc_id
+}

--- a/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
+++ b/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
@@ -10,18 +10,17 @@ resource "aws_secretsmanager_secret_version" "route53_resolver_firewall_blocked_
   secret_id = aws_secretsmanager_secret.route53_resolver_firewall_blocked_domains.id
 
   lifecycle {
-    ignore_changes = [secret_string]
+    # This secret is expected to be updated outside Terraform after bootstrap.
+    ignore_changes = all
   }
 
-  secret_string = jsonencode({
-    domains = ["CHANGE_ME"]
-  })
+  secret_string = "CHANGE_ME"
 }
 
 locals {
   route53_resolver_firewall_blocked_domains = distinct(compact([
-    for domain in try(jsondecode(data.aws_secretsmanager_secret_version.route53_resolver_firewall_blocked_domains_current.secret_string).domains, []) :
-    trimspace(tostring(domain))
+    for domain in split(",", try(data.aws_secretsmanager_secret_version.route53_resolver_firewall_blocked_domains_current.secret_string, "")) :
+    trimspace(domain)
   ]))
 }
 
@@ -46,6 +45,6 @@ resource "aws_route53_resolver_firewall_rule" "blocked_domains" {
 resource "aws_route53_resolver_firewall_rule_group_association" "vpc" {
   firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.blocked_domains.id
   name                   = "development-route53-resolver-firewall"
-  priority               = 100
+  priority               = 101
   vpc_id                 = module.vpc.vpc_id
 }

--- a/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
+++ b/terraform/aws/analytical-platform-development/cluster/route53-resolver-firewall.tf
@@ -13,7 +13,9 @@ resource "aws_secretsmanager_secret_version" "route53_resolver_firewall_blocked_
     ignore_changes = [secret_string]
   }
 
-  secret_string = "CHANGE_ME"
+  secret_string = jsonencode({
+    domains = ["CHANGE_ME"]
+  })
 }
 
 locals {

--- a/terraform/aws/analytical-platform-production/cluster/data.tf
+++ b/terraform/aws/analytical-platform-production/cluster/data.tf
@@ -64,6 +64,10 @@ data "aws_secretsmanager_secret_version" "chainguard_image_pull_token" {
   secret_id = "chainguard-image-pull-token"
 }
 
+data "aws_secretsmanager_secret_version" "route53_resolver_firewall_blocked_domains_current" {
+  secret_id = aws_secretsmanager_secret.route53_resolver_firewall_blocked_domains.id
+}
+
 data "aws_eks_cluster" "cluster" {
   name = module.eks.cluster_id
 }

--- a/terraform/aws/analytical-platform-production/cluster/route53-resolver-firewall.tf
+++ b/terraform/aws/analytical-platform-production/cluster/route53-resolver-firewall.tf
@@ -1,0 +1,50 @@
+resource "aws_secretsmanager_secret" "route53_resolver_firewall_blocked_domains" {
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  name        = "production/route53-resolver-firewall-blocked-domains"
+  description = "Blocked domains for the Route53 resolver firewall"
+  kms_key_id  = "alias/aws/secretsmanager"
+}
+
+resource "aws_secretsmanager_secret_version" "route53_resolver_firewall_blocked_domains" {
+  secret_id = aws_secretsmanager_secret.route53_resolver_firewall_blocked_domains.id
+
+  lifecycle {
+    ignore_changes = [secret_string]
+  }
+
+  secret_string = "CHANGE_ME"
+}
+
+locals {
+  route53_resolver_firewall_blocked_domains = distinct(compact([
+    for domain in try(jsondecode(data.aws_secretsmanager_secret_version.route53_resolver_firewall_blocked_domains_current.secret_string).domains, []) :
+    trimspace(tostring(domain))
+  ]))
+}
+
+resource "aws_route53_resolver_firewall_domain_list" "blocked_domains" {
+  name    = "production-route53-resolver-firewall-blocked-domains"
+  domains = local.route53_resolver_firewall_blocked_domains
+}
+
+resource "aws_route53_resolver_firewall_rule_group" "blocked_domains" {
+  name = "production-route53-resolver-firewall"
+}
+
+resource "aws_route53_resolver_firewall_rule" "blocked_domains" {
+  action                  = "BLOCK"
+  block_response          = "NXDOMAIN"
+  firewall_domain_list_id = aws_route53_resolver_firewall_domain_list.blocked_domains.id
+  firewall_rule_group_id  = aws_route53_resolver_firewall_rule_group.blocked_domains.id
+  name                    = "production-blocked-domains"
+  priority                = 100
+}
+
+resource "aws_route53_resolver_firewall_rule_group_association" "vpc" {
+  firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.blocked_domains.id
+  name                   = "production-route53-resolver-firewall"
+  priority               = 100
+  vpc_id                 = module.vpc.vpc_id
+
+  depends_on = [aws_route53_resolver_query_log_config_association.core_logging_s3]
+}

--- a/terraform/aws/analytical-platform-production/cluster/route53-resolver-firewall.tf
+++ b/terraform/aws/analytical-platform-production/cluster/route53-resolver-firewall.tf
@@ -1,5 +1,6 @@
 resource "aws_secretsmanager_secret" "route53_resolver_firewall_blocked_domains" {
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   name        = "production/route53-resolver-firewall-blocked-domains"
   description = "Blocked domains for the Route53 resolver firewall"
   kms_key_id  = "alias/aws/secretsmanager"

--- a/terraform/aws/analytical-platform-production/cluster/route53-resolver-firewall.tf
+++ b/terraform/aws/analytical-platform-production/cluster/route53-resolver-firewall.tf
@@ -10,18 +10,17 @@ resource "aws_secretsmanager_secret_version" "route53_resolver_firewall_blocked_
   secret_id = aws_secretsmanager_secret.route53_resolver_firewall_blocked_domains.id
 
   lifecycle {
-    ignore_changes = [secret_string]
+    # This secret is expected to be updated outside Terraform after bootstrap.
+    ignore_changes = all
   }
 
-  secret_string = jsonencode({
-    domains = ["CHANGE_ME"]
-  })
+  secret_string = "CHANGE_ME"
 }
 
 locals {
   route53_resolver_firewall_blocked_domains = distinct(compact([
-    for domain in try(jsondecode(data.aws_secretsmanager_secret_version.route53_resolver_firewall_blocked_domains_current.secret_string).domains, []) :
-    trimspace(tostring(domain))
+    for domain in split(",", try(data.aws_secretsmanager_secret_version.route53_resolver_firewall_blocked_domains_current.secret_string, "")) :
+    trimspace(domain)
   ]))
 }
 
@@ -46,7 +45,7 @@ resource "aws_route53_resolver_firewall_rule" "blocked_domains" {
 resource "aws_route53_resolver_firewall_rule_group_association" "vpc" {
   firewall_rule_group_id = aws_route53_resolver_firewall_rule_group.blocked_domains.id
   name                   = "production-route53-resolver-firewall"
-  priority               = 100
+  priority               = 101
   vpc_id                 = module.vpc.vpc_id
 
   depends_on = [aws_route53_resolver_query_log_config_association.core_logging_s3]

--- a/terraform/aws/analytical-platform-production/cluster/route53-resolver-firewall.tf
+++ b/terraform/aws/analytical-platform-production/cluster/route53-resolver-firewall.tf
@@ -13,7 +13,9 @@ resource "aws_secretsmanager_secret_version" "route53_resolver_firewall_blocked_
     ignore_changes = [secret_string]
   }
 
-  secret_string = "CHANGE_ME"
+  secret_string = jsonencode({
+    domains = ["CHANGE_ME"]
+  })
 }
 
 locals {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in

(https://github.com/ministryofjustice/data-platform-security/issues/29)

In consultation with OCTO Cyber, we are blocking the C2 endpoints used in TeamPCP's Trivy/LiteLLM exploit via the Route53 Resolver Firewall.

Static analysis override - failures not due to any changes associated with this PR.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

Secret has been applied locally in production but not development - dev Terraform will fail due to secret dependency.
