### PR TITLE
upgrade prod nodegroup to v1.35

### DIFF
--- a/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
+++ b/terraform/aws/analytical-platform-production/cluster/terraform.tfvars
@@ -131,7 +131,7 @@ redis_alarm_memory_threshold_bytes = 100000
 ##################################################
 eks_versions = {
   cluster    = "1.35"
-  node-group = "1.34"
+  node-group = "1.35"
 }
 eks_addon_versions = {
   coredns        = "v1.14.2-eksbuild.4"


### PR DESCRIPTION
# Pull Request Objective

Upgrading the AP prod cluster nodegroup from `1.34` to `1.35`

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/9917)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
Detail the problem it addresses or the functionality it adds.
Highlight how this contributes to the project goals,
improves performance, or solves a specific issue. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
