### PR TITLE
split alert rules into per-env configmaps to reduce file size

### DIFF
--- a/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
@@ -20,8 +20,11 @@ resource "helm_release" "grafana" {
           data.github_team.probation_data_science.id,
           data.github_team.probation_integration.id
         ])
-        alert_rules_configmap = kubernetes_config_map_v1.grafana_alert_rules.metadata[0].name
-        alert_rules_checksum  = local.metrics_checksum
+        alert_rules_configmaps = {
+          for env, cm in kubernetes_config_map_v1.grafana_alert_rules :
+          env => cm.metadata[0].name
+        }
+        alert_rules_checksum = local.metrics_checksum
     }),
     yamlencode({
       podAnnotations = {

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/helm-releases.tf
@@ -24,6 +24,10 @@ resource "helm_release" "grafana" {
           for env, cm in kubernetes_config_map_v1.grafana_alert_rules :
           env => cm.metadata[0].name
         }
+        alert_rules_files = [
+          for env, cm in kubernetes_config_map_v1.grafana_alert_rules :
+          "/etc/grafana/provisioning/alerting/rules-${env}.yaml"
+        ]
         alert_rules_checksum = local.metrics_checksum
     }),
     yamlencode({

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/locals_environments.tf
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/locals_environments.tf
@@ -108,6 +108,7 @@ locals {
       s3_buckets = ["mojap-compute-development-mwaa", "mojap-compute-development-velero"]
       enabled_groups = [
         "NAT Gateway",
+        "Transit Gateway",
         "EKS",
         "MWAA",
         "S3"
@@ -123,6 +124,7 @@ locals {
       s3_buckets = ["mojap-compute-test-mwaa", "mojap-compute-test-velero"]
       enabled_groups = [
         "NAT Gateway",
+        "Transit Gateway",
         "EKS",
         "MWAA",
         "S3",
@@ -139,6 +141,7 @@ locals {
       s3_buckets = ["mojap-compute-production-mwaa", "mojap-compute-production-velero"]
       enabled_groups = [
         "NAT Gateway",
+        "Transit Gateway",
         "EKS",
         "MWAA",
         "S3",

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/main.tf
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/main.tf
@@ -1,10 +1,10 @@
 locals {
-  alert_rules_yaml = yamlencode({
-    groups = flatten([
-      for env in keys(local.environment_configurations) :
-      local.group_blocks_by_env[env]
-    ])
-  })
+  alert_rules_yaml_by_env = {
+    for env in keys(local.environment_configurations) :
+    env => yamlencode({
+      groups = local.group_blocks_by_env[env]
+    })
+  }
 }
 
 locals {
@@ -12,21 +12,23 @@ locals {
     golden_signals             = local.golden_signals
     defaults                   = local.defaults
     environment_configurations = local.environment_configurations
-    alert_rules_yaml           = local.alert_rules_yaml
+    alert_rules_yaml_by_env    = local.alert_rules_yaml_by_env
   }))
 }
 
 resource "kubernetes_config_map_v1" "grafana_alert_rules" {
+  for_each = local.environment_configurations
+
   metadata {
-    name      = "grafana-alert-rules"
+    name      = "grafana-alert-rules-${each.key}"
     namespace = var.namespace
 
     annotations = {
-      "checksum/rules" = local.metrics_checksum
+      "checksum/rules" = sha256(local.alert_rules_yaml_by_env[each.key])
     }
   }
 
   data = {
-    "rules.yaml" = local.alert_rules_yaml
+    "rules.yaml" = local.alert_rules_yaml_by_env[each.key]
   }
 }

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
@@ -427,18 +427,20 @@ extraInitContainers:
       - |
         set -eu
 
-        RULES_DIR=/etc/grafana/provisioning/alerting
+        RULES_FILES="${join(" ", alert_rules_files)}"
 
         DB_HOST=$(echo "$DB_HOST_FULL" | cut -d':' -f1)
         DB_PORT=$(echo "$DB_HOST_FULL" | cut -d':' -f2)
 
         echo "Checking provisioning files..."
-        if ! ls "$RULES_DIR"/rules-*.yaml > /dev/null 2>&1; then
-          echo "ERROR: no rules files found in $RULES_DIR — aborting to protect existing rules"
-          exit 1
-        fi
+        for f in $RULES_FILES; do
+          if [ ! -f "$f" ]; then
+            echo "ERROR: expected rules file not found: $f — aborting to protect existing rules"
+            exit 1
+          fi
+        done
 
-        PROVISIONED_UIDS=$(grep -E '^\s+"uid":' "$RULES_DIR"/rules-*.yaml \
+        PROVISIONED_UIDS=$(grep -E '^\s+"uid":' $RULES_FILES \
           | awk -F'"' '{print $4}' \
           | sed "s/.*/'&'/" \
           | tr '\n' ',' | sed 's/,$//')
@@ -509,3 +511,4 @@ extraInitContainers:
         subPath: rules.yaml
         readOnly: true
 %{~ endfor }
+

--- a/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
+++ b/terraform/cloud-platform/live/analytical-platform-production/observability/src/helm/values/grafana/values.yml.tftpl
@@ -375,15 +375,19 @@ alerting:
                   - analytical-platform-alerts
 
 extraVolumes:
-  - name: alert-rules
+%{~ for env, cm_name in alert_rules_configmaps }
+  - name: alert-rules-${env}
     configMap:
-      name: ${alert_rules_configmap}
+      name: ${cm_name}
+%{~ endfor }
 
 extraVolumeMounts:
-  - name: alert-rules
-    mountPath: /etc/grafana/provisioning/alerting/rules.yaml
+%{~ for env, cm_name in alert_rules_configmaps }
+  - name: alert-rules-${env}
+    mountPath: /etc/grafana/provisioning/alerting/rules-${env}.yaml
     subPath: rules.yaml
     readOnly: true
+%{~ endfor }
 
 podAnnotations:
   checksum/alert-rules: "${alert_rules_checksum}"
@@ -423,29 +427,40 @@ extraInitContainers:
       - |
         set -eu
 
-        RULES_FILE=/etc/grafana/provisioning/alerting/rules.yaml
+        RULES_DIR=/etc/grafana/provisioning/alerting
 
         DB_HOST=$(echo "$DB_HOST_FULL" | cut -d':' -f1)
         DB_PORT=$(echo "$DB_HOST_FULL" | cut -d':' -f2)
 
-        echo "Checking provisioning file..."
-        if [ ! -f "$RULES_FILE" ]; then
-          echo "ERROR: rules file not found — aborting to protect existing rules"
+        echo "Checking provisioning files..."
+        if ! ls "$RULES_DIR"/rules-*.yaml > /dev/null 2>&1; then
+          echo "ERROR: no rules files found in $RULES_DIR — aborting to protect existing rules"
           exit 1
         fi
 
-        PROVISIONED_UIDS=$(grep -E '^\s+"uid":' "$RULES_FILE" \
+        PROVISIONED_UIDS=$(grep -E '^\s+"uid":' "$RULES_DIR"/rules-*.yaml \
           | awk -F'"' '{print $4}' \
           | sed "s/.*/'&'/" \
           | tr '\n' ',' | sed 's/,$//')
 
         if [ -z "$PROVISIONED_UIDS" ]; then
-          echo "WARNING: no UIDs found in provisioning file — skipping purge"
+          echo "WARNING: no UIDs found in provisioning files — skipping purge"
           exit 0
         fi
 
         UID_COUNT=$(echo "$PROVISIONED_UIDS" | tr ',' '\n' | wc -l | tr -d ' ')
-        echo "Found $UID_COUNT provisioned rule(s) in file"
+        echo "Found $UID_COUNT provisioned rule(s) across all environments"
+
+        echo "Checking if alert_rule table exists..."
+        TABLE_EXISTS=$(psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
+          -t -A \
+          -c "SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'alert_rule';") \
+          || { echo "ERROR: failed to connect to DB — check DB_HOST, DB_USER, DB_NAME and PGPASSWORD"; exit 1; }
+
+        if [ "$TABLE_EXISTS" -eq 0 ]; then
+          echo "alert_rule table not found — Grafana has not run migrations yet, skipping purge"
+          exit 0
+        fi
 
         echo "Checking for stale rules in DB..."
         STALE_COUNT=$(psql -h "$DB_HOST" -p "$DB_PORT" -U "$DB_USER" -d "$DB_NAME" \
@@ -456,7 +471,7 @@ extraInitContainers:
         echo "Stale rules found: $STALE_COUNT"
 
         if [ "$STALE_COUNT" -eq 0 ]; then
-          echo "Nothing to purge — DB is already in sync with provisioning file"
+          echo "Nothing to purge — DB is already in sync with provisioning files"
           exit 0
         fi
 
@@ -488,7 +503,9 @@ extraInitContainers:
           exit 1
         fi
     volumeMounts:
-      - name: alert-rules
-        mountPath: /etc/grafana/provisioning/alerting/rules.yaml
+%{~ for env, cm_name in alert_rules_configmaps }
+      - name: alert-rules-${env}
+        mountPath: /etc/grafana/provisioning/alerting/rules-${env}.yaml
         subPath: rules.yaml
         readOnly: true
+%{~ endfor }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/data-platform/issues/251)
GitHub Issue.

**Changes**
* Previously all alert rules were combined into a single ConfigMap (`grafana-alert-rules`) containing the full yamlencode output for all environments. With x environments and all signal groups enabled this produced large size of YAML causing terraform plan to be OOM-killed with exit code 143.
Split into one ConfigMap per environment (`grafana-alert-rules-<env>`) so reduce Terraform now diffs individual environment files rather than the entire combined YAML, significantly reducing memory usage during TF.
* added transit gw alerts for all APC accounts

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
