### PR TITLE
Drop LF grant permissions and other refs to these paths

### DIFF
--- a/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table-dev.tf
+++ b/terraform/aws/analytical-platform-data-production/github-actions-roles/mojas-create-a-derived-table-dev.tf
@@ -153,20 +153,6 @@ data "aws_iam_policy_document" "create_a_derived_table_dev" {
     resources = ["*"]
   }
   statement {
-    sid    = "LakeFormationDataLocationAccess"
-    effect = "Allow"
-    actions = [
-      "lakeformation:GrantPermissions"
-    ]
-    resources = [
-      "arn:aws:s3:::alpha-app-opg-lpa-dashboard/prod/models/domain_name=opg/database_name=sirius_derived",
-      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=guardianship_derived",
-      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=sirius_derived",
-      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=sirius_derived/table_name=opg_annual_report",
-      "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=prison/database_name=calculate_release_dates_api"
-    ]
-  }
-  statement {
     sid    = "KMSDecryptActions"
     effect = "Allow"
     actions = [
@@ -222,43 +208,5 @@ module "create_a_derived_table_dev_iam_role" {
       provider_arn               = "arn:aws:iam::593291632749:oidc-provider/oidc.eks.eu-west-2.amazonaws.com/id/F147414004D7C4CF820F21F453AF80F1"
       namespace_service_accounts = ["actions-runners:actions-runner-mojas-cadet-dev"]
     }
-  }
-}
-
-# Lake formation hybrid locations
-locals {
-  create_a_derived_table_dev_data_locations = [
-    "arn:aws:s3:::alpha-app-opg-lpa-dashboard/prod/models/domain_name=opg/database_name=sirius_derived",
-    "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=guardianship_derived",
-    "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=sirius_derived",
-    "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=opg/database_name=sirius_derived/table_name=opg_annual_report",
-    "arn:aws:s3:::mojap-derived-tables/prod/models/domain_name=prison/database_name=calculate_release_dates_api"
-  ]
-
-  lf_data_location_dev_roles = [
-    "arn:aws:iam::593291632749:role/airflow_prod_cadet_deploy_nomis_daily",
-    "arn:aws:iam::593291632749:role/create-a-derived-table-dev"
-  ]
-}
-# Combinations of paths and roles
-locals {
-  lf_data_location_dev_pairs = merge([
-    for role in local.lf_data_location_dev_roles : {
-      for location in local.create_a_derived_table_dev_data_locations :
-      "${role}|${location}" => {
-        principal = role
-        location  = location
-      }
-    }
-  ]...)
-}
-resource "aws_lakeformation_permissions" "create_a_derived_table_dev_data_locations" {
-  for_each = local.lf_data_location_dev_pairs
-
-  principal   = each.value.principal
-  permissions = ["DATA_LOCATION_ACCESS"]
-
-  data_location {
-    arn = each.value.location
   }
 }


### PR DESCRIPTION
[Task tracked here](https://github.com/ministryofjustice/data-platform-security/issues/82)
This pull request removes all Lake Formation data location access configuration for the `create-a-derived-table-dev` role. Specifically, it deletes both the IAM policy statement granting `lakeformation:GrantPermissions` and the associated Terraform resources and locals that managed Lake Formation data location permissions.

**Removal of Lake Formation data location access:**

* Deleted the IAM policy statement (`LakeFormationDataLocationAccess`) that allowed the `lakeformation:GrantPermissions` action on a set of S3 data locations from the `aws_iam_policy_document` resource.
* Removed the Terraform locals defining the relevant S3 data locations and associated IAM roles, as well as the logic to pair them.
* Deleted the `aws_lakeformation_permissions.create_a_derived_table_dev_data_locations` resource, which granted `DATA_LOCATION_ACCESS` to the specified principals for the listed S3 paths.