### PR TITLE
Revert ":dependabot: terraform(deps): Bump terraform-aws-modules/s3-bucket/aws from 5.10.0 to 5.12.0 in /terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync"

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/s3.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/s3.tf
@@ -40,7 +40,7 @@ module "datasync_opg_ingress_s3" {
   for_each = local.analytical_platform_ingestion_environments
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.12.0"
+  version = "5.10.0"
 
   bucket = "mojap-data-production-datasync-opg-ingress-${each.key}"
 
@@ -141,7 +141,7 @@ module "datasync_laa_ingress_s3" {
   #checkov:skip=CKV2_AWS_67:Regular CMK key rotation is not required currently
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.12.0"
+  version = "5.10.0"
 
   bucket = "mojap-data-production-datasync-laa-ingress-production"
 
@@ -254,7 +254,7 @@ module "mojap_access_logging_eu_west_2_s3" {
   #checkov:skip=CKV2_AWS_67:Regular CMK key rotation is not required currently
 
   source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.12.0"
+  version = "5.10.0"
 
   bucket = "mojap-s3-bucket-access-logs-eu-west-2"
 


### PR DESCRIPTION
Reverts ministryofjustice/analytical-platform#10094