### PR TITLE
Add additional checks to catch outdated branch

### DIFF
--- a/.github/workflows/repository-dependabot-auto-merge.yml
+++ b/.github/workflows/repository-dependabot-auto-merge.yml
@@ -107,7 +107,23 @@ jobs:
                 }
               } catch (error) {
                 const status = error.status || error.response?.status
-                if (status === 405 || status === 409 || status === 422) {
+                if (status === 405) {
+                  // Branch may be behind main; update it to trigger a fresh CI run and retry via workflow_run.
+                  try {
+                    await github.rest.pulls.updateBranch({ owner, repo, pull_number: pullNumber })
+                    console.log(`Updated branch for #${pullNumber} — merge will be retried after CI re-runs`)
+                  } catch (updateError) {
+                    const updateStatus = updateError.status || updateError.response?.status
+                    if (updateStatus === 422) {
+                      console.log(`Branch for #${pullNumber} is already up to date — merge blocked by pending checks`)
+                    } else {
+                      console.log(`Could not update branch for #${pullNumber}: ${updateError.message}`)
+                    }
+                  }
+                  continue
+                }
+
+                if (status === 409 || status === 422) {
                   console.log(`Merge not ready for #${pullNumber}. The workflow will retry on a later event.`)
                   continue
                 }


### PR DESCRIPTION



This pull request updates the auto-merge workflow for Dependabot PRs to better handle cases where a branch is behind the main branch. The workflow now attempts to automatically update the branch and provides clearer logging for different failure scenarios.

Error handling improvements:

* When a merge fails with a 405 status (indicating the branch is behind), the workflow now tries to update the PR branch using `github.rest.pulls.updateBranch`, and logs the outcome, including handling the case where the branch is already up to date.
* The handling of 409 and 422 status codes (merge conflicts or unmergeable state) is separated to provide more specific logging and retry logic.


This piece of work is being tracked in [this](https://github.com/orgs/ministryofjustice/projects/167/views/5?filterQuery=Sprint%3A%40current++label%3A%22squad-one%22+label%3A%22platform-engineering%22&pane=issue&itemId=223257365&issue=ministryofjustice%7Cdata-platform%7C626) ticket please check for background information.

