### PR TITLE
Gw/destroy vpc infra

### DIFF
--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/redshift-aurora-test/main.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/redshift-aurora-test/main.tf
@@ -86,125 +86,131 @@ module "kms" {
 
 # -----------------------------------------------------------------------------
 # Bastion host for Aurora access via SSM
+# TEMPORARILY COMMENTED OUT for VPC subnet reconfiguration (2→3 AZs)
+# Restore after VPC changes have applied successfully
 # -----------------------------------------------------------------------------
-resource "aws_iam_role" "bastion" {
-  name = "${local.project_name}-bastion"
-
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17"
-    Statement = [
-      {
-        Effect = "Allow"
-        Principal = {
-          Service = "ec2.amazonaws.com"
-        }
-        Action = "sts:AssumeRole"
-      }
-    ]
-  })
-
-  tags = local.tags
-}
-
-resource "aws_iam_role_policy_attachment" "bastion_ssm" {
-  role       = aws_iam_role.bastion.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-resource "aws_iam_role_policy_attachment" "bastion_cloudwatch" {
-  role       = aws_iam_role.bastion.name
-  policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
-}
-
-resource "aws_iam_instance_profile" "bastion" {
-  name = "${local.project_name}-bastion"
-  role = aws_iam_role.bastion.name
-}
-
-resource "aws_security_group" "bastion" {
-  # checkov:skip=CKV_AWS_23: Bastion host uses SSM with no ingress rules.
-  # checkov:skip=CKV_AWS_382: Bastion host needs outbound internet access for SSM.
-  name_prefix = "${local.project_name}-bastion-"
-  description = "Security group for ${local.project_name} bastion host"
-  vpc_id      = module.vpc.vpc_id
-
-  egress {
-    from_port   = 0
-    to_port     = 0
-    protocol    = "-1"
-    cidr_blocks = ["0.0.0.0/0"]
-    description = "Outbound access for SSM and package installation"
-  }
-
-  tags = merge(local.tags, {
-    Name = "${local.project_name}-bastion"
-  })
-
-  lifecycle {
-    create_before_destroy = true
-  }
-}
-
-resource "aws_instance" "bastion" {
-  # checkov:skip=CKV_AWS_126: Detailed monitoring is not required for this test bastion.
-  ami                         = data.aws_ssm_parameter.al2023_arm64.value
-  ebs_optimized               = true
-  instance_type               = var.bastion_instance_type
-  iam_instance_profile        = aws_iam_instance_profile.bastion.name
-  subnet_id                   = module.vpc.private_subnet_ids[0]
-  vpc_security_group_ids      = [aws_security_group.bastion.id]
-  associate_public_ip_address = false
-
-  root_block_device {
-    encrypted = true
-  }
-
-  metadata_options {
-    http_endpoint               = "enabled"
-    http_tokens                 = "required"
-    http_put_response_hop_limit = 2
-    instance_metadata_tags      = "disabled"
-  }
-
-  tags = merge(local.tags, {
-    Name = "${local.project_name}-bastion"
-  })
-}
+# resource "aws_iam_role" "bastion" {
+#   name = "${local.project_name}-bastion"
+#
+#   assume_role_policy = jsonencode({
+#     Version = "2012-10-17"
+#     Statement = [
+#       {
+#         Effect = "Allow"
+#         Principal = {
+#           Service = "ec2.amazonaws.com"
+#         }
+#         Action = "sts:AssumeRole"
+#       }
+#     ]
+#   })
+#
+#   tags = local.tags
+# }
+#
+# resource "aws_iam_role_policy_attachment" "bastion_ssm" {
+#   role       = aws_iam_role.bastion.name
+#   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+# }
+#
+# resource "aws_iam_role_policy_attachment" "bastion_cloudwatch" {
+#   role       = aws_iam_role.bastion.name
+#   policy_arn = "arn:aws:iam::aws:policy/CloudWatchAgentServerPolicy"
+# }
+#
+# resource "aws_iam_instance_profile" "bastion" {
+#   name = "${local.project_name}-bastion"
+#   role = aws_iam_role.bastion.name
+# }
+#
+# resource "aws_security_group" "bastion" {
+#   # checkov:skip=CKV_AWS_23: Bastion host uses SSM with no ingress rules.
+#   # checkov:skip=CKV_AWS_382: Bastion host needs outbound internet access for SSM.
+#   name_prefix = "${local.project_name}-bastion-"
+#   description = "Security group for ${local.project_name} bastion host"
+#   vpc_id      = module.vpc.vpc_id
+#
+#   egress {
+#     from_port   = 0
+#     to_port     = 0
+#     protocol    = "-1"
+#     cidr_blocks = ["0.0.0.0/0"]
+#     description = "Outbound access for SSM and package installation"
+#   }
+#
+#   tags = merge(local.tags, {
+#     Name = "${local.project_name}-bastion"
+#   })
+#
+#   lifecycle {
+#     create_before_destroy = true
+#   }
+# }
+#
+# resource "aws_instance" "bastion" {
+#   # checkov:skip=CKV_AWS_126: Detailed monitoring is not required for this test bastion.
+#   ami                         = data.aws_ssm_parameter.al2023_arm64.value
+#   ebs_optimized               = true
+#   instance_type               = var.bastion_instance_type
+#   iam_instance_profile        = aws_iam_instance_profile.bastion.name
+#   subnet_id                   = module.vpc.private_subnet_ids[0]
+#   vpc_security_group_ids      = [aws_security_group.bastion.id]
+#   associate_public_ip_address = false
+#
+#   root_block_device {
+#     encrypted = true
+#   }
+#
+#   metadata_options {
+#     http_endpoint               = "enabled"
+#     http_tokens                 = "required"
+#     http_put_response_hop_limit = 2
+#     instance_metadata_tags      = "disabled"
+#   }
+#
+#   tags = merge(local.tags, {
+#     Name = "${local.project_name}-bastion"
+#   })
+# }
 
 # -----------------------------------------------------------------------------
 # Aurora PostgreSQL
+# TEMPORARILY COMMENTED OUT for VPC subnet reconfiguration (2→3 AZs)
+# Restore after VPC changes have applied successfully
 # -----------------------------------------------------------------------------
-module "aurora" {
-  source = "./modules/aurora"
-
-  tags = local.tags
-
-  vpc_id              = module.vpc.vpc_id
-  database_subnet_ids = module.vpc.database_subnet_ids
-  vpc_cidr            = var.vpc_cidr
-
-  cluster_name   = "${local.project_name}-aurora"
-  engine_version = var.aurora_engine_version
-  instance_class = var.aurora_instance_class
-
-  kms_key_arn = module.kms.key_arn
-}
+# module "aurora" {
+#   source = "./modules/aurora"
+#
+#   tags = local.tags
+#
+#   vpc_id              = module.vpc.vpc_id
+#   database_subnet_ids = module.vpc.database_subnet_ids
+#   vpc_cidr            = var.vpc_cidr
+#
+#   cluster_name   = "${local.project_name}-aurora"
+#   engine_version = var.aurora_engine_version
+#   instance_class = var.aurora_instance_class
+#
+#   kms_key_arn = module.kms.key_arn
+# }
 
 # -----------------------------------------------------------------------------
 # Redshift Serverless
+# TEMPORARILY COMMENTED OUT for VPC subnet reconfiguration (2→3 AZs)
+# Restore after VPC changes have applied successfully
 # -----------------------------------------------------------------------------
-module "redshift" {
-  source = "./modules/redshift"
-
-  project_name = local.project_name
-  environment  = local.environment
-  tags         = local.tags
-
-  vpc_id           = module.vpc.vpc_id
-  database_subnets = module.vpc.database_subnet_ids
-  vpc_cidr         = var.vpc_cidr
-
-  kms_key_arn = module.kms.key_arn
-
-  price_performance_level = var.redshift_price_performance_level
-}
+# module "redshift" {
+#   source = "./modules/redshift"
+#
+#   project_name = local.project_name
+#   environment  = local.environment
+#   tags         = local.tags
+#
+#   vpc_id           = module.vpc.vpc_id
+#   database_subnets = module.vpc.database_subnet_ids
+#   vpc_cidr         = var.vpc_cidr
+#
+#   kms_key_arn = module.kms.key_arn
+#
+#   price_performance_level = var.redshift_price_performance_level
+# }

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/redshift-aurora-test/main.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/redshift-aurora-test/main.tf
@@ -1,8 +1,9 @@
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
-data "aws_ssm_parameter" "al2023_arm64" {
-  name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64"
-}
+# TEMPORARILY COMMENTED OUT - used by bastion which is disabled for VPC reconfiguration
+# data "aws_ssm_parameter" "al2023_arm64" {
+#   name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-arm64"
+# }
 
 # -----------------------------------------------------------------------------
 # VPC

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/redshift-aurora-test/outputs.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/redshift-aurora-test/outputs.tf
@@ -3,55 +3,64 @@ output "vpc_id" {
   value       = module.vpc.vpc_id
 }
 
-output "aurora_cluster_endpoint" {
-  description = "The endpoint of the Aurora PostgreSQL cluster"
-  value       = module.aurora.cluster_endpoint
-}
+# -----------------------------------------------------------------------------
+# Aurora Outputs
+# TEMPORARILY COMMENTED OUT for VPC subnet reconfiguration (2→3 AZs)
+# -----------------------------------------------------------------------------
+# output "aurora_cluster_endpoint" {
+#   description = "The endpoint of the Aurora PostgreSQL cluster"
+#   value       = module.aurora.cluster_endpoint
+# }
+#
+# output "aurora_cluster_reader_endpoint" {
+#   description = "The reader endpoint of the Aurora PostgreSQL cluster"
+#   value       = module.aurora.cluster_reader_endpoint
+# }
+#
+# output "aurora_cluster_port" {
+#   description = "The port of the Aurora PostgreSQL cluster"
+#   value       = module.aurora.cluster_port
+# }
+#
+# output "aurora_master_secret_arn" {
+#   description = "The ARN of the master user secret (retrieve from Secrets Manager)"
+#   value       = module.aurora.master_user_secret_arn
+# }
 
-output "aurora_cluster_reader_endpoint" {
-  description = "The reader endpoint of the Aurora PostgreSQL cluster"
-  value       = module.aurora.cluster_reader_endpoint
-}
-
-output "aurora_cluster_port" {
-  description = "The port of the Aurora PostgreSQL cluster"
-  value       = module.aurora.cluster_port
-}
-
-output "aurora_master_secret_arn" {
-  description = "The ARN of the master user secret (retrieve from Secrets Manager)"
-  value       = module.aurora.master_user_secret_arn
-}
-
-output "bastion_instance_id" {
-  description = "The ID of the bastion EC2 instance"
-  value       = aws_instance.bastion.id
-}
-
-output "bastion_private_ip" {
-  description = "The private IP address of the bastion EC2 instance"
-  value       = aws_instance.bastion.private_ip
-}
-
-output "bastion_ssm_start_session_command" {
-  description = "Command to start an SSM session to the bastion instance"
-  value       = "aws ssm start-session --target ${aws_instance.bastion.id} --region ${data.aws_region.current.name}"
-}
+# -----------------------------------------------------------------------------
+# Bastion Outputs
+# TEMPORARILY COMMENTED OUT for VPC subnet reconfiguration (2→3 AZs)
+# -----------------------------------------------------------------------------
+# output "bastion_instance_id" {
+#   description = "The ID of the bastion EC2 instance"
+#   value       = aws_instance.bastion.id
+# }
+#
+# output "bastion_private_ip" {
+#   description = "The private IP address of the bastion EC2 instance"
+#   value       = aws_instance.bastion.private_ip
+# }
+#
+# output "bastion_ssm_start_session_command" {
+#   description = "Command to start an SSM session to the bastion instance"
+#   value       = "aws ssm start-session --target ${aws_instance.bastion.id} --region ${data.aws_region.current.name}"
+# }
 
 # -----------------------------------------------------------------------------
 # Redshift Outputs
+# TEMPORARILY COMMENTED OUT for VPC subnet reconfiguration (2→3 AZs)
 # -----------------------------------------------------------------------------
-output "redshift_endpoint_address" {
-  description = "The DNS address for the Redshift Serverless instance"
-  value       = module.redshift.endpoint_address
-}
-
-output "redshift_endpoint_port" {
-  description = "The port that Redshift Serverless listens on"
-  value       = module.redshift.endpoint_port
-}
-
-output "redshift_admin_secret_arn" {
-  description = "The ARN of the Redshift admin user secret (retrieve from Secrets Manager)"
-  value       = module.redshift.admin_secret_arn
-}
+# output "redshift_endpoint_address" {
+#   description = "The DNS address for the Redshift Serverless instance"
+#   value       = module.redshift.endpoint_address
+# }
+#
+# output "redshift_endpoint_port" {
+#   description = "The port that Redshift Serverless listens on"
+#   value       = module.redshift.endpoint_port
+# }
+#
+# output "redshift_admin_secret_arn" {
+#   description = "The ARN of the Redshift admin user secret (retrieve from Secrets Manager)"
+#   value       = module.redshift.admin_secret_arn
+# }


### PR DESCRIPTION
Removing infra that caused the tf apply failure https://github.com/ministryofjustice/analytical-platform/actions/runs/28506892395

Further fix to correct changes in:
#10390 

This PR temporarily removes Aurora, Redshift Serverless, and the bastion host to allow VPC subnet reconfiguration.

Changes:
VPC module - Updated to use 3 AZs (from 2) and adjusted CIDR offsets to avoid overlap
Aurora, Redshift, Bastion - Temporarily commented out to allow subnet changes to apply