### PR TITLE
Cannot reference SSO role directly, so using a wildcard with ArnLike condition to deny DE access. 

### DIFF
--- a/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/s3.tf
+++ b/terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync/s3.tf
@@ -81,16 +81,17 @@ data "aws_iam_policy_document" "datasync_laa_ingress_bucket_policy" {
     resources = ["arn:aws:s3:::mojap-data-production-datasync-laa-ingress-production/*"]
   }
 
-  # The DE modernisation-platform-data-eng role has elevated permissions in the
+  # The DE modernisation-platform-data-eng SSO role has elevated permissions in the
   # data-production account that would otherwise grant broad S3 read access to
-  # this sensitive LAA ingress bucket. This deny statement explicitly blocks
-  # data-plane access for that role regardless of any IAM grants.
+  # this sensitive LAA ingress bucket. SSO roles cannot be referenced directly as
+  # principals in bucket policies; a wildcard principal with an ArnLike condition
+  # on aws:PrincipalArn is required to match the assumed-role session ARN.
   statement {
     sid    = "DenyDataEngineeringRoleAccess"
     effect = "Deny"
     principals {
       type        = "AWS"
-      identifiers = ["arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/modernisation-platform-data-eng"]
+      identifiers = ["*"]
     }
     actions = [
       "s3:GetObject",
@@ -102,6 +103,11 @@ data "aws_iam_policy_document" "datasync_laa_ingress_bucket_policy" {
       "arn:aws:s3:::mojap-data-production-datasync-laa-ingress-production",
       "arn:aws:s3:::mojap-data-production-datasync-laa-ingress-production/*"
     ]
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/aws-reserved/sso.amazonaws.com/*AWSReservedSSO_modernisation-platform-data-eng*"]
+    }
   }
 }
 


### PR DESCRIPTION
# Pull Request Objective

[Terraform failed apply](https://github.com/ministryofjustice/analytical-platform/actions/runs/32265332744) following https://github.com/ministryofjustice/analytical-platform/pull/10574. 

This PR aims to solve this apply failure.

- Direct principal ARN: Solves at parse time. This causes the error.
- Wildcard +aws:PrincipalArn: Solves at request time. This should fix the error.

The `modernisation-platform-data-eng` role is an AWS SSO reserved role. The MalformedPolicy: Invalid principal error could be because SSO roles live under `arn:aws:iam:::role/aws-reserved/sso.amazonaws.com/` and they cannot be named directly as principals in S3 bucket policies like #10574 tried to do. As I understand it, AWS rejects them at parse time.

This PR replaces the direct principal ARN with a wildcard principal ( * ) and then uses an  ArnLike  condition on  `aws:PrincipalArn` , which pattern-matches the SSO role at request time instead. The deny behaviour should be identical; only DE users assuming this SSO role are blocked from reading the LAA ingress bucket. The difference is that `aws:PrincipalArn`  is evaluated at request time against the underlying role ARN rather than the session ARN, whereas a direct principal ARN is validated at policy parse time. S3 rejects the  aws-reserved  SSO role path at that stage with `MalformedPolicy: Invalid principal` . See [AWS IAM docs on Principal](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html#principal-roles): 

> "the role session principal is granted the permissions based on the ARN of the role that was assumed, and not the ARN of the resulting session."

I think this timing is what caused the error, and I think changing to the wildcard changes the timing of implementing the deny.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

Because this is a timing issue on complex roles, it is unlikely that the `tf plan`-based checks will catch it. We will only learn if AWS accepts the policy during `tf apply`
