### PR TITLE
Upgrade production EKS node group to version 1.32

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -131,7 +131,7 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 eks_versions = {
   cluster    = "1.32"
-  node-group = "1.31"
+  node-group = "1.32"
 }
 eks_addon_versions = {
   coredns        = "v1.11.4-eksbuild.32"


### PR DESCRIPTION
This pull request updates the production EKS node group version in the Terraform configuration to align with the cluster version.

- **Infrastructure version alignment:**
  * Updated the `node-group` version from `1.31` to `1.32` in the `eks_versions` map within `terraform.tfvars` to match the `cluster` version and ensure compatibility.

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/9659)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed with `override-static-analysis` label as these fails are OK to ignore in this case; compare to https://github.com/ministryofjustice/analytical-platform/pull/9915
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
