### PR TITLE
🪣 OPG: Create bucket and key

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -78,6 +78,7 @@ updates:
       - "terraform/aws/analytical-platform-data-production/ingestion-ingress/datasync"
       - "terraform/aws/analytical-platform-data-production/ingestion-ingress/dms"
       - "terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data"
+      - "terraform/aws/analytical-platform-data-production/opg-forms"
       - "terraform/aws/analytical-platform-data-production/powerbi-gateway"
       - "terraform/aws/analytical-platform-data-production/rds-s3-exports"
       - "terraform/aws/analytical-platform-data-production/s3-glue-crawler"

--- a/terraform/aws/analytical-platform-data-production/opg-forms/.terraform.lock.hcl
+++ b/terraform/aws/analytical-platform-data-production/opg-forms/.terraform.lock.hcl
@@ -1,0 +1,26 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.61.0"
+  constraints = ">= 6.28.0, >= 6.42.0"
+  hashes = [
+    "h1:xgqNausjCmDbyoc3aY+flDVsUKgefbTjgKA9cQun4Ks=",
+    "zh:216566f0fbc506e107d3a961c87d88aed052ec2b4ced13388394d3cff30425ac",
+    "zh:4700ad141d0ad96465ac35a3900f2ff7c91a1e5528428ac687c8b5825c0be718",
+    "zh:6b79d2fa6550fc51e2fac04f1066c5cc96e957e7634ad86d2250240e637db205",
+    "zh:76f6227bf2bcd7422cf29d9868d8b517c8220ec3edd4e7c8434b867a71c03334",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:a7be5814cf94a8e3869ec9fa7f5182223a11373a4510ce68b9bab431f9b83746",
+    "zh:b65392e24506fe99f8df7bd2b5d3940d7a234b64b79a890f1aabe2be91a827e5",
+    "zh:b68a5092203cf5a9d1a5f01f9f2e96fded3eb7cacfd49ae851c50b87bc610fe9",
+    "zh:b8fedfa62bac16592519e1bae0c82dd7cd1544b0637543d72e3597e46ad7db32",
+    "zh:bba8a35212c07e68b6c881aa011c4b26a284e42b971059579aca9ffb63a8faef",
+    "zh:bbd0391e3e2f21c8930872829df7cf7f4e35f84c4d6d7b7619a94f8078fe6f3d",
+    "zh:c9c921e8e466281c04cada8d336ec1ce978128ee153e9df7b451847fbea49d18",
+    "zh:c9cb0be3097f4392b977fa254d28efd0909d008f572e74a41ead6c0d84c0daaa",
+    "zh:cc7aeb23fa3775816e391d4668a9865f787993f9f8d6f5b7a9f7e4effdffb3cb",
+    "zh:e59e487220cec8999bbd120ba8f97b5e04b010fb9149e47d4c9032961614d7c7",
+    "zh:fa19a7571a99397120f2f2bdcf33bbcc2f39091b9b0c879cd7e5f9ebb1966c40",
+  ]
+}

--- a/terraform/aws/analytical-platform-data-production/opg-forms/kms-keys.tf
+++ b/terraform/aws/analytical-platform-data-production/opg-forms/kms-keys.tf
@@ -1,0 +1,30 @@
+module "opg_forms_kms" {
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-kms.git?ref=af1d45558a6073c017a732d2273efcc733b34d0f" # v4.2.1
+
+  aliases               = ["s3/mojap-data-production-opg-forms"]
+  description           = "MoJ AP OPG Forms"
+  enable_default_policy = true
+  key_statements = [
+    {
+      sid = "AllowGOVUKFormsAccess"
+      actions = [
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
+      ]
+      resources = ["*"]
+      effect    = "Allow"
+      principals = [
+        {
+          type        = "AWS"
+          identifiers = ["arn:aws:iam::443944947292:root"]
+        }
+      ]
+      conditions = [{
+        test     = "ArnLike"
+        variable = "aws:PrincipalArn"
+        values   = ["arn:aws:iam::443944947292:role/govuk-forms-submissions-to-s3-production"]
+      }]
+    }
+  ]
+  deletion_window_in_days = 7
+}

--- a/terraform/aws/analytical-platform-data-production/opg-forms/s3.tf
+++ b/terraform/aws/analytical-platform-data-production/opg-forms/s3.tf
@@ -1,0 +1,59 @@
+data "aws_iam_policy_document" "opg_forms_bucket_policy" {
+
+  statement {
+    sid    = "AllowGOVUKFormsAccess"
+    effect = "Allow"
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::443944947292:root"]
+    }
+    actions = [
+      "s3:PutObject"
+    ]
+    resources = ["arn:aws:s3:::mojap-data-production-opg-forms/*"]
+
+    condition {
+      test     = "ArnLike"
+      variable = "aws:PrincipalArn"
+      values   = ["arn:aws:iam::443944947292:role/govuk-forms-submissions-to-s3-production"]
+    }
+  }
+}
+
+#tfsec:ignore:AVD-AWS-0088:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#tfsec:ignore:AVD-AWS-0089:False positive in remote scan; module logging input is set below
+#tfsec:ignore:AVD-AWS-0132:Bucket is encrypted with CMK KMS, but not detected by Trivy
+#trivy:ignore:AVD-AWS-0089:False positive in remote scan; module logging input is set below
+module "opg_forms_s3" {
+  #checkov:skip=CKV_AWS_18:Access logging not enabled currently
+  #checkov:skip=CKV_AWS_21:Versioning is enabled, but not detected by Checkov
+  #checkov:skip=CKV_AWS_145:Bucket is encrypted with CMK KMS, but not detected by Checkov
+  #checkov:skip=CKV_AWS_300:Lifecycle configuration not enabled currently
+  #checkov:skip=CKV_AWS_144:Cross-region replication is not required currently
+  #checkov:skip=CKV2_AWS_6:Public access block is enabled, but not detected by Checkov
+  #checkov:skip=CKV2_AWS_61:Lifecycle configuration not enabled currently
+  #checkov:skip=CKV2_AWS_62:Bucket notifications not required currently
+  #checkov:skip=CKV2_AWS_67:Regular CMK key rotation is not required currently
+
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-s3-bucket.git?ref=dd0c434de5e74d8864e249ee020d917b076b6e32" # v5.15.4
+
+  bucket = "mojap-data-production-opg-forms"
+
+  force_destroy = true
+
+  versioning = {
+    enabled = true
+  }
+
+  attach_policy = true
+  policy        = data.aws_iam_policy_document.opg_forms_bucket_policy.json
+
+  server_side_encryption_configuration = {
+    rule = {
+      apply_server_side_encryption_by_default = {
+        kms_master_key_id = module.opg_forms_kms.key_arn
+        sse_algorithm     = "aws:kms"
+      }
+    }
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/opg-forms/terraform.tf
+++ b/terraform/aws/analytical-platform-data-production/opg-forms/terraform.tf
@@ -1,0 +1,26 @@
+terraform {
+  backend "s3" {
+    acl          = "private"
+    bucket       = "global-tf-state-aqsvzyd5u9"
+    encrypt      = true
+    key          = "aws/analytical-platform-data-production/opg-forms/terraform.tfstate"
+    region       = "eu-west-2"
+    use_lockfile = true
+  }
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 6.28.0"
+    }
+  }
+  required_version = "~> 1.5"
+}
+provider "aws" {
+  region = "eu-west-1"
+  assume_role {
+    role_arn = "arn:aws:iam::${var.account_ids["analytical-platform-data-production"]}:role/GlobalGitHubActionAdmin"
+  }
+  default_tags {
+    tags = var.tags
+  }
+}

--- a/terraform/aws/analytical-platform-data-production/opg-forms/terraform.tfvars
+++ b/terraform/aws/analytical-platform-data-production/opg-forms/terraform.tfvars
@@ -1,0 +1,17 @@
+account_ids = {
+  analytical-platform-data-production       = "593291632749"
+  analytical-platform-management-production = "042130406152"
+  analytical-platform-compute-development   = "381491960855"
+  analytical-platform-compute-production    = "992382429243"
+}
+
+tags = {
+  business-unit          = "Platforms"
+  application            = "Analytical Platform"
+  component              = "opg-forms"
+  environment            = "production"
+  is-production          = "true"
+  owner                  = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  infrastructure-support = "analytical-platform:analytical-platform@digital.justice.gov.uk"
+  source-code            = "github.com/ministryofjustice/analytical-platform/terraform/aws/analytical-platform-data-production/opg-forms"
+}

--- a/terraform/aws/analytical-platform-data-production/opg-forms/variables.tf
+++ b/terraform/aws/analytical-platform-data-production/opg-forms/variables.tf
@@ -1,0 +1,9 @@
+variable "account_ids" {
+  type        = map(string)
+  description = "Map of account names to account IDs"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Map of tags to apply to resources"
+}


### PR DESCRIPTION
Created a new KMS key and S3 bucket for GOV.UK Forms submissions.

This replacement PR includes the generated `.github/dependabot.yml` entry and Terraform lock file in the initial signed commit, so the Data Platform robot does not need to add a follow-up commit.

Related issue: https://github.com/ministryofjustice/data-platform/issues/357

The original PR is #10048.