### PR TITLE
Externalise Splink S3 KMS key-user principals to a JSON access list

### DIFF
--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms.tf
@@ -64,6 +64,25 @@ data "aws_iam_policy_document" "s3_kms_policy" {
       values   = ["s3.${data.aws_region.current.region}.amazonaws.com"]
     }
   }
+
+  statement {
+    sid = "AllowAirflowKeyUse"
+
+    principals {
+      type        = "AWS"
+      identifiers = local.splink_s3_key_user_arns
+    }
+
+    actions = [
+      "kms:Encrypt",
+      "kms:Decrypt",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:DescribeKey"
+    ]
+
+    resources = ["*"]
+  }
 }
 
 resource "aws_kms_key" "s3_kms_key" {

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
@@ -1,8 +1,6 @@
 {
   "splink_s3_bucket": {
-    "key_users": [
-      "alpha_user_jamess-moj"
-    ]
+    "key_users": ["alpha_user_jamess-moj"]
   },
   "splink_s3_test_bucket": {
     "key_users": [

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
@@ -1,0 +1,16 @@
+{
+  "splink_s3_bucket": {
+    "key_users": [
+      "airflow-production-laa-si-access",
+      "airflow-production-laa-s3-ops"
+    ]
+  },
+  "splink_s3_test_bucket": {
+    "key_users": [
+      "airflow-development-laa-si-access-test",
+      "airflow-development-laa-s3-ops",
+      "alpha_user_jamess-moj",
+      "alpha_user_dami-moj"
+    ]
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
@@ -7,6 +7,7 @@
   },
   "splink_s3_test_bucket": {
     "key_users": [
+      "airflow-development-laa-search-index-source",
       "airflow-development-laa-si-access-test",
       "airflow-development-laa-s3-ops",
       "alpha_user_jamess-moj",

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
@@ -1,8 +1,7 @@
 {
   "splink_s3_bucket": {
     "key_users": [
-      "airflow-production-laa-si-access",
-      "airflow-production-laa-s3-ops"
+      "alpha_user_jamess-moj"
     ]
   },
   "splink_s3_test_bucket": {

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/locals.tf
@@ -1,5 +1,16 @@
 locals {
-  app = jsondecode(file("${path.module}/application_variables.json"))
+  app           = jsondecode(file("${path.module}/application_variables.json"))
+  kms_key_users = jsondecode(file("${path.module}/kms_key_users.json"))
+
+  splink_s3_key_user_arns = [
+    for role in local.kms_key_users.splink_s3_bucket.key_users :
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${role}"
+  ]
+
+  splink_s3_test_key_user_arns = [
+    for role in local.kms_key_users.splink_s3_test_bucket.key_users :
+    "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/${role}"
+  ]
 
   application_name            = local.app.application_name
   logging_bucket_name         = "moj-analytics-s3-logs-eu-west-2"

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3_test.tf
@@ -73,13 +73,8 @@ data "aws_iam_policy_document" "s3_test_kms_policy" {
     sid = "AllowAirflowAndNamedUserKeyUse"
 
     principals {
-      type = "AWS"
-      identifiers = [
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/airflow-development-laa-si-access-test",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/airflow-development-laa-s3-ops",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/alpha_user_jamess-moj",
-        "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/alpha_user_dami-moj"
-      ]
+      type        = "AWS"
+      identifiers = local.splink_s3_test_key_user_arns
     }
 
     actions = [


### PR DESCRIPTION
# Pull Request Objective

Moves the KMS key-use principal identifiers for the Splink prod and test S3 keys into an auditable kms_key_users.json file, decoded in locals and referenced by both key policies, so access is managed in one reviewable place and new buckets can be added easily. Prod is scoped to the Airflow roles while test also includes the named users.