### PR TITLE
creating-deny-statement-for-DE

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/s3.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/s3.tf
@@ -80,6 +80,29 @@ data "aws_iam_policy_document" "datasync_laa_ingress_bucket_policy" {
     ]
     resources = ["arn:aws:s3:::mojap-data-production-datasync-laa-ingress-production/*"]
   }
+
+  # The DE modernisation-platform-data-eng role has elevated permissions in the
+  # data-production account that would otherwise grant broad S3 read access to
+  # this sensitive LAA ingress bucket. This deny statement explicitly blocks
+  # data-plane access for that role regardless of any IAM grants.
+  statement {
+    sid    = "DenyDataEngineeringRoleAccess"
+    effect = "Deny"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/modernisation-platform-data-eng"]
+    }
+    actions = [
+      "s3:GetObject",
+      "s3:GetObjectVersion",
+      "s3:ListBucket",
+      "s3:ListBucketVersions"
+    ]
+    resources = [
+      "arn:aws:s3:::mojap-data-production-datasync-laa-ingress-production",
+      "arn:aws:s3:::mojap-data-production-datasync-laa-ingress-production/*"
+    ]
+  }
 }
 
 # Policy for LAA logging bucket


### PR DESCRIPTION
# Pull Request Objective

~This piece of work is being tracked in
[this](https://github.com/ministryofjustice/analytical-platform/issues/<your_issue_number_here>)
GitHub Issue.~

Broadly, DEs can view the `mojap-data-production-datasync-laa-ingress-production` bucket. This shouldn't be the case; only named individuals should have access to that bucket. This PR denys the `modernisation-platform-data-eng` DE role which has elevated permissions.

The aim is that only people defined in the AP control panel, or [the IAM policy,](https://github.com/moj-analytical-services/data-engineering-database-access/blob/main/project_access/laa_ingress_analysis.yaml) can read the bucket contents.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

<!-- Additional Comments Here -->
