### PR TITLE
Create 3 test secrets with expiry tags

### DIFF
--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -51,6 +51,8 @@ resource "aws_secretsmanager_secret" "github_token" {
 # test secrets
 resource "aws_secretsmanager_secret" "test_1" {
   provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   name        = "test-1"
   description = "Test secret with an expiry date"
 
@@ -62,6 +64,8 @@ resource "aws_secretsmanager_secret" "test_1" {
 
 resource "aws_secretsmanager_secret" "test_2" {
   provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   name        = "test-2"
   description = "Test secret with an expiry date"
 
@@ -73,6 +77,8 @@ resource "aws_secretsmanager_secret" "test_2" {
 
 resource "aws_secretsmanager_secret" "test_3" {
   provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   name        = "test-3"
   description = "Test secret with an expiry date"
 

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -47,3 +47,38 @@ resource "aws_secretsmanager_secret" "github_token" {
     credential-expiration = "2027-01-06"
   }
 }
+
+# test secrets
+resource "aws_secretsmanager_secret" "test_1" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  name        = "test-1"
+  description = "Test secret with an expiry date"
+
+  tags = {
+    expiry-date = "2026-12-31"
+    source-location = "the location the key needs updating"
+  }
+}
+
+resource "aws_secretsmanager_secret" "test_2" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  name        = "test-2"
+  description = "Test secret with an expiry date"
+
+  tags = {
+    expiry-date = "2026-09-20"
+    source-location = "the location the key needs updating"
+  }
+}
+
+resource "aws_secretsmanager_secret" "test_3" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  name        = "test-3"
+  description = "Test secret with an expiry date"
+
+  tags = {
+    expiry-date = "2026-09-6"
+    source-location = "the location the key needs updating"
+  }
+}
+

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf
@@ -57,7 +57,7 @@ resource "aws_secretsmanager_secret" "test_1" {
   description = "Test secret with an expiry date"
 
   tags = {
-    expiry-date = "2026-12-31"
+    expiry-date     = "2026-12-31"
     source-location = "the location the key needs updating"
   }
 }
@@ -70,7 +70,7 @@ resource "aws_secretsmanager_secret" "test_2" {
   description = "Test secret with an expiry date"
 
   tags = {
-    expiry-date = "2026-09-20"
+    expiry-date     = "2026-09-20"
     source-location = "the location the key needs updating"
   }
 }
@@ -83,7 +83,7 @@ resource "aws_secretsmanager_secret" "test_3" {
   description = "Test secret with an expiry date"
 
   tags = {
-    expiry-date = "2026-09-6"
+    expiry-date     = "2026-09-6"
     source-location = "the location the key needs updating"
   }
 }


### PR DESCRIPTION
This pull request adds three test secrets to the AWS Secrets Manager configuration for the analytical platform management production environment. These new resources are intended for testing purposes and each includes an expiry date and a source location tag.

**New test secrets added:**

* Added `aws_secretsmanager_secret` resources for `test-1`, `test-2`, and `test-3`, each with a description, expiry date, and source location in the `terraform/aws/analytical-platform-management-production/aws-secrets-manager/secrets.tf` file.

This piece of work is being tracked in [this](https://github.com/orgs/ministryofjustice/projects/167/views/9?filterQuery=label%3Asquad-one+-status%3ADone+label%3Asquad-one+platform-&pane=issue&itemId=200862680&issue=ministryofjustice%7Cdata-platform%7C378) GitHub Issue.

