### PR TITLE
Shorten namespace name to not hit 53 char limit in helm chart name

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table-dev.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table-dev.tf
@@ -210,17 +210,17 @@ module "create_a_derived_table_dev_iam_role" {
     analytical-platform-compute-production = {
       provider_arn = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/801920EDEF91E3CAB03E04C03A2DE2BB"
       namespace_service_accounts = [
-        "actions-runners:actions-runner-mojas-create-a-derived-table-dev",
-        "actions-runners:actions-runner-mojas-create-a-derived-table-dev-non-spot"
+        "actions-runners:actions-runner-mojas-cadet-dev",
+        "actions-runners:actions-runner-mojas-cadet-dev-non-spot"
       ]
     }
     cloud-platform = {
       provider_arn               = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/DF366E49809688A3B16EEC29707D8C09"
-      namespace_service_accounts = ["data-platform-production:actions-runner-mojas-create-a-derived-table-dev"]
+      namespace_service_accounts = ["data-platform-production:actions-runner-mojas-cadet-dev"]
     }
     data-platform-production = {
       provider_arn               = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/F147414004D7C4CF820F21F453AF80F1"
-      namespace_service_accounts = ["actions-runners:actions-runner-mojas-create-a-derived-table-dev"]
+      namespace_service_accounts = ["actions-runners:actions-runner-mojas-cadet-dev"]
     }
   }
 }


### PR DESCRIPTION
# Pull Request Objective

This piece of work is being tracked in
[this](https://github.com/ministryofjustice/data-platform-security/issues/79) GitHub Issue.

Namespace names too long for helm chart names.