### PR TITLE
added permsission for bucket access in prod

### DIFF
--- a/terraform/aws/analytical-platform-data-engineering-production/github-actions-roles/iam.tf
+++ b/terraform/aws/analytical-platform-data-engineering-production/github-actions-roles/iam.tf
@@ -310,6 +310,8 @@ data "aws_iam_policy_document" "create_a_derived_table_prod" {
       "arn:aws:s3:::probation-datalake-prod*",
       "arn:aws:s3:::probation-query-results-prod*/*",
       "arn:aws:s3:::probation-query-results-prod*",
+      "arn:aws:s3:::mojap-derived-tables/*",
+      "arn:aws:s3:::mojap-derived-tables"
     ]
   }
   statement {


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/<your_issue_number_here>)
GitHub Issue.

This PR adds a bucket to the bucket access permissions list. This bucket is the location of stored results to allow the [check_run_results.py script in this repo](https://github.com/ministryofjustice/analytical-platform-airflow-cadet-deployer) to access.
## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
