### PR TITLE
upgrade AP prod cluster and add-ons

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -135,7 +135,7 @@ eks_versions = {
 }
 eks_addon_versions = {
   coredns        = "v1.14.2-eksbuild.4"
-  ebs-csi-driver = "v1.59.0-eksbuild.1"
+  ebs-csi-driver = "v1.60.0-eksbuild.1"
   kube-proxy     = "v1.35.3-eksbuild.5"
   vpc-cni        = "v1.21.1-eksbuild.8"
 }

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -130,14 +130,14 @@ redis_alarm_memory_threshold_bytes = 100000
 # EKS
 ##################################################
 eks_versions = {
-  cluster    = "1.34"
+  cluster    = "1.35"
   node-group = "1.34"
 }
 eks_addon_versions = {
-  coredns        = "v1.13.2-eksbuild.7"
-  ebs-csi-driver = "v1.58.0-eksbuild.1"
-  kube-proxy     = "v1.34.6-eksbuild.2"
-  vpc-cni        = "v1.21.1-eksbuild.7"
+  coredns        = "v1.14.2-eksbuild.4"
+  ebs-csi-driver = "v1.59.0-eksbuild.1"
+  kube-proxy     = "v1.35.3-eksbuild.5"
+  vpc-cni        = "v1.21.1-eksbuild.8"
 }
 eks_node_group_name_prefix = "prod"
 eks_node_group_capacities = {

--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -134,9 +134,9 @@ eks_versions = {
   node-group = "1.34"
 }
 eks_addon_versions = {
-  coredns        = "v1.14.2-eksbuild.4"
+  coredns        = "v1.13.2-eksbuild.7"
   ebs-csi-driver = "v1.60.0-eksbuild.1"
-  kube-proxy     = "v1.35.3-eksbuild.5"
+  kube-proxy     = "v1.34.6-eksbuild.5"
   vpc-cni        = "v1.21.1-eksbuild.8"
 }
 eks_node_group_name_prefix = "prod"


### PR DESCRIPTION
# Pull Request Objective

Upgrading the AP prod cluster from `1.34` to `1.35`

**Addons**

  * `ebs-csi-driver` from `v1.58.0-eksbuild.1` to `v1.60.0-eksbuild.1`
  * `kube-proxy` from `v1.34.6-eksbuild.2` to `v1.34.6-eksbuild.5`
  * `vpc-cni` from `v1.21.1-eksbuild.7` to `v1.21.1-eksbuild.8`


This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/9917)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
