### PR TITLE
upgrade PROD node group version to 1.34

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -131,7 +131,7 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 eks_versions = {
   cluster    = "1.34"
-  node-group = "1.33"
+  node-group = "1.34"
 }
 eks_addon_versions = {
   coredns        = "v1.13.2-eksbuild.7"


### PR DESCRIPTION
This pull request makes a small update to the EKS node group version in the Terraform configuration. The node group version is now aligned with the cluster version, both set to "1.34".

This work is been tracked in this [ticket](https://github.com/orgs/ministryofjustice/projects/27/views/18?reload=1&pane=issue&itemId=4051883933&issue=ministryofjustice%7Canalytical-platform%7C9867)