### PR TITLE
purge stale alert rules from DB on pod restart

### DIFF
--- a/terraform/cloud-platform/live/analytical-platform-production/observability/locals_environments.tf
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/locals_environments.tf
@@ -117,7 +117,6 @@ locals {
       enabled_groups             = ["Control Panel", "EFS"]
       aws_region                 = "eu-west-1"
       cloudwatch_datasource_name = "mojap-development-cloudwatch"
-      prometheus_datasource_name = "mojap-development-prometheus"
       #  slack_channel = "analytical-platform-alerts-slack"
 
       efs_file_systems = ["fs-0dbd6739"] #eks-development-user-homes

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
@@ -421,23 +421,69 @@ extraInitContainers:
       - sh
       - -c
       - |
-        echo "Fetching UIDs from provisioning file..."
-        PROVISIONED_UIDS=$(grep -E '^\s+"uid":' /etc/grafana/provisioning/alerting/rules.yaml \
+        set -eu
+
+        RULES_FILE=/etc/grafana/provisioning/alerting/rules.yaml
+
+        echo "Checking provisioning file..."
+        if [ ! -f "$RULES_FILE" ]; then
+          echo "ERROR: rules file not found — aborting to protect existing rules"
+          exit 1
+        fi
+
+        PROVISIONED_UIDS=$(grep -E '^\s+"uid":' "$RULES_FILE" \
           | awk -F'"' '{print $4}' \
           | sed "s/.*/'&'/" \
           | tr '\n' ',' | sed 's/,$//')
-        echo "Provisioned UIDs: $PROVISIONED_UIDS"
+
         if [ -z "$PROVISIONED_UIDS" ]; then
-          echo "No UIDs found in provisioning file, skipping purge"
+          echo "WARNING: no UIDs found in provisioning file — skipping purge"
           exit 0
         fi
-        psql -h $DB_HOST -U $DB_USER -d $DB_NAME -c "
-          DELETE FROM alert_instance WHERE rule_uid NOT IN ($PROVISIONED_UIDS);
-          DELETE FROM alert_rule_state WHERE rule_uid NOT IN ($PROVISIONED_UIDS);
-          DELETE FROM alert_rule_version WHERE rule_uid NOT IN ($PROVISIONED_UIDS);
-          DELETE FROM alert_rule WHERE uid NOT IN ($PROVISIONED_UIDS);
-        "
-        echo "Purge complete"
+
+        UID_COUNT=$(echo "$PROVISIONED_UIDS" | tr ',' '\n' | wc -l | tr -d ' ')
+        echo "Found $UID_COUNT provisioned rule(s) in file"
+
+        echo "Checking for stale rules in DB..."
+        STALE_COUNT=$(psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" \
+          --set ON_ERROR_STOP=1 -t -A \
+          -c "SELECT COUNT(*) FROM alert_rule WHERE uid NOT IN ($PROVISIONED_UIDS);") \
+          || { echo "ERROR: failed to query DB — check DB_HOST, DB_USER, DB_NAME and PGPASSWORD"; exit 1; }
+
+        echo "Stale rules found: $STALE_COUNT"
+
+        if [ "$STALE_COUNT" -eq 0 ]; then
+          echo "Nothing to purge — DB is already in sync with provisioning file"
+          exit 0
+        fi
+
+        echo "Stale rule details:"
+        psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" \
+          --set ON_ERROR_STOP=1 \
+          -c "SELECT uid, title, rule_group FROM alert_rule WHERE uid NOT IN ($PROVISIONED_UIDS);" \
+          || { echo "ERROR: failed to list stale rules"; exit 1; }
+
+        echo "Running purge transaction..."
+        psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" --set ON_ERROR_STOP=1 \
+          -c "BEGIN; DELETE FROM alert_instance WHERE rule_uid NOT IN ($PROVISIONED_UIDS); DELETE FROM alert_rule_state WHERE rule_uid NOT IN ($PROVISIONED_UIDS); DELETE FROM alert_rule_version WHERE rule_uid NOT IN ($PROVISIONED_UIDS); DELETE FROM alert_rule WHERE uid NOT IN ($PROVISIONED_UIDS); COMMIT;"
+        PURGE_EXIT=$?
+        if [ "$PURGE_EXIT" -ne 0 ]; then
+          echo "ERROR: purge transaction failed (exit code $PURGE_EXIT) — DB has been rolled back, no rules were deleted"
+          exit 1
+        fi
+
+        echo "Verifying purge..."
+        REMAINING=$(psql -h "$DB_HOST" -U "$DB_USER" -d "$DB_NAME" \
+          --set ON_ERROR_STOP=1 -t -A \
+          -c "SELECT COUNT(*) FROM alert_rule WHERE uid NOT IN ($PROVISIONED_UIDS);") \
+          || { echo "ERROR: failed to verify purge — unable to query DB after transaction"; exit 1; }
+
+        if [ "$REMAINING" -eq 0 ]; then
+          echo "Purge complete — $STALE_COUNT stale rule(s) deleted, 0 remaining"
+        else
+          echo "ERROR: Purge incomplete — $REMAINING stale rule(s) still remain in DB after purge"
+          exit 1
+        fi
     volumeMounts:
       - name: alert-rules
         mountPath: /etc/grafana/provisioning/alerting/rules.yaml

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
@@ -443,3 +443,4 @@ extraInitContainers:
         mountPath: /etc/grafana/provisioning/alerting/rules.yaml
         subPath: rules.yaml
         readOnly: true
+        

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
@@ -387,3 +387,59 @@ extraVolumeMounts:
 
 podAnnotations:
   checksum/alert-rules: "${alert_rules_checksum}"
+
+env:
+  GF_PROVISIONING_ALERTING_FORCE_UPDATE: "true"
+  GF_ALERTING_PROVISIONING_PURGE_NOT_IN_FILES: "true"
+
+
+extraInitContainers:
+  - name: purge-stale-alert-rules
+    image: postgres:15-alpine
+    env:
+      - name: PGPASSWORD
+        valueFrom:
+          secretKeyRef:
+            name: grafana-rds
+            key: database_password
+      - name: DB_HOST
+        valueFrom:
+          secretKeyRef:
+            name: grafana-rds
+            key: rds_instance_endpoint
+      - name: DB_USER
+        valueFrom:
+          secretKeyRef:
+            name: grafana-rds
+            key: database_username
+      - name: DB_NAME
+        valueFrom:
+          secretKeyRef:
+            name: grafana-rds
+            key: database_name
+    command:
+      - sh
+      - -c
+      - |
+        echo "Fetching UIDs from provisioning file..."
+        PROVISIONED_UIDS=$(grep -E '^\s+"uid":' /etc/grafana/provisioning/alerting/rules.yaml \
+          | awk -F'"' '{print $4}' \
+          | sed "s/.*/'&'/" \
+          | tr '\n' ',' | sed 's/,$//')
+        echo "Provisioned UIDs: $PROVISIONED_UIDS"
+        if [ -z "$PROVISIONED_UIDS" ]; then
+          echo "No UIDs found in provisioning file, skipping purge"
+          exit 0
+        fi
+        psql -h $DB_HOST -U $DB_USER -d $DB_NAME -c "
+          DELETE FROM alert_instance WHERE rule_uid NOT IN ($PROVISIONED_UIDS);
+          DELETE FROM alert_rule_state WHERE rule_uid NOT IN ($PROVISIONED_UIDS);
+          DELETE FROM alert_rule_version WHERE rule_uid NOT IN ($PROVISIONED_UIDS);
+          DELETE FROM alert_rule WHERE uid NOT IN ($PROVISIONED_UIDS);
+        "
+        echo "Purge complete"
+    volumeMounts:
+      - name: alert-rules
+        mountPath: /etc/grafana/provisioning/alerting/rules.yaml
+        subPath: rules.yaml
+        readOnly: true

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
@@ -443,4 +443,3 @@ extraInitContainers:
         mountPath: /etc/grafana/provisioning/alerting/rules.yaml
         subPath: rules.yaml
         readOnly: true
-        


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/data-platform/issues/251)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
