### PR TITLE
Bug: fix parameter name change

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/kms-keys.tf
@@ -70,7 +70,7 @@ module "datasync_laa_kms" {
           identifiers = ["s3.amazonaws.com"]
         }
       ]
-      conditions = [{
+      condition = [{
         test     = "StringEquals"
         variable = "aws:SourceAccount"
         values   = [var.account_ids["analytical-platform-data-production"]]


### PR DESCRIPTION
This pull request makes a minor update to the `datasync_laa_kms` module configuration in the Terraform file. The change corrects a property name from `conditions` to `condition` within the key policy statement block to align with the expected syntax.

The parameter was changed in the update to v4.0.0 [here](https://github.com/terraform-aws-modules/terraform-aws-kms/compare/v3.1.1...v4.0.0#diff-07f337e38ed1996f30ee4f04357ab23318c254cb606aaf4745d564cbd546722dL64) and has potentially been silently failing to use the condition since.