### PR TITLE
Update GH runner for Terraform job

### DIFF
--- a/.github/workflows/reusable-workflow-terraform.yml
+++ b/.github/workflows/reusable-workflow-terraform.yml
@@ -168,7 +168,7 @@ jobs:
   terraform:
     needs: [determine-workflow-mode]
     name: ${{ needs.determine-workflow-mode.outputs.mode }}
-    runs-on: ubuntu-latest
+    runs-on: octo-production
     steps:
       - name: Checkout
         id: checkout
@@ -254,15 +254,6 @@ jobs:
         shell: bash
         run: |
           terraform validate -no-color
-
-      - name: Check Runner Egress IP
-        id: check_runner_egress_ip
-        shell: bash
-        run: |
-          echo "Runner egress IP as seen by AWS:"
-          for i in {1..10}; do
-            curl --silent --fail https://checkip.amazonaws.com
-          done | sort --unique
 
       - name: Plan Terraform
         id: terraform_plan

--- a/.github/workflows/reusable-workflow-terraform.yml
+++ b/.github/workflows/reusable-workflow-terraform.yml
@@ -255,6 +255,15 @@ jobs:
         run: |
           terraform validate -no-color
 
+      - name: Check Runner Egress IP
+        id: check_runner_egress_ip
+        shell: bash
+        run: |
+          echo "Runner egress IP as seen by AWS:"
+          for i in {1..10}; do
+            curl --silent --fail https://checkip.amazonaws.com
+          done | sort --unique
+
       - name: Plan Terraform
         id: terraform_plan
         working-directory: ${{ env.working-directory }}

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -20,7 +20,7 @@ permissions: read-all
 jobs:
   detect-changes:
     name: Detect Changes
-    runs-on: octo-production
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read


### PR DESCRIPTION
# Pull Request Objective

Fixes the issue where terraform cannot plan/apply against the eks cluster due to the wrong runner.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
