### PR TITLE
rollback to pre-10579 state to avoid tf error

### DIFF
--- a/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3.tf
+++ b/terraform/aws/analytical-platform-data-production/laa-search-legal-aid-data/splink_s3.tf
@@ -75,6 +75,7 @@ module "s3_bucket_splink" {
         Principal = "*"
 
         Action = [
+          "s3:DeleteBucket",
           "s3:PutBucketAcl",
           "s3:PutBucketPolicy",
           "s3:PutEncryptionConfiguration",


### PR DESCRIPTION
# Pull Request Objective

Restores `"s3:DeleteBucket"` to the `DenyBucketDeletion` statement in `splink_s3.tf`, rolling the file back to its state before [#10579](https://github.com/ministryofjustice/analytical-platform/pull/10579).

`laa-splink-search-s3` is hard locked. Its own bucket policy denies `s3:PutBucketPolicy` to `Principal: "*"` with no condition or exception, so no IAM role, including the CI role, can update the policy. S3 evaluates the current policy before allowing an update and explicit deny always wins.

[#10579](https://github.com/ministryofjustice/analytical-platform/pull/10579) removed one line, `"s3:DeleteBucket"`, from that statement. That creates a diff against the live policy, so every apply now attempts `PutBucketPolicy` and fails with `AccessDenied`.

Restoring the line makes the configuration match the live policy exactly. Terraform sees no diff, never issues `PutBucketPolicy`, and the apply passes. No admin intervention required.

## Checklist

> [!NOTE]
> Each items should be checked. Skipping below checks could delay your PR review!

- [x] I have reviewed the [style guide](https://docs.analytical-platform.service.justice.gov.uk/documentation/platform/infrastructure/terraform.html#terraform)
and ensured that my code complies with it
- [x] All checks have passed (or override label applied, if I've
used the `override-static-analysis` label, I've explained why)
- [x] I have self-reviewed my code
- [x] I have reviewed the checks and can attest they're as expected

### Additional Comments

**This is an unblock, not a fix.**

- The bucket remains hard locked. Any future policy change to `laa-splink-search-s3` still needs AWS root user intervention
- [#10629](https://github.com/ministryofjustice/analytical-platform/pull/10629) is the actual fix, dropping `s3:PutBucketPolicy` from the deny. It cannot merge until root unlocks the bucket, because applying it requires the very call that is denied. Leaving it open until then
- Only `laa-splink-search-s3` is affected. The new test buckets do not carry this deny, and James S has already removed the restriction from the new buckets

**Verification**

- `git diff b4aab11a~1 -- splink_s3.tf` returns empty, confirming the file is byte identical to its pre-#10579 state

**Note on the earlier failed applies**. The other buckets in this workspace applied successfully alongside this failure.