### PR TITLE
added policy for DataHub role to list buckets present in Glue

### DIFF
--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -136,8 +136,7 @@ data "aws_iam_policy_document" "datahub_ingestion_github_actions_s3_read_all_buc
     effect = "Allow"
     actions = [
       "s3:ListBucket",
-      "s3:GetBucketLocation",
-      "s3:GetObject"
+      "s3:GetBucketLocation"
     ]
     resources = [
       "arn:aws:s3:::*",

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -129,10 +129,10 @@ resource "aws_iam_role_policy_attachment" "datahub_ingestion_github_actions_athe
 }
 
 #trivy:ignore:aws-iam-no-policy-wildcards
-# Reading all Glue buckets for finding the latest file timestamp so that analysts can see the correct timestamp.
-data "aws_iam_policy_document" "datahub_ingestion_github_actions_s3_read_all_buckets" {
+# Listing all Glue buckets for finding the latest file timestamp so that analysts can see the correct timestamp.
+data "aws_iam_policy_document" "datahub_ingestion_github_actions_s3_list_all_buckets" {
   statement {
-    sid    = "datahubIngestionGithubActionsS3ReadAllBuckets"
+    sid    = "datahubIngestionGithubActionsS3ListAllBuckets"
     effect = "Allow"
     actions = [
       "s3:ListBucket",
@@ -145,13 +145,13 @@ data "aws_iam_policy_document" "datahub_ingestion_github_actions_s3_read_all_buc
   }
 }
 
-resource "aws_iam_policy" "datahub_ingestion_github_actions_s3_read_all_buckets" {
-  name   = "datahub_ingestion_github_actions_s3_read_all_buckets"
-  policy = data.aws_iam_policy_document.datahub_ingestion_github_actions_s3_read_all_buckets.json
+resource "aws_iam_policy" "datahub_ingestion_github_actions_s3_list_all_buckets" {
+  name   = "datahub_ingestion_github_actions_s3_list_all_buckets"
+  policy = data.aws_iam_policy_document.datahub_ingestion_github_actions_s3_list_all_buckets.json
 }
 
-resource "aws_iam_role_policy_attachment" "datahub_ingestion_github_actions_s3_read_all_buckets" {
-  policy_arn = aws_iam_policy.datahub_ingestion_github_actions_s3_read_all_buckets.arn
+resource "aws_iam_role_policy_attachment" "datahub_ingestion_github_actions_s3_list_all_buckets" {
+  policy_arn = aws_iam_policy.datahub_ingestion_github_actions_s3_list_all_buckets.arn
   role       = aws_iam_role.datahub_ingestion_github_actions.name
 }
 

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -128,6 +128,34 @@ resource "aws_iam_role_policy_attachment" "datahub_ingestion_github_actions_athe
   role       = aws_iam_role.datahub_ingestion_github_actions.name
 }
 
+#trivy:ignore:aws-iam-no-policy-wildcards
+# Reading all Glue buckets for finding the latest file timestamp so that analysts can see the correct timestamp.
+data "aws_iam_policy_document" "datahub_ingestion_github_actions_s3_read_all_buckets" {
+  statement {
+    sid    = "datahubIngestionGithubActionsS3ReadAllBuckets"
+    effect = "Allow"
+    actions = [
+      "s3:ListBucket",
+      "s3:GetBucketLocation",
+      "s3:GetObject"
+    ]
+    resources = [
+      "arn:aws:s3:::*",
+      "arn:aws:s3:::*/*"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "datahub_ingestion_github_actions_s3_read_all_buckets" {
+  name   = "datahub_ingestion_github_actions_s3_read_all_buckets"
+  policy = data.aws_iam_policy_document.datahub_ingestion_github_actions_s3_read_all_buckets.json
+}
+
+resource "aws_iam_role_policy_attachment" "datahub_ingestion_github_actions_s3_read_all_buckets" {
+  policy_arn = aws_iam_policy.datahub_ingestion_github_actions_s3_read_all_buckets.arn
+  role       = aws_iam_role.datahub_ingestion_github_actions.name
+}
+
 #trivy:ignore:avd-aws-0057:sensitive action 'glue:GetDatabases' on wildcarded resource
 data "aws_iam_policy_document" "datahub_ingest_glue_datasets" {
   statement {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/data-platform/issues/155)
GitHub Issue.

<!-- Please describe the purpose of this pull request.
In order for Datahub to provide a correct and latest timestamp as part of the FMD metadata, the datahub role needs the permissions to do the ListBucket on all Glue buckets. -->

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
