### PR TITLE
create date check for expiry date

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -41,7 +41,7 @@ jobs:
               [ -z "${name}" ] && continue
 
               expiry_epoch=$(date -u -d "${expiry_date}" +%s 2>/dev/null) || {
-                echo "::warning::Secret ${name} in ${region} has an unparseable expiry-date tag value: ${expiry_date}"
+                echo "::warning::Secret ${name} in ${region} has an unparsable expiry-date tag value: ${expiry_date}"
                 continue
               }
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -21,10 +21,57 @@ jobs:
 
       - name: Check secret expiry dates
         run: |
+          today_epoch=$(date -u -d "$(date -u +%F)" +%s)
+
+          {
+            echo "| Region | Secret name | Source-location | expiry-date | Status |"
+            echo "|--------|-------------|------------------|-------------|--------|"
+          } >> "${GITHUB_STEP_SUMMARY}"
+
+          exit_code=0
+
           for region in eu-west-1 eu-west-2; do
-            echo "Secrets in ${region}:"
-            aws secretsmanager list-secrets \
+            secrets=$(aws secretsmanager list-secrets \
               --region "${region}" \
-              --query 'SecretList[*].[Name,ARN,Tags]' \
-              --output json
+              --query 'SecretList[*].[Name,Tags]' \
+              --output json)
+
+            # Only process secrets tagged with expiry-date
+            while IFS=$'\t' read -r name expiry_date source_location; do
+              [ -z "${name}" ] && continue
+
+              expiry_epoch=$(date -u -d "${expiry_date}" +%s 2>/dev/null) || {
+                echo "::warning::Secret ${name} in ${region} has an unparseable expiry-date tag value: ${expiry_date}"
+                continue
+              }
+
+              days_remaining=$(( (expiry_epoch - today_epoch) / 86400 ))
+
+              if [ "${days_remaining}" -lt 0 ]; then
+                status="EXPIRED"
+              elif [ "${days_remaining}" -le 7 ]; then
+                status="CRITICAL"
+              elif [ "${days_remaining}" -le 30 ]; then
+                status="WARNING"
+              else
+                status="OK"
+              fi
+
+              if [ "${status}" != "OK" ]; then
+                exit_code=1
+              fi
+
+              echo "| ${region} | ${name} | ${source_location:-N/A} | ${expiry_date} | ${status} |" >> "${GITHUB_STEP_SUMMARY}"
+            done < <(echo "${secrets}" | jq -r '
+              .[]
+              | select((.[1] // []) | any(.Key == "expiry-date"))
+              | [
+                  .[0],
+                  ((.[1][] | select(.Key == "expiry-date") | .Value)),
+                  ((.[1][] | select(.Key == "Source-location") | .Value) // "N/A")
+                ]
+              | @tsv
+            ')
           done
+
+          exit "${exit_code}"

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,58 +19,13 @@ jobs:
           role-to-assume: arn:aws:iam::042130406152:role/github-actions-secret-check
           aws-region: eu-west-2
 
+      - name: Setup Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c # v6.0.0
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: pip install boto3
+
       - name: Check secret expiry dates
-        run: |
-          today_epoch=$(date -u -d "$(date -u +%F)" +%s)
-
-          {
-            echo "| Region | Secret name | Source-location | expiry-date | Status |"
-            echo "|--------|-------------|------------------|-------------|--------|"
-          } >> "${GITHUB_STEP_SUMMARY}"
-
-          for region in eu-west-1 eu-west-2; do
-            secrets=$(aws secretsmanager list-secrets \
-              --region "${region}" \
-              --query 'SecretList[*].[Name,Tags]' \
-              --output json)
-
-            # Only process secrets tagged with expiry-date
-            while IFS=$'\t' read -r name expiry_date source_location; do
-              [ -z "${name}" ] && continue
-
-              expiry_epoch=$(date -u -d "${expiry_date}" +%s 2>/dev/null) || {
-                echo "::warning::Secret ${name} in ${region} has an unparsable expiry-date tag value: ${expiry_date}"
-                continue
-              }
-
-              days_remaining=$(( (expiry_epoch - today_epoch) / 86400 ))
-
-              if [ "${days_remaining}" -lt 0 ]; then
-                status="EXPIRED"
-              elif [ "${days_remaining}" -le 7 ]; then
-                status="CRITICAL"
-              elif [ "${days_remaining}" -le 30 ]; then
-                status="WARNING"
-              else
-                status="OK"
-              fi
-
-              # Report via annotations only, this is a scheduled report and non-OK statuses are expected, not workflow failures
-              if [ "${status}" = "EXPIRED" ]; then
-                echo "::error::Secret ${name} in ${region} is EXPIRED (expiry-date: ${expiry_date})"
-              elif [ "${status}" = "CRITICAL" ] || [ "${status}" = "WARNING" ]; then
-                echo "::warning::Secret ${name} in ${region} is ${status} (expiry-date: ${expiry_date})"
-              fi
-
-              echo "| ${region} | ${name} | ${source_location:-N/A} | ${expiry_date} | ${status} |" >> "${GITHUB_STEP_SUMMARY}"
-            done < <(echo "${secrets}" | jq -r '
-              .[]
-              | select((.[1] // []) | any(.Key == "expiry-date"))
-              | [
-                  .[0],
-                  ((.[1][] | select(.Key == "expiry-date") | .Value)),
-                  ((.[1][] | select(.Key == "Source-location") | .Value) // "N/A")
-                ]
-              | @tsv
-            ')
-          done
+        run: python scripts/secret-scan/check_secret_expiry.py

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -28,8 +28,6 @@ jobs:
             echo "|--------|-------------|------------------|-------------|--------|"
           } >> "${GITHUB_STEP_SUMMARY}"
 
-          exit_code=0
-
           for region in eu-west-1 eu-west-2; do
             secrets=$(aws secretsmanager list-secrets \
               --region "${region}" \
@@ -57,8 +55,11 @@ jobs:
                 status="OK"
               fi
 
-              if [ "${status}" != "OK" ]; then
-                exit_code=1
+              # Report via annotations only, this is a scheduled report and non-OK statuses are expected, not workflow failures
+              if [ "${status}" = "EXPIRED" ]; then
+                echo "::error::Secret ${name} in ${region} is EXPIRED (expiry-date: ${expiry_date})"
+              elif [ "${status}" = "CRITICAL" ] || [ "${status}" = "WARNING" ]; then
+                echo "::warning::Secret ${name} in ${region} is ${status} (expiry-date: ${expiry_date})"
               fi
 
               echo "| ${region} | ${name} | ${source_location:-N/A} | ${expiry_date} | ${status} |" >> "${GITHUB_STEP_SUMMARY}"
@@ -73,5 +74,3 @@ jobs:
               | @tsv
             ')
           done
-
-          exit "${exit_code}"

--- a/scripts/secret-scan/check_secret_expiry.py
+++ b/scripts/secret-scan/check_secret_expiry.py
@@ -1,0 +1,95 @@
+"""
+Checks AWS Secrets Manager secrets for an `expiry-date` tag and reports their status.
+
+Usage:
+    python check_secret_expiry.py
+
+Requirements:
+    - AWS CLI/credentials configured with appropriate permissions.
+    - boto3 library installed (pip install boto3).
+
+Environment variables:
+    GITHUB_STEP_SUMMARY: path to a file to append a markdown summary table to.
+"""
+
+import os
+from datetime import datetime, timezone
+
+import boto3
+
+REGIONS = ["eu-west-1", "eu-west-2"]
+
+WARNING_THRESHOLD_DAYS = 30
+CRITICAL_THRESHOLD_DAYS = 7
+
+
+def get_tagged_secrets(region):
+    """
+    Returns a list of (name, expiry_date, source_location) tuples for secrets
+    in the given region that are tagged with `expiry-date`.
+    """
+    client = boto3.client("secretsmanager", region_name=region)
+    secrets = []
+
+    paginator = client.get_paginator("list_secrets")
+    for page in paginator.paginate():
+        for secret in page.get("SecretList", []):
+            tags = {tag["Key"]: tag["Value"] for tag in secret.get("Tags", [])}
+            if "expiry-date" not in tags:
+                continue
+            secrets.append(
+                (
+                    secret["Name"],
+                    tags["expiry-date"],
+                    tags.get("Source-location", "N/A"),
+                )
+            )
+
+    return secrets
+
+
+def get_status(days_remaining):
+    if days_remaining < 0:
+        return "EXPIRED"
+    if days_remaining <= CRITICAL_THRESHOLD_DAYS:
+        return "CRITICAL"
+    if days_remaining <= WARNING_THRESHOLD_DAYS:
+        return "WARNING"
+    return "OK"
+
+
+def main():
+    today = datetime.now(timezone.utc).date()
+    summary_rows = ["| Region | Secret name | Source-location | expiry-date | Status |",
+                     "|--------|-------------|------------------|-------------|--------|"]
+
+    for region in REGIONS:
+        for name, expiry_date, source_location in get_tagged_secrets(region):
+            try:
+                expiry = datetime.strptime(expiry_date, "%Y-%m-%d").date()
+            except ValueError:
+                print(
+                    f"::warning::Secret {name} in {region} has an unparsable expiry-date tag value: {expiry_date}"
+                )
+                continue
+
+            days_remaining = (expiry - today).days
+            status = get_status(days_remaining)
+
+            if status == "EXPIRED":
+                print(f"::error::Secret {name} in {region} is EXPIRED (expiry-date: {expiry_date})")
+            elif status in ("CRITICAL", "WARNING"):
+                print(f"::warning::Secret {name} in {region} is {status} (expiry-date: {expiry_date})")
+
+            summary_rows.append(f"| {region} | {name} | {source_location} | {expiry_date} | {status} |")
+
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+    if summary_path:
+        with open(summary_path, "a", encoding="utf-8") as summary_file:
+            summary_file.write("\n".join(summary_rows) + "\n")
+    else:
+        print("\n".join(summary_rows))
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/secret-scan/check_secret_expiry.py
+++ b/scripts/secret-scan/check_secret_expiry.py
@@ -60,8 +60,10 @@ def get_status(days_remaining):
 
 def main():
     today = datetime.now(timezone.utc).date()
-    summary_rows = ["| Region | Secret name | Source-location | expiry-date | Status |",
-                     "|--------|-------------|------------------|-------------|--------|"]
+    summary_rows = [
+        "| Region | Secret name | Source-location | expiry-date | Status |",
+        "|--------|-------------|------------------|-------------|--------|",
+    ]
 
     for region in REGIONS:
         for name, expiry_date, source_location in get_tagged_secrets(region):
@@ -77,11 +79,17 @@ def main():
             status = get_status(days_remaining)
 
             if status == "EXPIRED":
-                print(f"::error::Secret {name} in {region} is EXPIRED (expiry-date: {expiry_date})")
+                print(
+                    f"::error::Secret {name} in {region} is EXPIRED (expiry-date: {expiry_date})"
+                )
             elif status in ("CRITICAL", "WARNING"):
-                print(f"::warning::Secret {name} in {region} is {status} (expiry-date: {expiry_date})")
+                print(
+                    f"::warning::Secret {name} in {region} is {status} (expiry-date: {expiry_date})"
+                )
 
-            summary_rows.append(f"| {region} | {name} | {source_location} | {expiry_date} | {status} |")
+            summary_rows.append(
+                f"| {region} | {name} | {source_location} | {expiry_date} | {status} |"
+            )
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
     if summary_path:

--- a/scripts/secret-scan/check_secret_expiry.py
+++ b/scripts/secret-scan/check_secret_expiry.py
@@ -1,12 +1,18 @@
 """
 Checks AWS Secrets Manager secrets for an `expiry-date` tag and reports their status.
 
+The script can scan:
+- The AWS account represented by the credentials already configured in the runner.
+- Additional AWS accounts by assuming a `github-actions-secret-check` role.
+
 Usage:
     python check_secret_expiry.py
 
 Requirements:
-    - AWS CLI/credentials configured with appropriate permissions.
-    - boto3 library installed (pip install boto3).
+    - AWS credentials configured with appropriate permissions.
+    - boto3 library installed.
+    - The initial AWS role must have sts:AssumeRole permission for any
+      additional target account roles.
 
 Environment variables:
     GITHUB_STEP_SUMMARY: path to a file to append a markdown summary table to.
@@ -17,83 +23,299 @@ from datetime import datetime, timezone
 
 import boto3
 
+
 REGIONS = ["eu-west-1", "eu-west-2"]
 
 WARNING_THRESHOLD_DAYS = 30
 CRITICAL_THRESHOLD_DAYS = 7
 
 
-def get_tagged_secrets(region):
+# Accounts to scan.
+#
+# role_arn = None means:
+#   Use the AWS credentials already configured in the GitHub runner.
+#
+# For additional accounts, specify the role that should be assumed.
+#
+# Rename the account names below as appropriate once the mapping between
+# account IDs and Analytical Platform environments is confirmed.
+ACCOUNTS = {
+    "analytical-platform-management-production": {
+        "account_id": "042130406152",
+        "role_arn": None,
+    }
+}
+
+
+STATUS_PRIORITY = {
+    "EXPIRED": 0,
+    "CRITICAL": 1,
+    "WARNING": 2,
+    "INVALID": 3,
+    "OK": 4,
+}
+
+
+def get_session(role_arn=None):
     """
-    Returns a list of (name, expiry_date, source_location) tuples for secrets
-    in the given region that are tagged with `expiry-date`.
+    Returns a boto3 Session.
+
+    If role_arn is provided, assumes that role first.
+    Otherwise, uses the credentials already available to the runner.
     """
-    client = boto3.client("secretsmanager", region_name=region)
+    if role_arn is None:
+        return boto3.Session()
+
+    sts_client = boto3.client("sts")
+
+    response = sts_client.assume_role(
+        RoleArn=role_arn,
+        RoleSessionName="github-actions-secret-expiry-check",
+    )
+
+    credentials = response["Credentials"]
+
+    return boto3.Session(
+        aws_access_key_id=credentials["AccessKeyId"],
+        aws_secret_access_key=credentials["SecretAccessKey"],
+        aws_session_token=credentials["SessionToken"],
+    )
+
+
+def get_tagged_secrets(session, region):
+    """
+    Returns secrets in the given region that have an `expiry-date` tag.
+
+    Each returned dictionary contains:
+        name
+        expiry_date
+        source_location
+    """
+    client = session.client("secretsmanager", region_name=region)
     secrets = []
 
     paginator = client.get_paginator("list_secrets")
+
     for page in paginator.paginate():
         for secret in page.get("SecretList", []):
-            tags = {tag["Key"]: tag["Value"] for tag in secret.get("Tags", [])}
+            tags = {
+                tag["Key"]: tag["Value"]
+                for tag in secret.get("Tags", [])
+            }
+
             if "expiry-date" not in tags:
                 continue
+
             secrets.append(
-                (
-                    secret["Name"],
-                    tags["expiry-date"],
-                    tags.get("Source-location", "N/A"),
-                )
+                {
+                    "name": secret["Name"],
+                    "expiry_date": tags["expiry-date"],
+                    "source_location": tags.get(
+                        "source-location",
+                        "N/A",
+                    ),
+                }
             )
 
     return secrets
 
 
 def get_status(days_remaining):
+    """
+    Returns the expiry status based on the number of days remaining.
+    """
     if days_remaining < 0:
         return "EXPIRED"
+
     if days_remaining <= CRITICAL_THRESHOLD_DAYS:
         return "CRITICAL"
+
     if days_remaining <= WARNING_THRESHOLD_DAYS:
         return "WARNING"
+
     return "OK"
+
+
+def escape_markdown(value):
+    """
+    Escapes pipe characters so tag values or secret names do not break
+    the GitHub Markdown table.
+    """
+    return str(value).replace("|", "\\|")
 
 
 def main():
     today = datetime.now(timezone.utc).date()
-    summary_rows = [
-        "| Region | Secret name | Source-location | expiry-date | Status |",
-        "|--------|-------------|------------------|-------------|--------|",
-    ]
+    results = []
 
-    for region in REGIONS:
-        for name, expiry_date, source_location in get_tagged_secrets(region):
+    for account_name, account_config in ACCOUNTS.items():
+        account_id = account_config["account_id"]
+        role_arn = account_config["role_arn"]
+
+        print(
+            f"Scanning account {account_name} "
+            f"({account_id})"
+        )
+
+        try:
+            session = get_session(role_arn)
+        except Exception as exc:
+            print(
+                f"::warning::Unable to obtain credentials for "
+                f"{account_name} ({account_id}): {exc}"
+            )
+            continue
+
+        for region in REGIONS:
+            print(
+                f"Scanning {account_name} "
+                f"({account_id}) in {region}"
+            )
+
             try:
-                expiry = datetime.strptime(expiry_date, "%Y-%m-%d").date()
-            except ValueError:
+                secrets = get_tagged_secrets(session, region)
+            except Exception as exc:
                 print(
-                    f"::warning::Secret {name} in {region} has an unparsable expiry-date tag value: {expiry_date}"
+                    f"::warning::Unable to scan Secrets Manager in "
+                    f"{account_name} ({account_id}), {region}: {exc}"
                 )
                 continue
 
-            days_remaining = (expiry - today).days
-            status = get_status(days_remaining)
+            for secret in secrets:
+                name = secret["name"]
+                expiry_date = secret["expiry_date"]
+                source_location = secret["source_location"]
 
-            if status == "EXPIRED":
-                print(
-                    f"::error::Secret {name} in {region} is EXPIRED (expiry-date: {expiry_date})"
-                )
-            elif status in ("CRITICAL", "WARNING"):
-                print(
-                    f"::warning::Secret {name} in {region} is {status} (expiry-date: {expiry_date})"
+                try:
+                    expiry = datetime.strptime(
+                        expiry_date,
+                        "%Y-%m-%d",
+                    ).date()
+
+                except ValueError:
+                    status = "INVALID"
+
+                    print(
+                        f"::warning::Secret {name} in "
+                        f"{account_name} ({account_id}), {region} "
+                        f"has an unparsable expiry-date tag value: "
+                        f"{expiry_date}"
+                    )
+
+                    results.append(
+                        {
+                            "account": account_name,
+                            "account_id": account_id,
+                            "region": region,
+                            "name": name,
+                            "source_location": source_location,
+                            "expiry_date": expiry_date,
+                            "days_remaining": "N/A",
+                            "status": status,
+                        }
+                    )
+
+                    continue
+
+                days_remaining = (expiry - today).days
+                status = get_status(days_remaining)
+
+                if status == "EXPIRED":
+                    print(
+                        f"::error::Secret {name} in "
+                        f"{account_name} ({account_id}), {region} "
+                        f"is EXPIRED "
+                        f"(expiry-date: {expiry_date})"
+                    )
+
+                elif status in ("CRITICAL", "WARNING"):
+                    print(
+                        f"::warning::Secret {name} in "
+                        f"{account_name} ({account_id}), {region} "
+                        f"is {status} "
+                        f"(expiry-date: {expiry_date}, "
+                        f"{days_remaining} days remaining)"
+                    )
+
+                results.append(
+                    {
+                        "account": account_name,
+                        "account_id": account_id,
+                        "region": region,
+                        "name": name,
+                        "source_location": source_location,
+                        "expiry_date": expiry_date,
+                        "days_remaining": days_remaining,
+                        "status": status,
+                    }
                 )
 
-            summary_rows.append(
-                f"| {region} | {name} | {source_location} | {expiry_date} | {status} |"
-            )
+    # Sort most urgent results first.
+    #
+    # Within each status, secrets with the fewest days remaining
+    # appear first.
+    def sort_key(result):
+        days = result["days_remaining"]
+
+        if isinstance(days, int):
+            days_sort = days
+        else:
+            days_sort = float("inf")
+
+        return (
+            STATUS_PRIORITY[result["status"]],
+            days_sort,
+            result["account"],
+            result["region"],
+            result["name"],
+        )
+
+    results.sort(key=sort_key)
+
+    summary_rows = [
+        "## AWS Secret Expiry Check",
+        "",
+        f"Check date: `{today}`",
+        "",
+        (
+            "| Account | Account ID | Region | Secret name | "
+            "Source location | Expiry date | Days remaining | Status |"
+        ),
+        (
+            "|---------|------------|--------|-------------|"
+            "-----------------|-------------|----------------|--------|"
+        ),
+    ]
+
+    for result in results:
+        summary_rows.append(
+            "| "
+            f"{escape_markdown(result['account'])} | "
+            f"{escape_markdown(result['account_id'])} | "
+            f"{escape_markdown(result['region'])} | "
+            f"{escape_markdown(result['name'])} | "
+            f"{escape_markdown(result['source_location'])} | "
+            f"{escape_markdown(result['expiry_date'])} | "
+            f"{escape_markdown(result['days_remaining'])} | "
+            f"{escape_markdown(result['status'])} |"
+        )
+
+    if not results:
+        summary_rows.extend(
+            [
+                "",
+                "No secrets with an `expiry-date` tag were found.",
+            ]
+        )
 
     summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+
     if summary_path:
-        with open(summary_path, "a", encoding="utf-8") as summary_file:
+        with open(
+            summary_path,
+            "a",
+            encoding="utf-8",
+        ) as summary_file:
             summary_file.write("\n".join(summary_rows) + "\n")
     else:
         print("\n".join(summary_rows))

--- a/scripts/secret-scan/check_secret_expiry.py
+++ b/scripts/secret-scan/check_secret_expiry.py
@@ -23,7 +23,6 @@ from datetime import datetime, timezone
 
 import boto3
 
-
 REGIONS = ["eu-west-1", "eu-west-2"]
 
 WARNING_THRESHOLD_DAYS = 30
@@ -98,10 +97,7 @@ def get_tagged_secrets(session, region):
 
     for page in paginator.paginate():
         for secret in page.get("SecretList", []):
-            tags = {
-                tag["Key"]: tag["Value"]
-                for tag in secret.get("Tags", [])
-            }
+            tags = {tag["Key"]: tag["Value"] for tag in secret.get("Tags", [])}
 
             if "expiry-date" not in tags:
                 continue
@@ -152,10 +148,7 @@ def main():
         account_id = account_config["account_id"]
         role_arn = account_config["role_arn"]
 
-        print(
-            f"Scanning account {account_name} "
-            f"({account_id})"
-        )
+        print(f"Scanning account {account_name} " f"({account_id})")
 
         try:
             session = get_session(role_arn)
@@ -167,10 +160,7 @@ def main():
             continue
 
         for region in REGIONS:
-            print(
-                f"Scanning {account_name} "
-                f"({account_id}) in {region}"
-            )
+            print(f"Scanning {account_name} " f"({account_id}) in {region}")
 
             try:
                 secrets = get_tagged_secrets(session, region)


### PR DESCRIPTION
This pull request updates the secret expiry check process in the GitHub Actions workflow by replacing an inline shell script with a new Python script. The new script provides more robust scanning and reporting of AWS Secrets Manager secrets with expiry dates, supporting multiple accounts and regions, and outputs a markdown summary for GitHub Actions.

Key changes:

**Workflow enhancements:**

* The `.github/workflows/secret-scan.yml` workflow now sets up Python 3.13 and installs the `boto3` library as dependencies before running the secret expiry check. The previous shell-based check is replaced with a call to the new Python script.

**Secret expiry check improvements:**

* Added a new script `scripts/secret-scan/check_secret_expiry.py` that:
  - Scans AWS Secrets Manager for secrets with an `expiry-date` tag across multiple accounts and regions.
  - Assumes roles for cross-account scanning if needed.
  - Classifies secrets as OK, WARNING, CRITICAL, EXPIRED, or INVALID based on expiry date.
  - Outputs results as a markdown table (for GitHub Actions summary) and as workflow logs, with appropriate warnings and errors for secrets nearing or past expiry.

This work is being tracked in this [ticket](https://github.com/orgs/ministryofjustice/projects/167/views/9?filterQuery=label%3Asquad-one+-status%3ADone+label%3Asquad-one+platform-&pane=issue&itemId=200862680&issue=ministryofjustice%7Cdata-platform%7C378)