### PR TITLE
Allow Airflow production role to use Splink S3 KMS key

### DIFF
--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
@@ -1,6 +1,9 @@
 {
   "splink_s3_bucket": {
-    "key_users": ["alpha_user_jamess-moj"]
+    "key_users": [
+      "alpha_user_jamess-moj",
+      "airflow-production-laa-search-index-s3-ops"
+    ]
   },
   "splink_s3_test_bucket": {
     "key_users": [


### PR DESCRIPTION
# Pull Request Objective

Add `airflow-production-laa-search-index-s3-ops` to the `splink_s3_bucket` KMS key users in production. This allows the Airflow production role to perform encrypted S3 operations against the Splink bucket.
