### PR TITLE
Create secret scanning workflow

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,23 @@
+on:
+  workflow_dispatch:
+
+jobs:
+  check-secret-expiry:
+    runs-on: ubuntu-latest
+
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@e6de054238d6b7531b4efff3b6587d9aade6a06c # v6.2.3
+        with:
+          role-to-assume: arn:aws:iam::042130406152:role/github-actions-secret-check
+          aws-region: eu-west-2
+
+      - name: Check secret expiry dates
+        run: |
+          aws secretsmanager list-secrets \
+            --query 'SecretList[*].[Name,ARN,Tags]' \
+            --output json


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow to help monitor AWS secret expiration. The workflow can be triggered manually and checks the expiry dates of secrets in AWS Secrets Manager.

**New workflow for AWS secret monitoring:**

* Added `.github/workflows/secret-scan.yml` to define a workflow that can be run manually (`workflow_dispatch`), assumes a specific AWS IAM role, and lists all secrets in AWS Secrets Manager to check their expiry dates.
