### PR TITLE
feat: restrict splink test S3 KMS key use to Airflow roles

### DIFF
--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
@@ -70,12 +70,13 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
   }
 
   statement {
-    sid = "AllowKeyUseViaIAM"
+    sid = "AllowAirflowKeyUse"
 
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "arn:aws:iam::593291632749:role/airflow-development-laa-si-access-test",
+        "arn:aws:iam::593291632749:role/airflow-development-laa-s3-ops"
       ]
     }
 

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
@@ -75,8 +75,7 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::593291632749:role/airflow-development-laa-si-access-test",
-        "arn:aws:iam::593291632749:role/airflow-development-laa-s3-ops"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
       ]
     }
 
@@ -89,6 +88,14 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
     ]
 
     resources = ["*"]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values = [
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/airflow-development-laa-*"
+      ]
+    }
   }
 }
 

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
@@ -75,10 +75,10 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::593291632749:role/airflow-development-laa-si-access-test",
-        "arn:aws:iam::593291632749:role/airflow-development-laa-s3-ops",
-        "arn:aws:iam::593291632749:role/alpha_user_jamess-moj",
-        "arn:aws:iam::593291632749:role/alpha_user_dami-moj"
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/airflow-development-laa-si-access-test",
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/airflow-development-laa-s3-ops",
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/alpha_user_jamess-moj",
+        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/alpha_user_dami-moj"
       ]
     }
 

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
@@ -70,12 +70,15 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
   }
 
   statement {
-    sid = "AllowAirflowKeyUse"
+    sid = "AllowAirflowAndNamedUserKeyUse"
 
     principals {
       type = "AWS"
       identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"
+        "arn:aws:iam::593291632749:role/airflow-development-laa-si-access-test",
+        "arn:aws:iam::593291632749:role/airflow-development-laa-s3-ops",
+        "arn:aws:iam::593291632749:role/alpha_user_jamess-moj",
+        "arn:aws:iam::593291632749:role/alpha_user_dami-moj"
       ]
     }
 
@@ -88,14 +91,6 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
     ]
 
     resources = ["*"]
-
-    condition {
-      test     = "ArnLike"
-      variable = "aws:PrincipalArn"
-      values = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/airflow-development-laa-*"
-      ]
-    }
   }
 }
 


### PR DESCRIPTION
# Pull Request Objective

Replaces the account-root delegation on the Splink test S3 KMS key with an explicit principal list of Airflow roles plus named user assumed-roles, making the key policy itself the access constraint rather than relying on IAM grants managed elsewhere. Scoped to the test key only; production remains unchanged until the behaviour is validated.

## Checklist
- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected
