### PR TITLE
Grant data-plane KMS actions to S3 requesters via key policy

### DIFF
--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
@@ -68,6 +68,33 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
       values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
     }
   }
+
+  statement {
+    sid = "AllowKeyUseViaS3"
+
+    principals {
+      type = "AWS"
+      identifiers = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+      ]
+    }
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "kms:ViaService"
+      values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
+    }
+  }
 }
 
 resource "aws_kms_key" "s3_test_kms_key" {

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
   }
 
   statement {
-    sid = "AllowKeyUseViaS3"
+    sid = "AllowKeyUseViaIAM"
 
     principals {
       type = "AWS"
@@ -88,12 +88,6 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
     ]
 
     resources = ["*"]
-
-    condition {
-      test     = "StringEquals"
-      variable = "kms:ViaService"
-      values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
-    }
   }
 }
 


### PR DESCRIPTION
# Pull Request Objective

Adds an AllowKeyUseViaS3 statement to the Splink test bucket's KMS key policy, delegating data-plane actions (GenerateDataKey, Encrypt, Decrypt, etc.) to IAM and scoping them to S3-mediated calls. This unblocks encrypted PutObject operations, which previously failed because the key policy only granted management-plane actions.

## Checklist

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

