### PR TITLE
Revert auth0 version to 1.53.0

### DIFF
--- a/terraform/auth0/ministryofjustice-data-platform/terraform.tf
+++ b/terraform/auth0/ministryofjustice-data-platform/terraform.tf
@@ -14,7 +14,7 @@ terraform {
     }
     auth0 = {
       source  = "auth0/auth0"
-      version = "1.54.0"
+      version = "1.53.0"
     }
   }
   required_version = "~> 1.5"


### PR DESCRIPTION
This [PR](https://github.com/ministryofjustice/analytical-platform/pull/10541) to patch to 1.54.0 failed to apply due to a lack of permissions

This pull request makes a minor change to the Terraform configuration by downgrading the `auth0` provider version from `1.54.0` to `1.53.0` in the `terraform/auth0/ministryofjustice-data-platform/terraform.tf` file.  Which will hopefully apply so the code and state match.

