### PR TITLE
Update dev container feature versions

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,34 +1,34 @@
 {
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:": {
-      "version": "2.16.0",
-      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:31ef1bbfde793bcc62c52fa847c02a15fe659d69e48b2d8c1cfbd4db95f97cf7",
-      "integrity": "sha256:31ef1bbfde793bcc62c52fa847c02a15fe659d69e48b2d8c1cfbd4db95f97cf7"
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
     },
     "ghcr.io/devcontainers/features/github-cli:1": {
       "version": "1.1.0",
       "resolved": "ghcr.io/devcontainers/features/github-cli@sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671",
       "integrity": "sha256:d22f50b70ed75339b4eed1ba9ecde3a1791f90e88d37936517e3bace0bbad671"
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/aws:": {
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {
       "version": "1.1.1",
       "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/aws@sha256:e867962c11134137ef6eb267147e2e7e595360a3bef03c26526493eabb1914ce",
       "integrity": "sha256:e867962c11134137ef6eb267147e2e7e595360a3bef03c26526493eabb1914ce"
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:": {
-      "version": "1.1.1",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:530ae37a553ff38de71caf0ef74b5b624268f23bf17bcdfe3fb4ba0ab19bfc75",
-      "integrity": "sha256:530ae37a553ff38de71caf0ef74b5b624268f23bf17bcdfe3fb4ba0ab19bfc75"
+    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {
+      "version": "1.1.2",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes@sha256:5ba09d497a9a2886ed20199083b54be90a296ebd916878119b2b049ea9fd61b0",
+      "integrity": "sha256:5ba09d497a9a2886ed20199083b54be90a296ebd916878119b2b049ea9fd61b0"
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:1": {
-      "version": "1.0.0",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis@sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16",
-      "integrity": "sha256:e81d52725655c8ffb861605feac7ad155b447d51af65f6c3a03cab32d59f1e16"
+    "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:2": {
+      "version": "2.0.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis@sha256:07e194be7c48e95174486c5c817f661bc6be9159272230d8460604a2ac8ec901",
+      "integrity": "sha256:07e194be7c48e95174486c5c817f661bc6be9159272230d8460604a2ac8ec901"
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:": {
-      "version": "1.2.1",
-      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:fe2dfc9f2d57c904c2abe6a49e4f1dc2ec27a469555fd0add7a66d2c59779991",
-      "integrity": "sha256:fe2dfc9f2d57c904c2abe6a49e4f1dc2ec27a469555fd0add7a66d2c59779991"
+    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {
+      "version": "1.3.0",
+      "resolved": "ghcr.io/ministryofjustice/devcontainer-feature/terraform@sha256:55bade53f374bd8600e59b8333d28bef2ab94f501576ad462c8caddfe977387e",
+      "integrity": "sha256:55bade53f374bd8600e59b8333d28bef2ab94f501576ad462c8caddfe977387e"
     }
   }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,14 +2,14 @@
   "name": "analytical-platform",
   "image": "ghcr.io/ministryofjustice/devcontainer-base:latest",
   "features": {
-    "ghcr.io/devcontainers/features/docker-in-docker:": {},
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/aws:": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:": {
+    "ghcr.io/ministryofjustice/devcontainer-feature/aws:1": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/kubernetes:1": {
       "installVeleroCli": true
     },
-    "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:1": {},
-    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:": {}
+    "ghcr.io/ministryofjustice/devcontainer-feature/static-analysis:2": {},
+    "ghcr.io/ministryofjustice/devcontainer-feature/terraform:1": {}
   },
   "postCreateCommand": "bash .devcontainer/post-create.sh",
   "customizations": {


### PR DESCRIPTION
Yesterday I [merged a PR in the .devcontainer repo](https://github.com/ministryofjustice/.devcontainer/commit/20d4cbffa479a1ab040525f1f22d8a2312694aa3) which updated the base version, and the kubernetes feature, in order to fix a bug when installing `velero`.

This PR updates the dev container config to pin to major versions. I then rebuilt the dev container which updated the lockfile to use the latest versions.