### PR TITLE
removed references to Trivy

### DIFF
--- a/source/documentation/platform/infrastructure/containers.html.md.erb
+++ b/source/documentation/platform/infrastructure/containers.html.md.erb
@@ -9,7 +9,7 @@ review_in: 6 months
 
 The Analytical Platform team offers a managed pipeline for building, scanning and pushing containers to a registry. This is done via GitHub Actions and is available to all teams. This is managed in Terraform.
 
-Images are scanned for vulnerabilities using [Trivy](https://github.com/aquasecurity/trivy), currently with a default severity of `CRITICAL`
+Images are scanned for vulnerabilities using [Grype](https://anchore.com/grype/), currently with a default severity of `CRITICAL`
 
 Dockerfiles are linted by the Super Linter with [Hadolint](https://github.com/hadolint/hadolint)
 

--- a/terraform/aws/analytical-platform-data-engineering-production/dms-dev/ec2.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/dms-dev/ec2.tf
@@ -34,9 +34,6 @@
 #   name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 # }
 
-# #trivy:ignore:AVD-AWS-0099:Using default description.
-# #trivy:ignore:AVD-AWS-0124:Using default description.
-# #trivy:ignore:AVD-AWS-0104:Just a dev bastion to test source connection to database.
 # resource "aws_security_group" "dev_bastion_ec2" {
 #   # checkov:skip=CKV_AWS_23: Skipping as Terraform adds a default description.
 #   # checkov:skip=CKV_AWS_382: Skipping as dev bastion.

--- a/terraform/aws/analytical-platform-data-engineering-production/dms-preprod/ec2.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/dms-preprod/ec2.tf
@@ -34,9 +34,6 @@
 #   name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 # }
 
-# #trivy:ignore:AVD-AWS-0099:Using default description.
-# #trivy:ignore:AVD-AWS-0124:Using default description.
-# #trivy:ignore:AVD-AWS-0104:Just a preprod bastion to test source connection to database.
 # resource "aws_security_group" "preprod_bastion_ec2" {
 #   # checkov:skip=CKV_AWS_23: Skipping as Terraform adds a default description.
 #   # checkov:skip=CKV_AWS_382: Skipping as preprod bastion.

--- a/terraform/aws/analytical-platform-data-engineering-production/dms-prod/ec2.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/dms-prod/ec2.tf
@@ -34,9 +34,6 @@
 #   name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 # }
 
-# #trivy:ignore:AVD-AWS-0099:Using default description.
-# #trivy:ignore:AVD-AWS-0124:Using default description.
-# #trivy:ignore:AVD-AWS-0104:Just a prod bastion to test source connection to database.
 # resource "aws_security_group" "prod_bastion_ec2" {
 #   # checkov:skip=CKV_AWS_23: Skipping as Terraform adds a default description.
 #   # checkov:skip=CKV_AWS_382: Skipping as prod bastion.

--- a/terraform/aws/analytical-platform-data-engineering-production/ppud-dev/main.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/ppud-dev/main.tf
@@ -1,6 +1,3 @@
-# trivy:ignore:avd-aws-0132: Skipping because replicating existing bucket that does not encrypt data with a customer managed key
-# trivy:ignore:avd-aws-0088: Skipping because has server side encryption
-# trivy:ignore:avd-aws-0089: Skipping because access logging is managed externally.
 module "ppud_dev" {
   # checkov:skip=CKV_TF_1: Module registry does not support commit hashes for versions
   # checkov:skip=CKV_TF_2: Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-engineering-production/ppud-preprod/ec2.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/ppud-preprod/ec2.tf
@@ -33,7 +33,6 @@
 #   name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 # }
 
-# # trivy:ignore:avd-aws-0104: Required for SSM
 # resource "aws_security_group" "ec2_sg" {
 #   # checkov:skip=CKV_AWS_382: Required for SSM
 #   name        = "allow_access"

--- a/terraform/aws/analytical-platform-data-engineering-production/ppud-preprod/main.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/ppud-preprod/main.tf
@@ -1,6 +1,3 @@
-#trivy:ignore:avd-aws-0132: Skipping because replicating existing bucket that does not encrypt data with a customer managed key
-#trivy:ignore:avd-aws-0088: Skipping because has server side encryption
-#trivy:ignore:avd-aws-0089: Skipping because access logging is managed externally.
 module "ppud_preprod" {
   #checkov:skip=CKV_TF_1: Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2: Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-engineering-production/ppud-prod/ec2.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/ppud-prod/ec2.tf
@@ -33,7 +33,6 @@
 #   name = "/aws/service/ami-amazon-linux-latest/al2023-ami-kernel-default-x86_64"
 # }
 
-# # trivy:ignore:avd-aws-0104: Required for SSM
 # resource "aws_security_group" "ec2_sg" {
 #   # checkov:skip=CKV_AWS_382: Required for SSM
 #   name        = "allow_access"

--- a/terraform/aws/analytical-platform-data-engineering-production/ppud-prod/main.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/ppud-prod/main.tf
@@ -1,6 +1,3 @@
-#trivy:ignore:avd-aws-0132: Skipping because replicating existing bucket that does not encrypt data with a customer managed key
-#trivy:ignore:avd-aws-0088: Skipping because has server side encryption
-#trivy:ignore:avd-aws-0089: Skipping because access logging is managed externally.
 module "ppud_prod" {
   #checkov:skip=CKV_TF_1: Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2: Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/buckets.tf
+++ b/terraform/aws/analytical-platform-data-engineering-sandbox-a/opg-fabric-connector/buckets.tf
@@ -1,4 +1,3 @@
-#trivy:ignore:AVD-AWS-0089
 module "opg_fabric_store" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
+++ b/terraform/aws/analytical-platform-data-production/athena/athena-workgroups.tf
@@ -116,7 +116,6 @@ locals {
 }
 
 
-# trivy:ignore:AVD-AWS-0006 Not encrypting the workgroup currently
 resource "aws_athena_workgroup" "airflow" {
   #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
 
@@ -148,8 +147,6 @@ resource "aws_athena_workgroup" "airflow" {
   )
 }
 
-# trivy:ignore:AVD-AWS-0006 Not encrypting the workgroup currently
-# trivy:ignore:AVD-AWS-0007 Can't enforce output location due to DBT requirements
 resource "aws_athena_workgroup" "dbt" {
   #checkov:skip=CKV_AWS_159:Not encrypting the workgroup currently
   #checkov:skip=CKV_AWS_82:Can't enforce output location due to DBT requirements

--- a/terraform/aws/analytical-platform-data-production/cloudtrail-athena-events/lambda-functions.tf
+++ b/terraform/aws/analytical-platform-data-production/cloudtrail-athena-events/lambda-functions.tf
@@ -1,4 +1,3 @@
-#trivy:ignore:avd-aws-0066:X-Ray is not required for this service
 module "cloudtrail_athena_event_processor_function" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 

--- a/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/coat-integration/s3-buckets.tf
@@ -24,7 +24,6 @@ moved {
   to   = module.coat_s3_buckets["coat_cur_reports_v2_hourly"]
 }
 
-#trivy:ignore:AVD-AWS-0089:Bucket logging not enabled currently
 module "coat_s3_buckets" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/create-a-derived-table/buckets.tf
@@ -1,5 +1,3 @@
-#trivy:ignore:avd-aws-0132:Replicating existing bucket that does not encrypt data with a customer managed key
-#trivy:ignore:avd-aws-0090:Bucket versioning is not preferred for this bucket for now as data is produced on-demand (and versioning is expensive)
 module "mojap_cadet_production" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 

--- a/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/data-engineering-pipelines/buckets.tf
@@ -1,5 +1,4 @@
-#trivy:ignore:avd-aws-0090:Bucket versioning is not preferred for query bucket
-#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted.
 module "data_engineering_pipeline_buckets" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 

--- a/terraform/aws/analytical-platform-data-production/ingestion-egress/s3.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-egress/s3.tf
@@ -1,6 +1,6 @@
-#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS.
 #tfsec:ignore:AVD-AWS-0089:Bucket logging not enabled currently
-#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS.
 module "development_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
@@ -71,9 +71,9 @@ module "development_s3" {
   }
 }
 
-#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS.
 #tfsec:ignore:AVD-AWS-0089:Bucket logging not enabled currently
-#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS.
 module "production_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
@@ -144,9 +144,9 @@ module "production_s3" {
   }
 }
 
-#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS.
 #tfsec:ignore:AVD-AWS-0089:Bucket logging not enabled currently
-#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS.
 module "shared_services_client_team_gov_29148_egress_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/s3.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/s3.tf
@@ -20,10 +20,9 @@ data "aws_iam_policy_document" "datasync_opg_ingress_bucket_policy" {
   }
 }
 
-#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS.
 #tfsec:ignore:AVD-AWS-0089:False positive in remote scan; module logging input is set below
-#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS, but not detected by Trivy
-#trivy:ignore:AVD-AWS-0089:False positive in remote scan; module logging input is set below
+#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS.
 module "datasync_opg_ingress_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
@@ -126,8 +125,8 @@ data "aws_iam_policy_document" "datasync_laa_logs_bucket_policy" {
   }
 }
 
-#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS, but not detected by Trivy
-#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS.
+#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS.
 module "datasync_laa_ingress_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
@@ -237,9 +236,8 @@ module "datasync_laa_ingress_s3" {
   }
 }
 
-#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS, but not detected by Trivy
-#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS, but not detected by Trivy
-#trivy:ignore:AVD-AWS-0089:False positive in remote scan; module logging input is set below
+#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS.
+#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS.
 module "mojap_access_logging_eu_west_2_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/s3.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/s3.tf
@@ -17,9 +17,9 @@ data "aws_iam_policy_document" "cica_dms_ingress_bucket_policy" {
   }
 }
 
-#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS.
 #tfsec:ignore:AVD-AWS-0089:Bucket logging not enabled currently
-#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS.
 module "cica_dms_ingress_s3" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/datahub-iam.tf
@@ -64,7 +64,6 @@ resource "aws_iam_policy" "datahub_ingest_athena_query_results" {
   policy = data.aws_iam_policy_document.datahub_ingest_athena_query_results.json
 }
 
-#trivy:ignore:avd-aws-0057:sensitive action 's3:*' on wildcarded resource
 data "aws_iam_policy_document" "datahub_read_cadet_bucket" {
   statement {
     sid    = "datahubReadCaDeTBucket"
@@ -128,7 +127,6 @@ resource "aws_iam_role_policy_attachment" "datahub_ingestion_github_actions_athe
   role       = aws_iam_role.datahub_ingestion_github_actions.name
 }
 
-#trivy:ignore:aws-iam-no-policy-wildcards
 # Listing all Glue buckets for finding the latest file timestamp so that analysts can see the correct timestamp.
 data "aws_iam_policy_document" "datahub_ingestion_github_actions_s3_list_all_buckets" {
   statement {
@@ -155,7 +153,6 @@ resource "aws_iam_role_policy_attachment" "datahub_ingestion_github_actions_s3_l
   role       = aws_iam_role.datahub_ingestion_github_actions.name
 }
 
-#trivy:ignore:avd-aws-0057:sensitive action 'glue:GetDatabases' on wildcarded resource
 data "aws_iam_policy_document" "datahub_ingest_glue_datasets" {
   statement {
     sid    = "datahubIngestGlueDatasets"
@@ -177,7 +174,6 @@ resource "aws_iam_policy" "datahub_ingest_glue_datasets" {
   policy = data.aws_iam_policy_document.datahub_ingest_glue_datasets.json
 }
 
-#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "datahub_ingest_glue_jobs" {
   statement {
     sid    = "datahubIngestGlueJobs"

--- a/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-data-production/tooling-iam/tooling-integration-iam-policies.tf
@@ -1,5 +1,3 @@
-#trivy:ignore:aws-iam-no-policy-wildcards
-#trivy:ignore:AVD-AWS-0342 passing of role is needed for batch processing
 data "aws_iam_policy_document" "bedrock_integration" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
@@ -223,7 +221,6 @@ resource "aws_iam_policy" "textract_integration" {
   policy      = data.aws_iam_policy_document.textract_integration.json
 }
 
-#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "quicksight_author" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
@@ -272,7 +269,6 @@ resource "aws_iam_policy" "quicksight_author" {
   policy = data.aws_iam_policy_document.quicksight_author.json
 }
 
-#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "lake_formation_data_access" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
@@ -291,8 +287,6 @@ resource "aws_iam_policy" "lake_formation_data_access" {
   policy = data.aws_iam_policy_document.lake_formation_data_access.json
 }
 
-#trivy:ignore:aws-iam-no-policy-wildcards
-#trivy:ignore:AVD-AWS-0342
 data "aws_iam_policy_document" "comprehend_integration" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
@@ -368,7 +362,6 @@ resource "aws_iam_policy" "comprehend_integration" {
 # Comprehend Batch Processing Role
 ##################################################
 
-#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "comprehend_batch_processing_assume_role" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
@@ -401,7 +394,6 @@ resource "aws_iam_role" "comprehend_batch_processing" {
   assume_role_policy = data.aws_iam_policy_document.comprehend_batch_processing_assume_role.json
 }
 
-#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "comprehend_batch_processing_s3_access" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources

--- a/terraform/aws/analytical-platform-data-production/transcribe/buckets.tf
+++ b/terraform/aws/analytical-platform-data-production/transcribe/buckets.tf
@@ -1,7 +1,3 @@
-#trivy:ignore:avd-aws-0132:Replicating existing bucket that does not encrypt data with a customer managed key
-#trivy:ignore:avd-aws-0090:Bucket versioning is not preferred for this bucket for now as data is processed on-demand
-# trivy:ignore:AVD-AWS-0090 Bucket versioning is not preferred for this bucket for now as data is processed on-demand
-# trivy:ignore:avd-aws-0090 Bucket versioning is not preferred for this bucket for now as data is processed on-demand
 module "mojap_transcribe_spike" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
 

--- a/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/tooling-integration-iam-policies.tf
@@ -127,8 +127,6 @@ data "aws_iam_policy_document" "textract_integration" {
   }
 }
 
-#trivy:ignore:aws-iam-no-policy-wildcards
-#trivy:ignore:AVD-AWS-0342
 data "aws_iam_policy_document" "comprehend_integration" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources

--- a/terraform/aws/analytical-platform-development/tooling-iam/tooling-integration-iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/tooling-iam/tooling-integration-iam-policies.tf
@@ -1,4 +1,3 @@
-#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "quicksight_author" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources
@@ -47,7 +46,6 @@ resource "aws_iam_policy" "quicksight_author" {
   policy = data.aws_iam_policy_document.quicksight_author.json
 }
 
-#trivy:ignore:aws-iam-no-policy-wildcards
 data "aws_iam_policy_document" "lake_formation_data_access" {
   #checkov:skip=CKV_AWS_111: This is a service policy
   #checkov:skip=CKV_AWS_356: Needs to access multiple resources

--- a/terraform/aws/analytical-platform-production/route53/iam-polices.tf
+++ b/terraform/aws/analytical-platform-production/route53/iam-polices.tf
@@ -1,4 +1,3 @@
-#trivy:ignore:avd-aws-0057:Wildcard is suggested from listing zones
 data "aws_iam_policy_document" "analytical_platform_compute_route53_access" {
   #checkov:skip=CKV_AWS_356:Wildcard is suggested from listing zones
 


### PR DESCRIPTION
This pull request primarily removes `trivy:ignore` comments and related vulnerability scan suppression annotations from various Terraform and documentation files. It also updates the documentation to reflect a change in the container image vulnerability scanning tool. These changes help clean up the codebase and ensure that only relevant and up-to-date security annotations are present.

The most important changes are:

**Security annotation cleanup:**

* Removed numerous `trivy:ignore` comments and related scan suppression annotations from Terraform files across multiple modules, including S3 buckets, EC2 security groups, IAM policies, and Athena workgroups. This reduces noise and ensures that only necessary security suppressions remain. 

**Documentation update:**

* Updated the platform documentation to state that container images are now scanned for vulnerabilities using Grype instead of Trivy, reflecting a change in the security tooling.

These changes streamline the codebase by removing outdated or unnecessary scan suppressions and keep documentation in sync with current practices.
