### PR TITLE
fixed kms role typo.

### DIFF
--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/kms_key_users.json
@@ -15,7 +15,7 @@
     "key_users": ["airflow-production-laa-search-index-source"]
   },
   "splink_s3_source_write_bucket": {
-    "key_users": ["airflow-production-laa-s3-ops"]
+    "key_users": ["airflow-production-laa-search-index-s3-ops"]
   },
   "splink_s3_input_read_bucket": {
     "key_users": ["airflow-production-laa-search-index-s3-ops"]


### PR DESCRIPTION
# Pull Request Objective

Fixes a typo in `kms_key_users.json`. `splink_s3_source_write_bucket` referenced `airflow-production-laa-s3-ops`, a role that doesn't exist. Should be `airflow-production-laa-search-index-s3-ops` (already granted elsewhere in this file). Non-existent principal caused KMS `PutKeyPolicy` to fail with `MalformedPolicyDocumentException: invalid principals` during the #10579 at the [terraform apply](https://github.com/ministryofjustice/analytical-platform/actions/runs/33654386146/job/100329267375) step.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [ ] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [ ] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [ ] I have self-reviewed my code
- [ ] I have reviewed the checks and can attest they're as expected

### Additional Comments

James Shepherd's access matrix has the roles laid out https://github.com/ministryofjustice/analytical-platform/pull/10579#issuecomment-5451032160

relates to:
- #10579 
- #10624 