### PR TITLE
Upgrade EKS cluster and add necessary addons

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -134,7 +134,7 @@ eks_versions = {
 eks_addon_versions = {
   coredns        = "v1.13.2-eksbuild.7"
   ebs-csi-driver = "v1.58.0-eksbuild.1"
-  kube-proxy     = "v1.34.6-eksbuild.2q"
+  kube-proxy     = "v1.34.6-eksbuild.2"
   vpc-cni        = "v1.21.1-eksbuild.7"
 }
 eks_node_group_name_prefix = "dev"

--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -128,13 +128,13 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 
 eks_versions = {
-  cluster    = "1.33"
+  cluster    = "1.34"
   node-group = "1.33"
 }
 eks_addon_versions = {
-  coredns        = "v1.13.2-eksbuild.4"
-  ebs-csi-driver = "v1.57.1-eksbuild.1"
-  kube-proxy     = "v1.33.10-eksbuild.2"
+  coredns        = "v1.13.2-eksbuild.7"
+  ebs-csi-driver = "v1.58.0-eksbuild.1"
+  kube-proxy     = "v1.34.6-eksbuild.2q"
   vpc-cni        = "v1.21.1-eksbuild.7"
 }
 eks_node_group_name_prefix = "dev"


### PR DESCRIPTION
This pull request updates the EKS cluster and several related add-on versions in the `terraform.tfvars` file. These changes ensure compatibility with newer Kubernetes features and include important bug fixes and improvements.

**EKS version upgrades:**
* Updated the `cluster` EKS version from `1.33` to `1.34`, while keeping the `node-group` at `1.33`.

**Add-on version upgrades:**
* Upgraded `coredns` from `v1.13.2-eksbuild.4` to `v1.13.2-eksbuild.7`.
* Upgraded `ebs-csi-driver` from `v1.57.1-eksbuild.1` to `v1.58.0-eksbuild.1`.
* Upgraded `kube-proxy` from `v1.33.10-eksbuild.2` to `v1.34.6-eksbuild.2`.

This work is been tracked in this [ticket](https://github.com/orgs/ministryofjustice/projects/27/views/18?reload=1&pane=issue&itemId=4051879115&issue=ministryofjustice%7Canalytical-platform%7C9866)