### PR TITLE
Changed logging bucket to one in region.

### DIFF
--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/application_variables.json
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/application_variables.json
@@ -1,6 +1,6 @@
 {
   "application_name": "laa-search-legal-aid-data",
-  "logging_bucket_name": "moj-analytics-s3-logs",
+  "logging_bucket_name": "moj-analytics-s3-logs-eu-west-2",
   "splink_bucket_name": "laa-splink-search-s3",
   "splink_test_bucket_name": "laa-splink-search-s3-test",
   "splink_source_bucket_name": "laa-splink-source-s3",

--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/locals.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/locals.tf
@@ -154,6 +154,11 @@ locals {
   splink_audit_bucket_test_name         = local.app.splink_audit_test_bucket_name
   splink_search_s3_test_name            = local.app.splink_search_s3_test_bucket_name
   #Logging, SNS, Bucket event rule variables
+  # S3 access logging requires the target bucket to be in the same region as the
+  # source bucket. `moj-analytics-s3-logs` (no suffix) is the eu-west-1 logging
+  # bucket; `-eu-west-2` is a separate, region-specific bucket provisioned for
+  # eu-west-2 workspaces like this one (all buckets here are eu-west-2, see
+  # terraform.tf), hence the region suffix in the name.
   logging_bucket_name         = local.app.logging_bucket_name
   splink_bucket_name          = local.app.splink_bucket_name
   splink_test_bucket_name     = local.app.splink_test_bucket_name


### PR DESCRIPTION
# Pull Request Objective

Fixes one of the `laa-search-legal-aid-data` Terraform apply failure seen in [run 33654386146](https://github.com/ministryofjustice/analytical-platform/actions/runs/33654386146/job/100329267375), which followed #10579. 

All S3 buckets in this workspace are provisioned in `eu-west-2` (see `terraform.tf`), but `logging_bucket_name` pointed at `moj-analytics-s3-logs`, which is the pre-existing `eu-west-1` access-logs bucket. S3 server access logging requires the target bucket to be in the same region as the source bucket, so every `PutBucketLogging` call in the apply failed with `CrossLocationLoggingProhibitted`.

This PR switches the logging target to `moj-analytics-s3-logs-eu-west-2`, a separate, region-specific logging bucket already provisioned for `eu-west-2` workspaces (e.g. `data-warehouses-eu-west-2`). No bucket is being renamed or moved. S3 bucket regions are immutable, so this points at the correct existing bucket rather than altering the mismatched one.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

This is fix 1 of 3 for run