### PR TITLE
add ae rota users

### DIFF
--- a/terraform/pagerduty/ae-support-rota.tf
+++ b/terraform/pagerduty/ae-support-rota.tf
@@ -7,14 +7,15 @@ locals {
         {
           name                         = "AE Daily Support Rota SEO_HEO"
           start                        = "2023-03-27T09:00:00Z"
-          rotation_virtual_start       = "2026-01-28T00:00:00+00:00"
+          rotation_virtual_start       = "2026-04-14T00:00:00+00:00"
           rotation_turn_length_seconds = 86400
           users = [
+            module.users_ae_seo["owen.buckley@justice.gov.uk"].id,
+            module.users_ae_seo["brian.seery@justice.gov.uk"].id,
             module.users_ae_seo["vijay.solanki@justice.gov.uk"].id,
             module.users_ae_seo["billy.pawsey@justice.gov.uk"].id,
-            module.users_ae_seo["owen.buckley@justice.gov.uk"].id,
-            module.users_ae_seo["brian.seery@justice.gov.uk"].id
-
+            module.users_ae_seo["clare.plater@justice.gov.uk"].id,
+            module.users_ae_seo["rebeccaanne.ratcliffe@justice.gov.uk"].id
           ]
           restrictions = [
             {
@@ -58,17 +59,19 @@ locals {
         {
           name                         = "AE Daily Support Rota G7"
           start                        = "2023-03-27T09:00:00Z"
-          rotation_virtual_start       = "2026-01-28T00:00:00+00:00"
+          rotation_virtual_start       = "2026-04-14T00:00:00+00:00"
           rotation_turn_length_seconds = 86400
           users = [
+            module.users_ae_g7["holly.furniss@justice.gov.uk"].id,
+            module.users_ae_g7["matthew.rixson@justice.gov.uk"].id,
             module.users_ae_g7["ivy.lau1@justice.gov.uk"].id,
             module.users_ae_g7["ian.rickard@justice.gov.uk"].id,
             module.users_ae_g7["ben.waterfield1@justice.gov.uk"].id,
             module.users_ae_g7["quinta.davies@justice.gov.uk"].id,
             module.users_ae_g7["danielle.kelly1@justice.gov.uk"].id,
             module.users_ae_g7["alex.pavlopoulos@justice.gov.uk"].id,
-            module.users_ae_g7["holly.furniss@justice.gov.uk"].id,
-            module.users_ae_g7["matthew.rixson@justice.gov.uk"].id
+            module.users_ae_g7["neil.wilkins@justice.gov.uk"].id,
+            module.users_ae_g7["keeleyann.kerr@justice.gov.uk"].id
           ]
           restrictions = [
             {
@@ -150,6 +153,16 @@ locals {
       name  = "Brian Seery"
       email = "brian.seery@justice.gov.uk"
       role  = "responder"
+    },
+    {
+      name  = "Clare Plater"
+      email = "clare.plater@justice.gov.uk"
+      role  = "responder"
+    },
+    {
+      name  = "Rebecca Anne Ratcliffe"
+      email = "rebeccaanne.ratcliffe@justice.gov.uk"
+      role  = "responder"
     }
   ]
 
@@ -193,6 +206,16 @@ locals {
       name  = "Matthew Rixson"
       email = "matthew.rixson@justice.gov.uk"
       role  = "responder"
+    },
+    {
+      name  = "Neil Wilkins"
+      email = "neil.wilkins@justice.gov.uk"
+      role  = "responder"
+    },
+    {
+      name  = "Keeley Ann Kerr"
+      email = "keeleyann.kerr@justice.gov.uk"
+      role  = "responder"
     }
   ]
 }
@@ -233,6 +256,8 @@ module "users_ae_g7" {
   email  = each.key
 }
 
+// SEO_HEO
+
 import {
   to = module.users_ae_seo["owen.buckley@justice.gov.uk"].pagerduty_user.this
   id = "PRTC0Q5"
@@ -252,6 +277,18 @@ import {
   to = module.users_ae_seo["brian.seery@justice.gov.uk"].pagerduty_user.this
   id = "P32SEQW"
 }
+
+import {
+  to = module.users_ae_seo["rebeccaanne.ratcliffe@justice.gov.uk"].pagerduty_user.this
+  id = "P4ZYZ3K"
+}
+
+import {
+  to = module.users_ae_seo["clare.plater@justice.gov.uk"].pagerduty_user.this
+  id = "P10NYRX"
+}
+
+// G7
 
 import {
   to = module.users_ae_g7["alex.pavlopoulos@justice.gov.uk"].pagerduty_user.this
@@ -293,3 +330,12 @@ import {
   id = "PREPU2L"
 }
 
+import {
+  to = module.users_ae_g7["neil.wilkins@justice.gov.uk"].pagerduty_user.this
+  id = "PEASOWW"
+}
+
+import {
+  to = module.users_ae_g7["keeleyann.kerr@justice.gov.uk"].pagerduty_user.this
+  id = "PKY1EDG"
+}


### PR DESCRIPTION
# Pull Request Objective

This PR adds new users to the SEO_HEO AE rota.
It adds a new user to the G7 AE rota, and reinstates a previously disabled G7 user

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
