### PR TITLE
Create cross-account IAM role and policy

### DIFF
--- a/scripts/secret-scan/check_secret_expiry.py
+++ b/scripts/secret-scan/check_secret_expiry.py
@@ -42,7 +42,11 @@ ACCOUNTS = {
     "analytical-platform-management-production": {
         "account_id": "042130406152",
         "role_arn": None,
-    }
+    },
+    "analytical-platform-development": {
+        "account_id": "525294151996",
+        "role_arn": "arn:aws:iam::525294151996:role/github-actions-secret-check",
+    },
 }
 
 

--- a/scripts/secret-scan/check_secret_expiry.py
+++ b/scripts/secret-scan/check_secret_expiry.py
@@ -31,7 +31,7 @@ CRITICAL_THRESHOLD_DAYS = 7
 
 # Accounts to scan.
 #
-# role_arn = None means:
+# role_name = None means:
 #   Use the AWS credentials already configured in the GitHub runner.
 #
 # For additional accounts, specify the role that should be assumed.
@@ -41,11 +41,11 @@ CRITICAL_THRESHOLD_DAYS = 7
 ACCOUNTS = {
     "analytical-platform-management-production": {
         "account_id": "042130406152",
-        "role_arn": None,
+        "role_name": None,
     },
     "analytical-platform-development": {
         "account_id": "525294151996",
-        "role_arn": "arn:aws:iam::525294151996:role/github-actions-secret-check",
+        "role_name": "github-actions-secret-check",
     },
 }
 
@@ -59,16 +59,17 @@ STATUS_PRIORITY = {
 }
 
 
-def get_session(role_arn=None):
+def get_session(account_id, role_name=None):
     """
     Returns a boto3 Session.
 
-    If role_arn is provided, assumes that role first.
+    If role_name is provided, assumes that role in the target account first.
     Otherwise, uses the credentials already available to the runner.
     """
-    if role_arn is None:
+    if role_name is None:
         return boto3.Session()
 
+    role_arn = f"arn:aws:iam::{account_id}:role/{role_name}"
     sts_client = boto3.client("sts")
 
     response = sts_client.assume_role(
@@ -150,12 +151,12 @@ def main():
 
     for account_name, account_config in ACCOUNTS.items():
         account_id = account_config["account_id"]
-        role_arn = account_config["role_arn"]
+        role_name = account_config["role_name"]
 
         print(f"Scanning account {account_name} " f"({account_id})")
 
         try:
-            session = get_session(role_arn)
+            session = get_session(account_id, role_name)
         except Exception as exc:
             print(
                 f"::warning::Unable to obtain credentials for "

--- a/terraform/aws/analytical-platform-development/cluster/data.tf
+++ b/terraform/aws/analytical-platform-development/cluster/data.tf
@@ -99,3 +99,20 @@ data "aws_route53_resolver_query_log_config" "core_logging_s3" {
     values = ["core-logging-rlq-s3-eu-west-1"]
   }
 }
+
+##################################################
+# Secret scan
+##################################################
+
+data "aws_iam_policy_document" "github_actions_secret_check" {
+  statement {
+    sid    = "AllowSecretsManagerList"
+    effect = "Allow"
+
+    actions = [
+      "secretsmanager:ListSecrets"
+    ]
+
+    resources = ["*"]
+  }
+}

--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -566,7 +566,7 @@ module "github_actions_secret_check_iam_policy" {
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
   source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
-  version = "6.6.1"
+  version = "5.60.0"
 
   name_prefix = "github-actions-secret-check"
   description = "IAM policy for checking AWS Secrets Manager expiry tags"

--- a/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-policies.tf
@@ -556,3 +556,21 @@ resource "aws_iam_policy" "control_panel_api" {
   description = "Control Panel policy for ${var.resource_prefix} EKS cluster"
   policy      = data.aws_iam_policy_document.control_panel_api.json
 }
+
+##################################################
+# Secret scan
+##################################################
+
+module "github_actions_secret_check_iam_policy" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-policy"
+  version = "6.6.1"
+
+  name_prefix = "github-actions-secret-check"
+  description = "IAM policy for checking AWS Secrets Manager expiry tags"
+
+  policy = data.aws_iam_policy_document.github_actions_secret_check.json
+
+}

--- a/terraform/aws/analytical-platform-development/cluster/iam-roles.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-roles.tf
@@ -256,7 +256,7 @@ module "github_actions_secret_check_iam_role" {
   role_requires_mfa = false
 
   trusted_role_arns = [
-    "arn:aws:iam::042130406152:role/github-actions-secret-check"
+    "arn:aws:iam::${var.account_ids["analytical-platform-management-production"]}:role/github-actions-secret-check"
   ]
 
   custom_role_policy_arns = [

--- a/terraform/aws/analytical-platform-development/cluster/iam-roles.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-roles.tf
@@ -239,3 +239,43 @@ module "iam_assumable_role_control_panel_api" {
     "system:serviceaccount:${var.control_panel_celery_beat_kubernetes_service_account}",
   ]
 }
+
+##################################################
+# Secret scan
+##################################################
+
+module "github_actions_secret_check_iam_role" {
+  #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
+  #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
+
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
+  version = "6.6.1"
+
+  use_name_prefix = false
+
+  name = "github-actions-secret-check"
+
+  trust_policy_permissions = {
+    AllowManagementProductionSecretCheckRole = {
+      effect = "Allow"
+
+      principals = [{
+        type = "AWS"
+
+        identifiers = [
+          "arn:aws:iam::042130406152:role/github-actions-secret-check"
+        ]
+      }]
+
+      actions = [
+        "sts:AssumeRole"
+      ]
+    }
+  }
+
+  policies = {
+    github_actions_secret_check = module.github_actions_secret_check_iam_policy.arn
+  }
+
+}
+

--- a/terraform/aws/analytical-platform-development/cluster/iam-roles.tf
+++ b/terraform/aws/analytical-platform-development/cluster/iam-roles.tf
@@ -248,34 +248,19 @@ module "github_actions_secret_check_iam_role" {
   #checkov:skip=CKV_TF_1:Module registry does not support commit hashes for versions
   #checkov:skip=CKV_TF_2:Module registry does not support tags for versions
 
-  source  = "terraform-aws-modules/iam/aws//modules/iam-role"
-  version = "6.6.1"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-assumable-role"
+  version = "5.60.0"
 
-  use_name_prefix = false
+  create_role       = true
+  role_name         = "github-actions-secret-check"
+  role_requires_mfa = false
 
-  name = "github-actions-secret-check"
+  trusted_role_arns = [
+    "arn:aws:iam::042130406152:role/github-actions-secret-check"
+  ]
 
-  trust_policy_permissions = {
-    AllowManagementProductionSecretCheckRole = {
-      effect = "Allow"
-
-      principals = [{
-        type = "AWS"
-
-        identifiers = [
-          "arn:aws:iam::042130406152:role/github-actions-secret-check"
-        ]
-      }]
-
-      actions = [
-        "sts:AssumeRole"
-      ]
-    }
-  }
-
-  policies = {
-    github_actions_secret_check = module.github_actions_secret_check_iam_policy.arn
-  }
-
+  custom_role_policy_arns = [
+    module.github_actions_secret_check_iam_policy.arn
+  ]
 }
 

--- a/terraform/aws/analytical-platform-development/cluster/secrets.tf
+++ b/terraform/aws/analytical-platform-development/cluster/secrets.tf
@@ -1,0 +1,42 @@
+##################################################
+# Secret scan test secrets
+##################################################
+
+resource "aws_secretsmanager_secret" "dev_test_1" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
+  name        = "dev-test-1"
+  description = "Test secret with an expiry date"
+
+  tags = {
+    expiry-date     = "2026-12-31"
+    source-location = "the location the key needs updating"
+  }
+}
+
+resource "aws_secretsmanager_secret" "dev_test_2" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
+  name        = "dev-test-2"
+  description = "Test secret with an expiry date"
+
+  tags = {
+    expiry-date     = "2026-09-20"
+    source-location = "the location the key needs updating"
+  }
+}
+
+resource "aws_secretsmanager_secret" "dev_test_3" {
+  provider = aws.analytical-platform-management-production-eu-west-1
+  #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
+  #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
+  name        = "dev-test-3"
+  description = "Test secret with an expiry date"
+
+  tags = {
+    expiry-date     = "2026-09-6"
+    source-location = "the location the key needs updating"
+  }
+}

--- a/terraform/aws/analytical-platform-development/cluster/secrets.tf
+++ b/terraform/aws/analytical-platform-development/cluster/secrets.tf
@@ -3,7 +3,6 @@
 ##################################################
 
 resource "aws_secretsmanager_secret" "dev_test_1" {
-  provider = aws.analytical-platform-management-production-eu-west-1
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   name        = "dev-test-1"
@@ -16,7 +15,6 @@ resource "aws_secretsmanager_secret" "dev_test_1" {
 }
 
 resource "aws_secretsmanager_secret" "dev_test_2" {
-  provider = aws.analytical-platform-management-production-eu-west-1
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   name        = "dev-test-2"
@@ -29,7 +27,6 @@ resource "aws_secretsmanager_secret" "dev_test_2" {
 }
 
 resource "aws_secretsmanager_secret" "dev_test_3" {
-  provider = aws.analytical-platform-management-production-eu-west-1
   #checkov:skip=CKV2_AWS_57:Automatic rotation is not required for this secret
   #checkov:skip=CKV_AWS_149:CMK encryption is not required for this secret
   name        = "dev-test-3"

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/iam-policies.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/iam-policies.tf
@@ -34,8 +34,8 @@ data "aws_iam_policy_document" "github_actions_secret_check" {
     ]
 
     resources = [
-      "arn:aws:iam::312423030077:role/github-actions-secret-check",
-      "arn:aws:iam::525294151996:role/github-actions-secret-check"
+      "arn:aws:iam::${var.account_ids["analytical-platform-production"]}:role/github-actions-secret-check",
+      "arn:aws:iam::${var.account_ids["analytical-platform-development"]}:role/github-actions-secret-check"
     ]
   }
 }

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/iam-policies.tf
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/iam-policies.tf
@@ -34,7 +34,8 @@ data "aws_iam_policy_document" "github_actions_secret_check" {
     ]
 
     resources = [
-      "arn:aws:iam::312423030077:role/github-actions-secret-check"
+      "arn:aws:iam::312423030077:role/github-actions-secret-check",
+      "arn:aws:iam::525294151996:role/github-actions-secret-check"
     ]
   }
 }

--- a/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tfvars
+++ b/terraform/aws/analytical-platform-management-production/aws-secrets-manager/terraform.tfvars
@@ -1,5 +1,7 @@
 account_ids = {
   analytical-platform-management-production = "042130406152"
+  analytical-platform-development           = "525294151996"
+  analytical-platform-production            = "312423030077"
 }
 
 tags = {


### PR DESCRIPTION
This pull request introduces support for secret expiry scanning in the `analytical-platform-development` AWS environment. The main changes include defining IAM policies and roles for a new GitHub Actions secret check, updating configuration for cross-account role assumption, and adding test secrets for development purposes.

**Secret scanning support for analytical-platform-development:**

* Added a new AWS account configuration for `analytical-platform-development` in `check_secret_expiry.py`, specifying the account ID and the ARN for the GitHub Actions secret check role.
* Defined a new IAM policy document (`github_actions_secret_check`) in `data.tf` to allow listing AWS Secrets Manager secrets.
* Created a new IAM policy and role for the GitHub Actions secret check using Terraform modules, and allowed the production account to assume this role. [[1]](diffhunk://#diff-db2352dbbd255515db76f848334dcb95b1a55de0eb301d30c62575c4619ff6d9R559-R576) [[2]](diffhunk://#diff-6a7fba848b1567c0aa9a68528556d8cbba4d60890360805e3fb4fc7eaba82a54R242-R266)
* Updated the production environment's IAM policy to allow assuming the new secret check role in the development account.

**Development test resources:**

* Added three test secrets in `secrets.tf` with expiry-date tags for validating the secret scanning functionality in the development environment.


this work is being tracked in this [ticket ](https://github.com/orgs/ministryofjustice/projects/167/views/9?filterQuery=label%3Asquad-one+-status%3ADone+label%3Asquad-one+platform-&pane=issue&itemId=200862680&issue=ministryofjustice%7Cdata-platform%7C378)