### PR TITLE
Upgrade DEV node group to version 1.34

### DIFF
--- a/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-development/cluster/terraform.tfvars
@@ -129,7 +129,7 @@ redis_alarm_memory_threshold_bytes = 100000
 
 eks_versions = {
   cluster    = "1.33"
-  node-group = "1.33"
+  node-group = "1.34"
 }
 eks_addon_versions = {
   coredns        = "v1.13.2-eksbuild.4"


### PR DESCRIPTION
This pull request updates the EKS node group version in the `terraform.tfvars` file to align it with the cluster version, ensuring consistency across the EKS configuration.

EKS version update:

* Updated the `node-group` version from `1.33` to `1.34` in the `eks_versions` map in `terraform/aws/analytical-platform-development/cluster/terraform.tfvars`.

This work is been tracked in this [ticket](https://github.com/orgs/ministryofjustice/projects/27/views/18?reload=1&pane=issue&itemId=4051879115&issue=ministryofjustice%7Canalytical-platform%7C9866)