### PR TITLE
refactor and added prod bucket and role

### DIFF
--- a/terraform/aws/analytical-platform-data-production/s3-replication/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/iam-policies.tf
@@ -60,6 +60,11 @@ resource "aws_iam_policy" "replication" {
   policy = data.aws_iam_policy_document.replication[each.key].json
 }
 
+moved {
+  from = data.aws_iam_policy_document.alpha_mojap_ho_data_transfer_replication
+  to   = data.aws_iam_policy_document.replication["test"]
+}
+
 data "aws_iam_policy_document" "replication_trust" {
   statement {
     sid     = "TrustS3"

--- a/terraform/aws/analytical-platform-data-production/s3-replication/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/iam-policies.tf
@@ -1,5 +1,5 @@
 data "aws_iam_policy_document" "replication" {
-  for_each = local.enabled_replication_configurations
+  for_each = local.replication_configurations
 
   statement {
     sid    = "DestinationBucketPermissions"
@@ -54,7 +54,7 @@ data "aws_iam_policy_document" "replication" {
 }
 
 resource "aws_iam_policy" "replication" {
-  for_each = local.enabled_replication_configurations
+  for_each = local.replication_configurations
 
   name   = "${each.value.source_bucket_name}-replication"
   policy = data.aws_iam_policy_document.replication[each.key].json

--- a/terraform/aws/analytical-platform-data-production/s3-replication/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/iam-policies.tf
@@ -1,4 +1,6 @@
-data "aws_iam_policy_document" "alpha_mojap_ho_data_transfer_replication" {
+data "aws_iam_policy_document" "replication" {
+  for_each = local.enabled_replication_configurations
+
   statement {
     sid    = "DestinationBucketPermissions"
     effect = "Allow"
@@ -9,7 +11,7 @@ data "aws_iam_policy_document" "alpha_mojap_ho_data_transfer_replication" {
       "s3:ReplicateTags",
       "s3:ReplicateDelete"
     ]
-    resources = ["arn:aws:s3:::dsa-cdl-police-s3-deposit-cjs-npa/*"]
+    resources = ["${each.value.destination_bucket_arn}/*"]
   }
 
   statement {
@@ -20,7 +22,7 @@ data "aws_iam_policy_document" "alpha_mojap_ho_data_transfer_replication" {
       "s3:ListBucket",
       "s3:PutInventoryConfiguration"
     ]
-    resources = [module.alpha_mojap_ho_data_transfer_test.s3_bucket_arn]
+    resources = ["${each.value.source_bucket_arn}"]
   }
 
   statement {
@@ -33,7 +35,7 @@ data "aws_iam_policy_document" "alpha_mojap_ho_data_transfer_replication" {
       "s3:GetObjectVersionTagging",
       "s3:ObjectOwnerOverrideToBucketOwner",
     ]
-    resources = ["${module.alpha_mojap_ho_data_transfer_test.s3_bucket_arn}/*"]
+    resources = ["${each.value.source_bucket_arn}/*"]
   }
 
   statement {
@@ -45,18 +47,20 @@ data "aws_iam_policy_document" "alpha_mojap_ho_data_transfer_replication" {
       "s3:PutObject"
     ]
     resources = [
-      "${module.alpha_mojap_ho_data_transfer_test.s3_bucket_arn}/*",
-      "arn:aws:s3:::dsa-cdl-police-s3-deposit-cjs-npa/*"
+      "${each.value.source_bucket_arn}/*",
+      "${each.value.destination_bucket_arn}/*"
     ]
   }
 }
 
-resource "aws_iam_policy" "alpha_mojap_ho_data_transfer_replication" {
-  name   = "alpha-mojap-ho-data-transfer-test-replication"
-  policy = data.aws_iam_policy_document.alpha_mojap_ho_data_transfer_replication.json
+resource "aws_iam_policy" "replication" {
+  for_each = local.enabled_replication_configurations
+
+  name   = "${each.value.source_bucket_name}-replication"
+  policy = data.aws_iam_policy_document.replication[each.key].json
 }
 
-data "aws_iam_policy_document" "alpha_mojap_ho_data_transfer_replication_trust" {
+data "aws_iam_policy_document" "replication_trust" {
   statement {
     sid     = "TrustS3"
     effect  = "Allow"
@@ -70,14 +74,4 @@ data "aws_iam_policy_document" "alpha_mojap_ho_data_transfer_replication_trust" 
       ]
     }
   }
-}
-
-resource "aws_iam_role" "alpha_mojap_ho_data_transfer_replication" {
-  name               = "alpha-mojap-ho-data-transfer-test-replication"
-  assume_role_policy = data.aws_iam_policy_document.alpha_mojap_ho_data_transfer_replication_trust.json
-}
-
-resource "aws_iam_role_policy_attachment" "alpha_mojap_ho_data_transfer_replication" {
-  role       = aws_iam_role.alpha_mojap_ho_data_transfer_replication.name
-  policy_arn = aws_iam_policy.alpha_mojap_ho_data_transfer_replication.arn
 }

--- a/terraform/aws/analytical-platform-data-production/s3-replication/iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/iam-policies.tf
@@ -22,7 +22,7 @@ data "aws_iam_policy_document" "replication" {
       "s3:ListBucket",
       "s3:PutInventoryConfiguration"
     ]
-    resources = ["${each.value.source_bucket_arn}"]
+    resources = [each.value.source_bucket_arn]
   }
 
   statement {

--- a/terraform/aws/analytical-platform-data-production/s3-replication/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/iam-roles.tf
@@ -1,12 +1,12 @@
 resource "aws_iam_role" "replication" {
-  for_each = local.enabled_replication_configurations
+  for_each = local.replication_configurations
 
   name               = "${each.value.source_bucket_name}-replication"
   assume_role_policy = data.aws_iam_policy_document.replication_trust.json
 }
 
 resource "aws_iam_role_policy_attachment" "replication" {
-  for_each = local.enabled_replication_configurations
+  for_each = local.replication_configurations
 
   role       = aws_iam_role.replication[each.key].name
   policy_arn = aws_iam_policy.replication[each.key].arn

--- a/terraform/aws/analytical-platform-data-production/s3-replication/iam-roles.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/iam-roles.tf
@@ -1,0 +1,29 @@
+resource "aws_iam_role" "replication" {
+  for_each = local.enabled_replication_configurations
+
+  name               = "${each.value.source_bucket_name}-replication"
+  assume_role_policy = data.aws_iam_policy_document.replication_trust.json
+}
+
+resource "aws_iam_role_policy_attachment" "replication" {
+  for_each = local.enabled_replication_configurations
+
+  role       = aws_iam_role.replication[each.key].name
+  policy_arn = aws_iam_policy.replication[each.key].arn
+}
+
+
+moved {
+  from = aws_iam_role.alpha_mojap_ho_data_transfer_replication
+  to   = aws_iam_role.replication["test"]
+}
+
+moved {
+  from = aws_iam_policy.alpha_mojap_ho_data_transfer_replication
+  to   = aws_iam_policy.replication["test"]
+}
+
+moved {
+  from = aws_iam_role_policy_attachment.alpha_mojap_ho_data_transfer_replication
+  to   = aws_iam_role_policy_attachment.replication["test"]
+}

--- a/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
@@ -8,7 +8,7 @@ locals {
       destination_bucket_arn = "arn:aws:s3:::dsa-cdl-police-s3-deposit-cjs-npa"
     }
     production = {
-      enabled                = true
+      enabled                = false
       source_bucket_name     = "alpha-mojap-ho-data-transfer"
       source_bucket_arn      = "arn:aws:s3:::alpha-mojap-ho-data-transfer"
       destination_account_id = "314425585946"

--- a/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
@@ -20,7 +20,7 @@ locals {
     for k, v in local.replication_configurations : k => v if v.enabled
   }
 
-  # Replication configs for the S3 module - only includes enabled configurations
+  # Replication configs for the S3 module
   # Dynamic map avoids the Terraform conditional type issue where the replication configuration must be defined even if replication is not enabled
   replication_configs = {
     for k, v in local.replication_configurations : k => {

--- a/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
@@ -19,4 +19,29 @@ locals {
   enabled_replication_configurations = {
     for k, v in local.replication_configurations : k => v if v.enabled
   }
+
+  # Replication configs for the S3 module - only includes enabled configurations
+  # Dynamic map avoids the Terraform conditional type issue where the replication configuration must be defined even if replication is not enabled
+  replication_configs = {
+    for k, v in local.replication_configurations : k => {
+      role = aws_iam_role.replication[k].arn
+      rules = [
+        {
+          id                        = "${v.source_bucket_name}-replication"
+          status                    = "Enabled"
+          delete_marker_replication = true
+
+          destination = {
+            account_id    = v.destination_account_id
+            bucket        = v.destination_bucket_arn
+            storage_class = "STANDARD"
+
+            access_control_translation = {
+              owner = "Destination"
+            }
+          }
+        }
+      ]
+    } if v.enabled
+  }
 }

--- a/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
@@ -16,10 +16,6 @@ locals {
     }
   }
 
-  enabled_replication_configurations = {
-    for k, v in local.replication_configurations : k => v if v.enabled
-  }
-
   # Replication configs for the S3 module
   # Dynamic map avoids the Terraform conditional type issue where the replication configuration must be defined even if replication is not enabled
   replication_configs = {

--- a/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/locals.tf
@@ -1,0 +1,22 @@
+locals {
+  replication_configurations = {
+    test = {
+      enabled                = true
+      source_bucket_name     = "alpha-mojap-ho-data-transfer-test"
+      source_bucket_arn      = "arn:aws:s3:::alpha-mojap-ho-data-transfer-test"
+      destination_account_id = "591168578261"
+      destination_bucket_arn = "arn:aws:s3:::dsa-cdl-police-s3-deposit-cjs-npa"
+    }
+    production = {
+      enabled                = true
+      source_bucket_name     = "alpha-mojap-ho-data-transfer"
+      source_bucket_arn      = "arn:aws:s3:::alpha-mojap-ho-data-transfer"
+      destination_account_id = "314425585946"
+      destination_bucket_arn = "arn:aws:s3:::dsa-cdl-police-s3-deposit-cjs-pda"
+    }
+  }
+
+  enabled_replication_configurations = {
+    for k, v in local.replication_configurations : k => v if v.enabled
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/s3-replication/s3-bucket.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/s3-bucket.tf
@@ -6,7 +6,7 @@ module "alpha_mojap_ho_data_transfer_test" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "5.12.0"
 
-  bucket = "alpha-mojap-ho-data-transfer-test"
+  bucket = local.replication_configurations["test"].source_bucket_name
 
   versioning = {
     enabled = true
@@ -21,16 +21,16 @@ module "alpha_mojap_ho_data_transfer_test" {
   }
 
   replication_configuration = {
-    role = aws_iam_role.alpha_mojap_ho_data_transfer_replication.arn
+    role = aws_iam_role.replication["test"].arn
     rules = [
       {
-        id                        = "alpha-mojap-ho-data-transfer-test-replication"
+        id                        = "${local.replication_configurations["test"].source_bucket_name}-replication"
         status                    = "Enabled"
         delete_marker_replication = true
 
         destination = {
-          account_id    = "591168578261"
-          bucket        = "arn:aws:s3:::dsa-cdl-police-s3-deposit-cjs-npa"
+          account_id    = local.replication_configurations["test"].destination_account_id
+          bucket        = local.replication_configurations["test"].destination_bucket_arn
           storage_class = "STANDARD"
 
           access_control_translation = {
@@ -43,7 +43,7 @@ module "alpha_mojap_ho_data_transfer_test" {
 
   logging = {
     target_bucket = "moj-analytics-s3-logs"
-    target_prefix = "alpha-mojap-ho-data-transfer-test/"
+    target_prefix = "${local.replication_configurations["test"].source_bucket_name}/"
     target_object_key_format = {
       simple_prefix = {}
     }
@@ -52,7 +52,7 @@ module "alpha_mojap_ho_data_transfer_test" {
   lifecycle_rule = [
     {
       enabled = true
-      id      = "alpha-mojap-ho-data-transfer-test_lifecycle_configuration"
+      id      = "${local.replication_configurations["test"].source_bucket_name}_lifecycle_configuration"
 
       transition = {
         days          = 0
@@ -62,3 +62,93 @@ module "alpha_mojap_ho_data_transfer_test" {
   ]
 }
 
+################### PRODUCTION REPLICATION #####################
+
+#tfsec:ignore:AVD-AWS-0089:Bucket logging not enabled currently
+module "alpha_mojap_ho_data_transfer" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/s3-bucket/aws"
+  version = "5.12.0"
+
+  bucket = local.replication_configurations["production"].source_bucket_name
+
+  versioning = {
+    enabled = true
+  }
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        sse_algorithm = "AES256"
+      }
+    }
+  }
+
+  replication_configuration = {
+    role = aws_iam_role.replication["production"].arn
+    rules = [
+      {
+        id                        = "${local.replication_configurations["production"].source_bucket_name}-replication"
+        status                    = "Enabled"
+        delete_marker_replication = true
+
+        destination = {
+          account_id    = local.replication_configurations["production"].destination_account_id
+          bucket        = local.replication_configurations["production"].destination_bucket_arn
+          storage_class = "STANDARD"
+
+          access_control_translation = {
+            owner = "Destination"
+          }
+        }
+      }
+    ]
+  }
+
+  logging = {
+    target_bucket = "moj-analytics-s3-logs"
+    target_prefix = "${local.replication_configurations["production"].source_bucket_name}/"
+    target_object_key_format = {
+      simple_prefix = {}
+    }
+  }
+
+  lifecycle_rule = [
+    {
+      enabled = true
+      id      = "${local.replication_configurations["production"].source_bucket_name}_lifecycle_configuration"
+
+      transition = {
+        days          = 0
+        storage_class = "INTELLIGENT_TIERING"
+      }
+    }
+  ]
+}
+
+import {
+  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_lifecycle_configuration.this[0]
+  id = "alpha-mojap-ho-data-transfer"
+}
+
+import {
+  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_server_side_encryption_configuration.this[0]
+  id = "alpha-mojap-ho-data-transfer"
+}
+
+import {
+  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_versioning.this[0]
+  id = "alpha-mojap-ho-data-transfer"
+}
+
+import {
+  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_logging.this[0]
+  id = "alpha-mojap-ho-data-transfer"
+}
+
+import {
+  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_public_access_block.this[0]
+  id = "alpha-mojap-ho-data-transfer"
+}

--- a/terraform/aws/analytical-platform-data-production/s3-replication/s3-bucket.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/s3-bucket.tf
@@ -20,26 +20,7 @@ module "alpha_mojap_ho_data_transfer_test" {
     }
   }
 
-  replication_configuration = {
-    role = aws_iam_role.replication["test"].arn
-    rules = [
-      {
-        id                        = "${local.replication_configurations["test"].source_bucket_name}-replication"
-        status                    = "Enabled"
-        delete_marker_replication = true
-
-        destination = {
-          account_id    = local.replication_configurations["test"].destination_account_id
-          bucket        = local.replication_configurations["test"].destination_bucket_arn
-          storage_class = "STANDARD"
-
-          access_control_translation = {
-            owner = "Destination"
-          }
-        }
-      }
-    ]
-  }
+  replication_configuration = lookup(local.replication_configs, "test", {})
 
   logging = {
     target_bucket = "moj-analytics-s3-logs"
@@ -86,26 +67,7 @@ module "alpha_mojap_ho_data_transfer" {
     }
   }
 
-  replication_configuration = {
-    role = aws_iam_role.replication["production"].arn
-    rules = [
-      {
-        id                        = "${local.replication_configurations["production"].source_bucket_name}-replication"
-        status                    = "Enabled"
-        delete_marker_replication = true
-
-        destination = {
-          account_id    = local.replication_configurations["production"].destination_account_id
-          bucket        = local.replication_configurations["production"].destination_bucket_arn
-          storage_class = "STANDARD"
-
-          access_control_translation = {
-            owner = "Destination"
-          }
-        }
-      }
-    ]
-  }
+  replication_configuration = lookup(local.replication_configs, "production", {})
 
   logging = {
     target_bucket = "moj-analytics-s3-logs"

--- a/terraform/aws/analytical-platform-data-production/s3-replication/s3-bucket.tf
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/s3-bucket.tf
@@ -1,12 +1,14 @@
 #tfsec:ignore:AVD-AWS-0089:Bucket logging not enabled currently
-module "alpha_mojap_ho_data_transfer_test" {
+module "replication_buckets" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  for_each = local.replication_configurations
 
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "5.12.0"
 
-  bucket = local.replication_configurations["test"].source_bucket_name
+  bucket = each.value.source_bucket_name
 
   versioning = {
     enabled = true
@@ -20,11 +22,11 @@ module "alpha_mojap_ho_data_transfer_test" {
     }
   }
 
-  replication_configuration = lookup(local.replication_configs, "test", {})
+  replication_configuration = lookup(local.replication_configs, each.key, {})
 
   logging = {
     target_bucket = "moj-analytics-s3-logs"
-    target_prefix = "${local.replication_configurations["test"].source_bucket_name}/"
+    target_prefix = "${each.value.source_bucket_name}/"
     target_object_key_format = {
       simple_prefix = {}
     }
@@ -33,7 +35,7 @@ module "alpha_mojap_ho_data_transfer_test" {
   lifecycle_rule = [
     {
       enabled = true
-      id      = "${local.replication_configurations["test"].source_bucket_name}_lifecycle_configuration"
+      id      = "${each.value.source_bucket_name}_lifecycle_configuration"
 
       transition = {
         days          = 0
@@ -43,74 +45,37 @@ module "alpha_mojap_ho_data_transfer_test" {
   ]
 }
 
-################### PRODUCTION REPLICATION #####################
+moved {
+  from = module.alpha_mojap_ho_data_transfer_test
+  to   = module.replication_buckets["test"]
+}
 
-#tfsec:ignore:AVD-AWS-0089:Bucket logging not enabled currently
-module "alpha_mojap_ho_data_transfer" {
-  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
-  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
-
-  source  = "terraform-aws-modules/s3-bucket/aws"
-  version = "5.12.0"
-
-  bucket = local.replication_configurations["production"].source_bucket_name
-
-  versioning = {
-    enabled = true
-  }
-
-  server_side_encryption_configuration = {
-    rule = {
-      apply_server_side_encryption_by_default = {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-  replication_configuration = lookup(local.replication_configs, "production", {})
-
-  logging = {
-    target_bucket = "moj-analytics-s3-logs"
-    target_prefix = "${local.replication_configurations["production"].source_bucket_name}/"
-    target_object_key_format = {
-      simple_prefix = {}
-    }
-  }
-
-  lifecycle_rule = [
-    {
-      enabled = true
-      id      = "${local.replication_configurations["production"].source_bucket_name}_lifecycle_configuration"
-
-      transition = {
-        days          = 0
-        storage_class = "INTELLIGENT_TIERING"
-      }
-    }
-  ]
+moved {
+  from = module.alpha_mojap_ho_data_transfer.aws_s3_bucket.this[0]
+  to   = module.replication_buckets["production"].aws_s3_bucket.this[0]
 }
 
 import {
-  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_lifecycle_configuration.this[0]
+  to = module.replication_buckets["production"].aws_s3_bucket_lifecycle_configuration.this[0]
   id = "alpha-mojap-ho-data-transfer"
 }
 
 import {
-  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_server_side_encryption_configuration.this[0]
+  to = module.replication_buckets["production"].aws_s3_bucket_server_side_encryption_configuration.this[0]
   id = "alpha-mojap-ho-data-transfer"
 }
 
 import {
-  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_versioning.this[0]
+  to = module.replication_buckets["production"].aws_s3_bucket_versioning.this[0]
   id = "alpha-mojap-ho-data-transfer"
 }
 
 import {
-  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_logging.this[0]
+  to = module.replication_buckets["production"].aws_s3_bucket_logging.this[0]
   id = "alpha-mojap-ho-data-transfer"
 }
 
 import {
-  to = module.alpha_mojap_ho_data_transfer.aws_s3_bucket_public_access_block.this[0]
+  to = module.replication_buckets["production"].aws_s3_bucket_public_access_block.this[0]
   id = "alpha-mojap-ho-data-transfer"
 }

--- a/terraform/aws/analytical-platform-data-production/s3-replication/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/s3-replication/terraform.tfvars
@@ -16,4 +16,5 @@ tags = {
   owner                  = "data-platform:data-platform-tech@digital.justice.gov.uk"
   infrastructure-support = "data-platform:data-platform-tech@digital.justice.gov.uk"
   source-code            = "github.com/ministryofjustice/data-platform/terraform/aws/analytical-platform-data-production/s3-replication"
+  buckettype             = "datawarehouse"
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[https://github.com/ministryofjustice/data-platform/issues/145

This PR adds the Production bucket in code and has some refactoring involved to avoid duplication of code.

It also adds a boolean to enable the role so it can be disable once testing is complete - because of the boolean and terraform restrictions the replication config has been abstracted to locals.

Boolean for prod is set to false currently until Governance is in place.


## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
